### PR TITLE
feat(skills): restructure opencode-* cluster as harness/opencode adapters + domain skills

### DIFF
--- a/packages/skills/domain/opencode/configs/CONTRACT.edn
+++ b/packages/skills/domain/opencode/configs/CONTRACT.edn
@@ -1,0 +1,42 @@
+;; ημ.skill/opencode-configs@0.2.0
+;; Migrated from pi/agent/skills/opencode-configs/CONTRACT.edn
+
+(skill-contract
+  (name "opencode-configs")
+  (v "ημ.skill/opencode-configs@0.2.0")
+
+  (intent
+    "Authoritative reference for opencode.json configuration schema.
+     Use when reading, writing, or validating opencode.json in any workspace.")
+
+  (activation
+    (priority 58)
+    (explicit ["skill:opencode-configs"])
+    (triggers ["opencode.json" "opencode config" "opencode configuration" "opencode settings"])
+    (autoload false))
+
+  (governance
+    (touch-layer :semi-stable)
+    (non-override [:mission :directives :safety :license])
+    (requires-user-approval false))
+
+  (effects
+    (writes false)
+    (network false)
+    (commits false))
+
+  (protocol
+    (schema
+      (top-level-keys
+        [:$schema :model :models :providers :agents :plugins :tools
+         :rules :mcp :keybindings :theme :experimental])
+      (model "Default model id string")
+      (models "Array of ModelConfig: {id, provider, temperature?, maxTokens?, contextLength?}")
+      (providers "Provider overrides: {openai?, anthropic?, google?, ollama?, ...}")
+      (agents "Array of AgentConfig: {name, description, share?, model?, rules?}")
+      (plugins "Array of plugin module paths or inline configs")
+      (tools "Array of tool configs: MCP server refs or inline tool defs")
+      (mcp "MCP server map: {<name>: {command, args, env?}}"))))
+
+  (output
+    (must-include ["Validate opencode.json against this schema before committing"])))

--- a/packages/skills/domain/opencode/model-variant-management/CONTRACT.edn
+++ b/packages/skills/domain/opencode/model-variant-management/CONTRACT.edn
@@ -1,0 +1,44 @@
+;; ημ.skill/opencode-model-variant-management@0.2.0
+;; Migrated from pi/agent/skills/opencode-model-variant-management/CONTRACT.edn
+
+(skill-contract
+  (name "opencode-model-variant-management")
+  (v "ημ.skill/opencode-model-variant-management@0.2.0")
+
+  (intent
+    "Manage multiple model variants in opencode.json for cost/quality tradeoffs.
+     Switch between providers per agent or per task type without changing prompt logic.")
+
+  (activation
+    (priority 54)
+    (explicit ["skill:opencode-model-variant-management"])
+    (triggers ["model variant" "model switching" "cost routing" "cheap model" "fast model"
+               "model per agent" "model per task"])
+    (autoload false))
+
+  (governance
+    (touch-layer :volatile)
+    (non-override [:mission :directives :safety :license])
+    (requires-user-approval false))
+
+  (effects
+    (writes true) ;; edits opencode.json
+    (network false)
+    (commits false))
+
+  (protocol
+    (patterns
+      (per-agent
+        "agents[].model overrides the top-level model for that agent only."
+        "Use expensive models (opus, o3) for planning agents."
+        "Use fast/cheap models (haiku, gpt-4o-mini, groq) for execution/scaffolding agents.")
+      (per-task
+        "task-router skill dispatches task type → model selection."
+        "Register task-type model preferences in opencode.json models[] array."
+        "Prefer model id stability over provider lock-in: wrap provider-specific ids in aliases.")
+      (cost-model
+        "Track cost per 1M tokens in receipts.log :decision entries."
+        "Flag when a session exceeds $5 in model spend.")))
+
+  (output
+    (must-include ["Always note model selection rationale in the receipt log"])))

--- a/packages/skills/domain/opencode/models-providers/CONTRACT.edn
+++ b/packages/skills/domain/opencode/models-providers/CONTRACT.edn
@@ -1,0 +1,46 @@
+;; ημ.skill/opencode-models-providers@0.2.0
+;; Migrated from pi/agent/skills/opencode-models-providers/CONTRACT.edn
+
+(skill-contract
+  (name "opencode-models-providers")
+  (v "ημ.skill/opencode-models-providers@0.2.0")
+
+  (intent
+    "Knowledge of model providers available in opencode: Anthropic, OpenAI, Google,
+     Ollama, Groq, AWS Bedrock, Azure. Covers how to configure, switch, and cost-model
+     each provider. Used by model-variant-management and task-router.")
+
+  (activation
+    (priority 55)
+    (explicit ["skill:opencode-models-providers"])
+    (triggers ["opencode models" "opencode providers" "opencode ollama" "model provider"
+               "anthropic opencode" "openai opencode" "provider config"])
+    (autoload false))
+
+  (governance
+    (touch-layer :volatile)
+    (non-override [:mission :directives :safety :license])
+    (requires-user-approval false))
+
+  (effects
+    (writes false)
+    (network false)
+    (commits false))
+
+  (protocol
+    (providers
+      (:anthropic  "claude-opus-4, claude-sonnet-4, claude-haiku-3-5. ANTHROPIC_API_KEY.")
+      (:openai     "gpt-4o, gpt-4o-mini, o3, o4-mini. OPENAI_API_KEY.")
+      (:google     "gemini-2.5-pro, gemini-2.5-flash. GOOGLE_API_KEY.")
+      (:ollama     "Local. Base URL: http://localhost:11434. No API key. Pull model first.")
+      (:groq       "Fast inference. GROQ_API_KEY. llama-3.3-70b, qwen-qwq-32b.")
+      (:bedrock    "AWS creds required. us.anthropic.claude-sonnet-4-20251101-v3:0")
+      (:azure      "AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY. Deployment name as model id."))
+
+    (ollama-notes
+      "Embedding models (qwen3-embedding:0.6b) are NOT chat models — do not configure as agents model."
+      "Set num_ctx via Modelfile or OLLAMA_NUM_CTX env for larger context windows."
+      "Memory budget: 8GB GPU with 32k ctx takes ~6GB; leaves ~2GB headroom.")))
+
+  (output
+    (must-include ["Verify provider env vars before configuring model in opencode.json"])))

--- a/packages/skills/domain/opencode/sdk/CONTRACT.edn
+++ b/packages/skills/domain/opencode/sdk/CONTRACT.edn
@@ -1,0 +1,59 @@
+;; ημ.skill/opencode-sdk@0.2.0
+;; Migrated from pi/agent/skills/opencode-sdk/CONTRACT.edn
+;; opencode-specific domain knowledge. Not harness-agnostic.
+
+(skill-contract
+  (name "opencode-sdk")
+  (v "ημ.skill/opencode-sdk@0.2.0")
+
+  (intent
+    "Knowledge of the opencode TypeScript SDK: session lifecycle, tool registration,
+     agent authoring, plugin/command/tool APIs, model provider config.
+     Primary reference for building opencode extensions in this monorepo.")
+
+  (activation
+    (priority 60)
+    (explicit ["skill:opencode-sdk"])
+    (triggers ["opencode sdk" "opencode api" "opencode typescript" "opencode session"
+               "opencode tool" "opencode plugin" "opencode command"])
+    (autoload false))
+
+  (governance
+    (touch-layer :semi-stable)
+    (non-override [:mission :directives :safety :license])
+    (requires-user-approval false))
+
+  (effects
+    (writes false)
+    (network false)
+    (commits false))
+
+  (protocol
+    (reference
+      (package "@opencode-ai/sdk")
+      (config-file "opencode.json")
+      (agents-dir ".opencode/agents/")
+      (skills-dir ".opencode/skills/")
+      (rules-dir ".opencode/rules/")
+      (commands-dir ".opencode/commands/")
+      (state-dir ".opencode/state/"))
+
+    (authoring-surfaces
+      ["Agent: .opencode/agents/<name>.md — system prompt fragments, autoloaded by share/mode"
+       "Skill: .opencode/skills/<name>/CONTRACT.edn — typed protocol contracts (this system)"
+       "Rule: .opencode/rules/<name>.md — always-on constraints, injected every turn"
+       "Command: .opencode/commands/<name>.md — slash-command with $ARGUMENTS substitution"
+       "Plugin: opencode.json plugins[] — TS module with hooks: sessionStart, afterTool, etc."
+       "Tool: opencode.json tools[] — MCP server or inline JS function tool"])
+
+    (hook-events
+      [:sessionStart :sessionEnd :beforeTool :afterTool
+       :messageReceived :messageSent :error])
+
+    (model-config
+      "Models configured in opencode.json under models[]"
+      "Each model entry: id, provider, temperature, maxTokens, contextLength"
+      "Model variants allow A/B between providers without changing agent prompts")))
+
+  (output
+    (must-include ["Reference the SDK API before authoring any opencode extension"])))

--- a/packages/skills/domain/opencode/session-search/CONTRACT.edn
+++ b/packages/skills/domain/opencode/session-search/CONTRACT.edn
@@ -1,0 +1,43 @@
+;; ημ.skill/opencode-session-search@0.2.0
+;; Migrated from pi/agent/skills/opencode-session-search/CONTRACT.edn
+
+(skill-contract
+  (name "opencode-session-search")
+  (v "ημ.skill/opencode-session-search@0.2.0")
+
+  (intent
+    "Search and replay opencode session history stored in .opencode/state/sessions/.
+     Used for continuity when resuming interrupted work or debugging past agent behavior.")
+
+  (activation
+    (priority 52)
+    (explicit ["skill:opencode-session-search"])
+    (triggers ["session search" "find session" "replay session" "session history"
+               "past session" "opencode sessions"])
+    (autoload false))
+
+  (governance
+    (touch-layer :mutable)
+    (non-override [:mission :directives :safety :license])
+    (requires-user-approval false))
+
+  (effects
+    (writes false)
+    (network false)
+    (commits false))
+
+  (protocol
+    (storage
+      (path ".opencode/state/sessions/")
+      (format "JSONL per session, one message object per line")
+      (index "session-index.json maps session-id → {start, end, summary, model, cost}"))
+    (search-strategy
+      ["grep -r <term> .opencode/state/sessions/ | head -20"
+       "jq 'select(.role == \"assistant\") | .content' .opencode/state/sessions/<id>.jsonl"
+       "Sort by mtime to find most recent: ls -lt .opencode/state/sessions/ | head -5"])
+    (continuity-rule
+      "Before starting a new session on an interrupted task: search sessions for the task."
+      "Inject the last receipt + last assistant message as context prefix.")))
+
+  (output
+    (must-include ["Check session history before declaring a task as not started"])))

--- a/packages/skills/harness/opencode/agent-authoring/ADAPTER.edn
+++ b/packages/skills/harness/opencode/agent-authoring/ADAPTER.edn
@@ -1,0 +1,28 @@
+;; Harness adapter: opencode → agent-authoring
+;; Restructured from pi/agent/skills/opencode-agent-authoring/CONTRACT.edn
+;; Core knowledge: packages/skills/domain/opencode/sdk/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "agent-authoring")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/agent-authoring/CONTRACT.edn")
+
+  (protocol
+    (agent-anatomy
+      (file ".opencode/agents/<name>.md")
+      (frontmatter [:description :share :model :rules])
+      (share-values
+        (:always "Injected into every session as system context")
+        (:manual "Only when explicitly invoked")
+        (:auto   "opencode selects based on task context"))
+      (body "Markdown system prompt. Supports {variable} substitution from session state."))
+
+    (authoring-rules
+      ["Keep agent prompts focused on one role — delegate via task-router for cross-domain."
+       "Always reference skill:work-cycle in planning agents."
+       "Always reference skill:receipt-river in any agent that writes files or commits."
+       "Use share: auto for domain agents; share: manual for utility/one-shot agents."]))
+
+  (notes
+    "See packages/skills/domain/opencode/sdk/CONTRACT.edn for full authoring surface reference."))

--- a/packages/skills/harness/opencode/agents-skills/ADAPTER.edn
+++ b/packages/skills/harness/opencode/agents-skills/ADAPTER.edn
@@ -1,0 +1,23 @@
+;; Harness adapter: opencode → agents-skills integration
+;; Restructured from pi/agent/skills/opencode-agents-skills/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "agents-skills")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/agents-skills/CONTRACT.edn")
+
+  (protocol
+    (skill-loading
+      "Skills in .opencode/skills/<name>/CONTRACT.edn are loaded by the eta-mu skill loader."
+      "Skill loader reads CONTRACT.edn, checks activation triggers and priority."
+      "Autoloaded skills are injected as system prompt prefix every turn."
+      "Triggered skills are injected when trigger phrase appears in user message or tool output.")
+    (skill-harness-bridge
+      "This adapter connects the opencode session lifecycle to the ηµΠ skill registry."
+      "On sessionStart: load skill-registry.edn, inject all autoload:true skills."
+      "On each turn: scan for trigger phrases, inject matching skills."
+      "On sessionEnd: emit skill-load-summary receipt to receipt river."))
+
+  (notes
+    "Implementation lives in packages/opencode-reactant. This adapter is the config layer."))

--- a/packages/skills/harness/opencode/command-authoring/ADAPTER.edn
+++ b/packages/skills/harness/opencode/command-authoring/ADAPTER.edn
@@ -1,0 +1,24 @@
+;; Harness adapter: opencode → command-authoring
+;; Restructured from pi/agent/skills/opencode-command-authoring/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "command-authoring")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/command-authoring/CONTRACT.edn")
+
+  (protocol
+    (command-anatomy
+      (dir ".opencode/commands/")
+      (file "<name>.md")
+      (invocation "/name [args]")
+      (arguments "$ARGUMENTS substituted from slash command input")
+      (body "Markdown template — rendered as user message when command invoked"))
+    (authoring-rules
+      ["Commands are composable templates — they call skills, not implement logic."
+       "Keep commands under 20 lines. Long logic belongs in an agent or plugin."
+       "Use $ARGUMENTS for required input; provide defaults in the template body for optional."
+       "Always end with an action directive: 'Now execute the above plan step by step.'"]))
+
+  (notes
+    "Commands fire as user messages. For turn hooks (before/after tool), use plugin-authoring instead."))

--- a/packages/skills/harness/opencode/plugin-authoring/ADAPTER.edn
+++ b/packages/skills/harness/opencode/plugin-authoring/ADAPTER.edn
@@ -1,0 +1,27 @@
+;; Harness adapter: opencode → plugin-authoring
+;; Restructured from pi/agent/skills/opencode-plugin-authoring/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "plugin-authoring")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/plugin-authoring/CONTRACT.edn")
+
+  (protocol
+    (plugin-anatomy
+      (registration "opencode.json plugins[] → path to .ts or .js module")
+      (exports "Default export: { hooks: { [HookEvent]: HookHandler } }")
+      (hook-signature "(ctx: PluginContext) => void | Promise<void>")
+      (context-shape
+        {:session "Current session state"
+         :message "Current message (if in message hook)"
+         :tool    "Tool name + args (if in tool hook)"
+         :emit    "Function to emit a receipt or log entry"}))
+    (authoring-rules
+      ["One responsibility per plugin — receipt-river hook, session summarizer, etc."
+       "Never mutate session state directly — use ctx.emit for side effects."
+       "Plugins that write files must call receipt_river via ctx.emit."
+       "Keep plugins under 80 lines. Larger logic belongs in an MCP tool."]))
+
+  (notes
+    "Plugin TS types: import type { Plugin, PluginContext } from '@opencode-ai/sdk'."))

--- a/packages/skills/harness/opencode/plugins/ADAPTER.edn
+++ b/packages/skills/harness/opencode/plugins/ADAPTER.edn
@@ -1,0 +1,27 @@
+;; Harness adapter: opencode → plugins inventory
+;; Restructured from pi/agent/skills/opencode-plugins/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "plugins")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/plugins/CONTRACT.edn")
+
+  (protocol
+    (inventory
+      "Live inventory of plugins registered in opencode.json for this workspace."
+      "Each plugin entry: { path, hooks[], description, status }"
+      "Status: :active | :disabled | :error")
+    (eta-mu-plugins
+      (:receipt-river-hook
+        "packages/opencode-reactant/src/plugins/receipt-river.ts"
+        "Hooks: afterTool, sessionEnd. Warns if substantive turn had no receipt.")
+      (:skill-loader
+        "packages/opencode-reactant/src/plugins/skill-loader.ts"
+        "Hooks: sessionStart. Loads skill-registry.edn, injects autoload skills.")
+      (:session-summarizer
+        "packages/opencode-reactant/src/plugins/session-summarizer.ts"
+        "Hooks: sessionEnd. Writes session summary to .opencode/state/sessions/index.")))
+
+  (notes
+    "Register new plugins in opencode.json AND add an entry here for discoverability."))

--- a/packages/skills/harness/opencode/skill-creation/ADAPTER.edn
+++ b/packages/skills/harness/opencode/skill-creation/ADAPTER.edn
@@ -1,0 +1,32 @@
+;; Harness adapter: opencode → skill-creation
+;; Restructured from pi/agent/skills/opencode-skill-creation/CONTRACT.edn
+;; Cross-references: packages/skills/core/work-cycle, packages/skills/skill-registry.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "skill-creation")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/skill-creation/CONTRACT.edn")
+
+  (protocol
+    (workflow
+      ["1. Identify the need: what repeated cognitive pattern is being codified?"
+       "2. Check skill-registry.edn — does a similar skill exist? If yes, extend; don't fork."
+       "3. Author packages/skills/core/<name>/CONTRACT.edn (harness-agnostic)."
+       "4. If opencode-specific: author packages/skills/domain/opencode/<name>/CONTRACT.edn instead."
+       "5. Add harness adapters for each relevant harness in packages/skills/harness/."
+       "6. Add entry to packages/skills/skill-registry.edn."
+       "7. Pay fork tax: commit + push on feat/skill-<name> branch, open PR."])
+    (contract-schema
+      (required [:name :v :intent :activation :governance :effects :protocol])
+      (optional [:output :driver :memory-injection :cross-reference])
+      (versioning "ημ.skill/<name>@<semver> — bump minor for new fields, patch for wording"))
+    (quality-bar
+      ["Intent is one sentence, specific, not generic."
+       "Triggers are the exact phrases that should activate it."
+       "Protocol is actionable: agent can follow it without further clarification."
+       "Priority reflects load order: core=80-100, domain=50-79, meta=20-49."]))
+
+  (notes
+    "This adapter IS the opencode-skill-creation skill, restructured.
+     Use it to onboard any new skill into the ημΠ monorepo."))

--- a/packages/skills/harness/opencode/tool-authoring/ADAPTER.edn
+++ b/packages/skills/harness/opencode/tool-authoring/ADAPTER.edn
@@ -1,0 +1,25 @@
+;; Harness adapter: opencode → tool-authoring
+;; Restructured from pi/agent/skills/opencode-tool-authoring/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "tool-authoring")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/tool-authoring/CONTRACT.edn")
+
+  (protocol
+    (tool-surfaces
+      (:inline
+        "opencode.json tools[]: small JS function tools defined inline."
+        "Shape: { name, description, parameters: JSONSchema, execute: string (JS fn body) }")
+      (:mcp
+        "MCP server tools: registered via opencode.json mcp{}."
+        "Full tool with side effects, filesystem access, network. See tools-mcp adapter."))
+    (authoring-rules
+      ["Prefer MCP tools for anything with side effects or >50 lines of logic."
+       "Inline tools for simple transformations, lookups, formatting."
+       "Every tool must have a description that states what it returns, not just what it does."
+       "Tools that write files must be receipt-river aware: call receipt_river after write."]))
+
+  (notes
+    "Tool TS types: import type { Tool } from '@opencode-ai/sdk'."))

--- a/packages/skills/harness/opencode/tools-mcp/ADAPTER.edn
+++ b/packages/skills/harness/opencode/tools-mcp/ADAPTER.edn
@@ -1,0 +1,30 @@
+;; Harness adapter: opencode → tools-mcp
+;; Restructured from pi/agent/skills/opencode-tools-mcp/CONTRACT.edn
+
+(harness-adapter
+  (harness :opencode)
+  (skill "tools-mcp")
+  (core-ref "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+  (install-path ".opencode/skills/tools-mcp/CONTRACT.edn")
+
+  (protocol
+    (mcp-registration
+      "opencode.json mcp{}: map of server name → { command, args, env? }"
+      "Example: { \"github\": { \"command\": \"npx\", \"args\": [\"-y\", \"@modelcontextprotocol/server-github\"] } }")
+    (eta-mu-mcp-servers
+      (:receipt-river
+        "packages/eta-mu-extensions/src/mcp/receipt-river-server.ts"
+        "Tools: receipt_river/append, receipt_river/tail, receipt_river/bootstrap")
+      (:promptdb
+        "packages/presence-core/src/mcp/promptdb-server.ts"
+        "Tools: promptdb/embed, promptdb/search, promptdb/say, promptdb/truth")
+      (:kanban
+        "packages/kanban/src/mcp/kanban-server.ts"
+        "Tools: kanban/card, kanban/move, kanban/list, kanban/fsm-transition"))
+    (authoring-rules
+      ["Every MCP server must expose a /health endpoint."
+       "Register in opencode.json mcp{} AND in packages/skills/harness/opencode/plugins/ADAPTER.edn inventory."
+       "MCP tools that write state must emit a receipt via receipt_river/append."]))
+
+  (notes
+    "MCP server framework: @modelcontextprotocol/sdk. See packages/eta-mu-extensions."))

--- a/packages/skills/skill-registry.edn
+++ b/packages/skills/skill-registry.edn
@@ -1,16 +1,8 @@
 ;; ημΠ skill registry — top-level monorepo manifest
-;; Replaces pi/agent/skills/.skill-lock.json pattern.
-;; Each entry is harness-agnostic; harness adapters live in harness/<target>/<skill>/ADAPTER.edn
-;;
-;; Fields:
-;;   :v       — semver of the core CONTRACT.edn
-;;   :path    — canonical path in this monorepo
-;;   :group   — :core | :harness | :domain | :infra | :social | :meta
-;;   :autoload — load in every session regardless of trigger
-;;   :priority — higher = loaded/applied first; core skills cluster 80–100
+;; Updated: opencode-* cluster restructured as harness/ and domain/ entries
 
 (skill-registry
-  (v "ημΠ.skill-registry@0.1.0")
+  (v "ημΠ.skill-registry@0.2.0")
   (root "packages/skills")
 
   ;; ============================================================
@@ -36,104 +28,94 @@
     (drivers [:fs :db :s3 :http])
     (description "Append-only μ-trace ledger. Driver-abstracted for cloud and local deploys."))
 
-  ;; ============================================================
-  ;; CORE — not yet migrated, still at pi/agent/skills/
-  ;; Migration order: agent-runtime-state → fork-tax → regression-triage
-  ;;                  → spec-driven-dev → session-mycology
-  ;; ============================================================
-
-  (entry
-    (name "agent-runtime-state")
-    (v "ημ.skill/agent-runtime-state@0.1.0")
-    (path "pi/agent/skills/agent-runtime-state/CONTRACT.edn") ;; TODO migrate
-    (group :core)
-    (priority 85)
-    (autoload true)
-    (description "Runtime registers, startup, drift detection, session continuity, tick model."))
-
-  (entry
-    (name "fork-tax")
-    (v "ημ.skill/fork-tax@0.1.0")
-    (path "pi/agent/skills/fork-tax/CONTRACT.edn") ;; TODO migrate
-    (group :core)
-    (priority 90)
-    (autoload false)
-    (description "Persist working state into git: commit + tag + push. 息 episodic commit operator."))
-
-  (entry
-    (name "regression-triage")
-    (v "ημ.skill/regression-triage@0.1.0")
-    (path "pi/agent/skills/regression-triage/CONTRACT.edn") ;; TODO migrate
-    (group :core)
-    (priority 80)
-    (autoload false)
-    (description "Investigate regressions: locate introducing change, rollback vs fix-forward."))
-
-  (entry
-    (name "spec-driven-dev")
-    (v "ημ.skill/spec-driven-dev@0.1.0")
-    (path "pi/agent/skills/spec-driven-dev/CONTRACT.edn") ;; TODO migrate
-    (group :core)
-    (priority 70)
-    (autoload false)
-    (description "Spec + phases + verification. Kanban FSM integration."))
-
-  (entry
-    (name "session-mycology")
-    (v "ημ.skill/session-mycology@0.1.0")
-    (path "pi/agent/skills/session-mycology/CONTRACT.edn") ;; TODO migrate
-    (group :core)
-    (priority 65)
-    (autoload true)
-    (description "Meta-cognition: difficulty/complexity/confidence scoring. Embedding-recalled skills."))
-
-  (entry
-    (name "contract-governance")
-    (v "ημ.skill/contract-governance@0.1.0")
-    (path "pi/agent/skills/contract-governance/CONTRACT.edn") ;; TODO migrate
-    (group :meta)
-    (priority 30)
-    (autoload false)
-    (description "Amendments, versioning, rollback, constitutional layers."))
+  ;; Core not yet migrated — TODO in order:
+  (entry (name "agent-runtime-state")  (path "pi/agent/skills/agent-runtime-state/CONTRACT.edn")  (group :core) (priority 85) (autoload true)  (status :pending-migration))
+  (entry (name "fork-tax")             (path "pi/agent/skills/fork-tax/CONTRACT.edn")             (group :core) (priority 90) (autoload false) (status :pending-migration))
+  (entry (name "regression-triage")   (path "pi/agent/skills/regression-triage/CONTRACT.edn")   (group :core) (priority 80) (autoload false) (status :pending-migration))
+  (entry (name "spec-driven-dev")      (path "pi/agent/skills/spec-driven-dev/CONTRACT.edn")      (group :core) (priority 70) (autoload false) (status :pending-migration))
+  (entry (name "session-mycology")     (path "pi/agent/skills/session-mycology/CONTRACT.edn")     (group :core) (priority 65) (autoload true)  (status :pending-migration))
+  (entry (name "contract-governance") (path "pi/agent/skills/contract-governance/CONTRACT.edn") (group :meta)  (priority 30) (autoload false) (status :pending-migration))
 
   ;; ============================================================
-  ;; HARNESS-SPECIFIC — opencode cluster (not yet restructured)
-  ;; These will become harness/opencode/*/ADAPTER.edn referencing core skills
+  ;; DOMAIN/OPENCODE — opencode-specific knowledge, harness-independent
   ;; ============================================================
 
   (entry
-    (name "opencode-agent-authoring")
-    (path "pi/agent/skills/opencode-agent-authoring/CONTRACT.edn") ;; TODO restructure
-    (group :harness)
+    (name "opencode-sdk")
+    (v "ημ.skill/opencode-sdk@0.2.0")
+    (path "packages/skills/domain/opencode/sdk/CONTRACT.edn")
+    (group :domain)
     (harness :opencode)
-    (priority 60))
+    (priority 60)
+    (autoload false)
+    (status :migrated))
 
   (entry
-    (name "opencode-plugin-authoring")
-    (path "pi/agent/skills/opencode-plugin-authoring/CONTRACT.edn") ;; TODO restructure
-    (group :harness)
+    (name "opencode-configs")
+    (v "ημ.skill/opencode-configs@0.2.0")
+    (path "packages/skills/domain/opencode/configs/CONTRACT.edn")
+    (group :domain)
     (harness :opencode)
-    (priority 60))
+    (priority 58)
+    (autoload false)
+    (status :migrated))
 
-  ;; ... remaining opencode-* skills follow same pattern, omitted for brevity
-  ;; Full list: opencode-agents-skills, opencode-command-authoring, opencode-configs,
-  ;;            opencode-model-variant-management, opencode-models-providers,
-  ;;            opencode-sdk, opencode-session-search, opencode-skill-creation,
-  ;;            opencode-tool-authoring, opencode-tools-mcp
+  (entry
+    (name "opencode-models-providers")
+    (v "ημ.skill/opencode-models-providers@0.2.0")
+    (path "packages/skills/domain/opencode/models-providers/CONTRACT.edn")
+    (group :domain)
+    (harness :opencode)
+    (priority 55)
+    (autoload false)
+    (status :migrated))
+
+  (entry
+    (name "opencode-model-variant-management")
+    (v "ημ.skill/opencode-model-variant-management@0.2.0")
+    (path "packages/skills/domain/opencode/model-variant-management/CONTRACT.edn")
+    (group :domain)
+    (harness :opencode)
+    (priority 54)
+    (autoload false)
+    (status :migrated))
+
+  (entry
+    (name "opencode-session-search")
+    (v "ημ.skill/opencode-session-search@0.2.0")
+    (path "packages/skills/domain/opencode/session-search/CONTRACT.edn")
+    (group :domain)
+    (harness :opencode)
+    (priority 52)
+    (autoload false)
+    (status :migrated))
 
   ;; ============================================================
-  ;; DOMAIN — not migrated yet, paths stay as-is
+  ;; HARNESS/OPENCODE — adapter layer (authoring + extension surfaces)
   ;; ============================================================
 
-  (entry (name "submodule-ops")        (path "pi/agent/skills/submodule-ops/CONTRACT.edn")        (group :domain) (priority 75))
-  (entry (name "kanban-fsm")           (path "pi/agent/skills/kanban-fsm/CONTRACT.edn")           (group :domain) (priority 70))
-  (entry (name "kanban-curation")      (path "pi/agent/skills/kanban-curation/CONTRACT.edn")      (group :domain) (priority 65))
-  (entry (name "task-router")          (path "pi/agent/skills/task-router/CONTRACT.edn")          (group :domain) (priority 72))
-  (entry (name "github-integration")   (path "pi/agent/skills/github-integration/CONTRACT.edn")   (group :domain) (priority 75))
-  (entry (name "mcp-server-integration") (path "pi/agent/skills/mcp-server-integration/CONTRACT.edn") (group :domain) (priority 68))
-  (entry (name "workspace-build")      (path "pi/agent/skills/workspace-build/CONTRACT.edn")      (group :domain) (priority 70))
-  (entry (name "workspace-lint")       (path "pi/agent/skills/workspace-lint/CONTRACT.edn")       (group :domain) (priority 68))
-  (entry (name "workspace-typecheck")  (path "pi/agent/skills/workspace-typecheck/CONTRACT.edn")  (group :domain) (priority 68))
-  (entry (name "workspace-navigation") (path "pi/agent/skills/workspace-navigation/CONTRACT.edn") (group :domain) (priority 66))
-  (entry (name "turn-retrospective")   (path "pi/agent/skills/turn-retrospective/CONTRACT.edn")   (group :domain) (priority 60))
-  (entry (name "skill-spore-incubator") (path "pi/agent/skills/skill-spore-incubator/CONTRACT.edn") (group :meta) (priority 55)))
+  (entry (name "opencode-agent-authoring")    (path "packages/skills/harness/opencode/agent-authoring/ADAPTER.edn")    (group :harness) (harness :opencode) (priority 60) (status :migrated))
+  (entry (name "opencode-agents-skills")      (path "packages/skills/harness/opencode/agents-skills/ADAPTER.edn")      (group :harness) (harness :opencode) (priority 58) (status :migrated))
+  (entry (name "opencode-command-authoring")  (path "packages/skills/harness/opencode/command-authoring/ADAPTER.edn")  (group :harness) (harness :opencode) (priority 56) (status :migrated))
+  (entry (name "opencode-plugin-authoring")   (path "packages/skills/harness/opencode/plugin-authoring/ADAPTER.edn")   (group :harness) (harness :opencode) (priority 56) (status :migrated))
+  (entry (name "opencode-plugins")            (path "packages/skills/harness/opencode/plugins/ADAPTER.edn")            (group :harness) (harness :opencode) (priority 55) (status :migrated))
+  (entry (name "opencode-tool-authoring")     (path "packages/skills/harness/opencode/tool-authoring/ADAPTER.edn")     (group :harness) (harness :opencode) (priority 54) (status :migrated))
+  (entry (name "opencode-tools-mcp")          (path "packages/skills/harness/opencode/tools-mcp/ADAPTER.edn")          (group :harness) (harness :opencode) (priority 54) (status :migrated))
+  (entry (name "opencode-skill-creation")     (path "packages/skills/harness/opencode/skill-creation/ADAPTER.edn")     (group :harness) (harness :opencode) (priority 50) (status :migrated))
+
+  ;; ============================================================
+  ;; DOMAIN — not yet migrated
+  ;; ============================================================
+
+  (entry (name "submodule-ops")        (path "pi/agent/skills/submodule-ops/CONTRACT.edn")        (group :domain) (priority 75) (status :pending-migration))
+  (entry (name "kanban-fsm")           (path "pi/agent/skills/kanban-fsm/CONTRACT.edn")           (group :domain) (priority 70) (status :pending-migration))
+  (entry (name "kanban-curation")      (path "pi/agent/skills/kanban-curation/CONTRACT.edn")      (group :domain) (priority 65) (status :pending-migration))
+  (entry (name "task-router")          (path "pi/agent/skills/task-router/CONTRACT.edn")          (group :domain) (priority 72) (status :pending-migration))
+  (entry (name "github-integration")   (path "pi/agent/skills/github-integration/CONTRACT.edn")   (group :domain) (priority 75) (status :pending-migration))
+  (entry (name "mcp-server-integration") (path "pi/agent/skills/mcp-server-integration/CONTRACT.edn") (group :domain) (priority 68) (status :pending-migration))
+  (entry (name "workspace-build")      (path "pi/agent/skills/workspace-build/CONTRACT.edn")      (group :domain) (priority 70) (status :pending-migration))
+  (entry (name "workspace-lint")       (path "pi/agent/skills/workspace-lint/CONTRACT.edn")       (group :domain) (priority 68) (status :pending-migration))
+  (entry (name "workspace-typecheck")  (path "pi/agent/skills/workspace-typecheck/CONTRACT.edn")  (group :domain) (priority 68) (status :pending-migration))
+  (entry (name "workspace-navigation") (path "pi/agent/skills/workspace-navigation/CONTRACT.edn") (group :domain) (priority 66) (status :pending-migration))
+  (entry (name "turn-retrospective")   (path "pi/agent/skills/turn-retrospective/CONTRACT.edn")   (group :domain) (priority 60) (status :pending-migration))
+  (entry (name "skill-spore-incubator") (path "pi/agent/skills/skill-spore-incubator/CONTRACT.edn") (group :meta) (priority 55) (status :pending-migration)))


### PR DESCRIPTION
## What

Restructures all 12 `opencode-*` skills from `pi/agent/skills/` into the `packages/skills/` layout established in #3.

Depends on: #3 (feat/skills-monorepo-migration)

## Structure

```
packages/skills/
├── domain/opencode/           ← opencode-specific knowledge (harness-aware but portable)
│   ├── sdk/CONTRACT.edn
│   ├── configs/CONTRACT.edn
│   ├── models-providers/CONTRACT.edn
│   ├── model-variant-management/CONTRACT.edn
│   └── session-search/CONTRACT.edn
└── harness/opencode/          ← authoring + extension surface adapters
    ├── agent-authoring/ADAPTER.edn
    ├── agents-skills/ADAPTER.edn
    ├── command-authoring/ADAPTER.edn
    ├── plugin-authoring/ADAPTER.edn
    ├── plugins/ADAPTER.edn
    ├── tool-authoring/ADAPTER.edn
    ├── tools-mcp/ADAPTER.edn
    └── skill-creation/ADAPTER.edn
```

## Split rationale

**Domain skills** (`domain/opencode/`) are facts about opencode: what the SDK exposes, what configs look like, what providers are available. They're opencode-specific but don't implement harness behavior — they're reference knowledge.

**Harness adapters** (`harness/opencode/`) are behavioral: how to author agents, commands, plugins, tools *in the opencode harness*. They reference domain skills for the factual content.

This split means:
- claude-code and codex can have their own `harness/<target>/agent-authoring/ADAPTER.edn` pointing to whatever their authoring surface is
- The domain skills are readable by any agent regardless of harness
- `opencode-skill-creation` becomes the canonical onboarding path for new skills into the monorepo

## New in domain/opencode/models-providers

Added Ollama-specific notes about embedding memory constraints:
- Embedding models ≠ chat models — don't configure `qwen3-embedding:0.6b` as an agents model
- `num_ctx` guidance: 32k ctx takes ~6GB on 8GB GPU
- Memory budget note preserved from working knowledge

## skill-registry.edn → v0.2.0

- All 12 opencode entries now point to `packages/skills/` paths with `status: :migrated`
- Remaining unmigrated skills retain `pi/agent/` paths with `status: :pending-migration`
- Registry version bumped to `ηµΠ.skill-registry@0.2.0`

## Not changed

`pi/agent/skills/opencode-*/` untouched. Pi keeps working.

## Next

- [ ] #3 merged first, then this
- [ ] PR3: `agent-runtime-state` + `fork-tax` core migrations
- [ ] PR4: `regression-triage` + `spec-driven-dev` + `session-mycology`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Five OpenCode domain skills now available for session history search, multi-model variant management, provider configuration, configuration validation, and SDK integration.

* **Chores**
  * Reorganized skill registry and introduced adapter architecture for agent, command, plugin, and tool authoring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->