### PR TITLE
feat(policy): pure evaluate-policies reducer

### DIFF
--- a/.github/workflows/eta-mu-extensions-tests.yml
+++ b/.github/workflows/eta-mu-extensions-tests.yml
@@ -26,16 +26,16 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: '10.14.0'
           run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Get pnpm store path
         id: pnpm-cache
@@ -60,6 +60,16 @@ jobs:
       - name: Run tests
         working-directory: packages/eta-mu-extensions
         run: node target/test.cjs
+
+      - name: Test summary
+        if: always()
+        working-directory: packages/eta-mu-extensions
+        run: |
+          echo '## Test Results' >> $GITHUB_STEP_SUMMARY
+          node target/test.cjs 2>&1 | tee /tmp/test-output.txt || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/test-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Clojure error reports
         if: failure()

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/contract_runtime_v2/core.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/contract_runtime_v2/core.cljs
@@ -4,6 +4,8 @@
 
 (def path-param-keys #{"path" "file" "dir" "root" "cwd" "target" "source" "dest"})
 
+;; ── String / EDN utils ──────────────────────────────────────────
+
 (defn strip-whitespace [s]
   (str/replace (or s "") #"\s+" ""))
 
@@ -40,29 +42,18 @@
           (string? sys) sys
           (map? sys)    (str "[fn-ref: " (:fn-ref sys) "]")
           :else         nil))
-
       :else
       (or (:raw m) raw-text))))
 
 (defn apply-map-dispatch [acc m raw-text]
-  (let [kind (contract-kind m)
+  (let [kind   (contract-kind m)
         prompt (prompt-block-for-map m raw-text)]
     (cond-> acc
-      (= kind :actor)
-      (update :actors (fnil conj []) m)
-
-      (= kind :policy)
-      (update :policies (fnil conj []) m)
-
-      (= kind :fulfillment)
-      (update :fulfills (fnil conj []) m)
-
-      (= kind :capability)
-      (assoc-in [:caps (str (:capability/id m))] m)
-
-      (= kind :role)
-      (assoc-in [:roles (str (:role/id m))] m)
-
+      (= kind :actor)       (update :actors      (fnil conj []) m)
+      (= kind :policy)      (update :policies    (fnil conj []) m)
+      (= kind :fulfillment) (update :fulfills    (fnil conj []) m)
+      (= kind :capability)  (assoc-in [:caps  (str (:capability/id m))] m)
+      (= kind :role)        (assoc-in [:roles (str (:role/id m))]        m)
       (and (string? prompt) (not (str/blank? prompt)))
       (update :prompt-blocks (fnil conj []) prompt))))
 
@@ -87,8 +78,91 @@
   [join-path dirname start-dir stop-dir existing?]
   (loop [cur start-dir acc []]
     (let [candidate (join-path cur "CONTRACT.edn")
-          acc* (if (existing? candidate) (conj acc candidate) acc)
-          parent (dirname cur)]
+          acc*      (if (existing? candidate) (conj acc candidate) acc)
+          parent    (dirname cur)]
       (if (or (= cur stop-dir) (= cur parent))
         (vec (reverse acc*))
         (recur parent acc*)))))
+
+;; ── Policy evaluation ─────────────────────────────────────────
+;;
+;; Policy shape (EDN):
+;;
+;;   {:contract/kind   :policy
+;;    :contract/id     "some.unique.id"
+;;    :policy/on       :before-tool-call          ; required - when this fires
+;;    :policy/match    {:tool/name "write_file"}  ; required - what it matches against
+;;    :policy/action   :block | :warn | :note      ; required - what to do on match
+;;    :policy/reason   "Human-readable explanation" ; optional
+;;    :policy/ttl-ms   60000}                      ; optional - overrides global TTL
+;;
+;; Tool-call shape passed to evaluate-policies:
+;;
+;;   {:tool/name   "write_file"
+;;    :tool/params {:path "/etc/passwd" ...}}
+;;
+;; Result shape:
+;;
+;;   {:action  :block | :warn | :note | :allow
+;;    :reason  str | nil
+;;    :policy  map | nil    ; the matching policy, if any
+;;    :matches [map ...]    ; all matching policies
+;;   }
+
+(defn policy-matches?
+  "True if policy fires for the given tool-call.
+  Matching rules (AND across all keys present in :policy/match):
+  - :tool/name  - exact string match
+  - :tool/param - {param-key pred-or-val}: val = exact, fn = predicate"
+  [policy tool-call]
+  (let [match (get policy :policy/match {})]
+    (every? (fn [[k v]]
+              (cond
+                (= k :tool/name)
+                (= v (:tool/name tool-call))
+
+                (= k :tool/params)
+                (every? (fn [[pk pv]]
+                          (let [actual (get-in tool-call [:tool/params pk])]
+                            (if (fn? pv) (pv actual) (= pv actual))))
+                        v)
+
+                ;; unknown match key -> conservative: does not match
+                :else false))
+            match)))
+
+(def action-severity
+  "Higher number = more severe. Used to pick the strongest action."
+  {:block 3 :warn 2 :note 1 :allow 0})
+
+(defn strongest-action [actions]
+  (->> actions
+       (map #(get action-severity % 0))
+       (apply max 0)
+       (fn [n] (some (fn [[k v]] (when (= v n) k)) action-severity))))
+
+(defn evaluate-policies
+  "Pure reducer. Given a seq of policy maps and a tool-call map, returns a
+  result map describing the strongest matching policy action.
+
+  Nearest-wins TTL: policies with :policy/ttl-ms are considered time-sensitive;
+  pass `now-ms` and `loaded-at` (ms) to enable TTL filtering.
+  If ttl-ms is omitted, the policy is always active."
+  ([policies tool-call]
+   (evaluate-policies policies tool-call nil nil))
+  ([policies tool-call now-ms loaded-at]
+   (let [active  (filter (fn [p]
+                           (let [ttl (get p :policy/ttl-ms)]
+                             (if (and ttl now-ms loaded-at)
+                               (< (- now-ms loaded-at) ttl)
+                               true)))
+                         policies)
+         matches (filter #(policy-matches? % tool-call) active)]
+     (if (empty? matches)
+       {:action :allow :reason nil :policy nil :matches []}
+       (let [action (strongest-action (map :policy/action matches))
+             winner (first (filter #(= action (:policy/action %)) matches))]
+         {:action  action
+          :reason  (:policy/reason winner)
+          :policy  winner
+          :matches (vec matches)})))))

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/contract_runtime_v2/core.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/contract_runtime_v2/core.cljs
@@ -73,8 +73,6 @@
     (< (- now-ms (get entry "loaded-at" 0)) ttl-ms)))
 
 (defn walk-up-paths
-  "Pure upward walk over path strings. Returns CONTRACT.edn candidate paths root->leaf.
-   `join-path` and `dirname` are injected for testability."
   [join-path dirname start-dir stop-dir existing?]
   (loop [cur start-dir acc []]
     (let [candidate (join-path cur "CONTRACT.edn")
@@ -85,36 +83,14 @@
         (recur parent acc*)))))
 
 ;; ── Policy evaluation ─────────────────────────────────────────
-;;
-;; Policy shape (EDN):
-;;
-;;   {:contract/kind   :policy
-;;    :contract/id     "some.unique.id"
-;;    :policy/on       :before-tool-call          ; required - when this fires
-;;    :policy/match    {:tool/name "write_file"}  ; required - what it matches against
-;;    :policy/action   :block | :warn | :note      ; required - what to do on match
-;;    :policy/reason   "Human-readable explanation" ; optional
-;;    :policy/ttl-ms   60000}                      ; optional - overrides global TTL
-;;
-;; Tool-call shape passed to evaluate-policies:
-;;
-;;   {:tool/name   "write_file"
-;;    :tool/params {:path "/etc/passwd" ...}}
-;;
-;; Result shape:
-;;
-;;   {:action  :block | :warn | :note | :allow
-;;    :reason  str | nil
-;;    :policy  map | nil    ; the matching policy, if any
-;;    :matches [map ...]    ; all matching policies
-;;   }
 
-(defn policy-matches?
-  "True if policy fires for the given tool-call.
-  Matching rules (AND across all keys present in :policy/match):
-  - :tool/name  - exact string match
-  - :tool/param - {param-key pred-or-val}: val = exact, fn = predicate"
-  [policy tool-call]
+(def action-severity {:block 3 :warn 2 :note 1 :allow 0})
+
+(defn strongest-action [actions]
+  (let [n (apply max 0 (map #(get action-severity % 0) actions))]
+    (some (fn [[k v]] (when (= v n) k)) action-severity)))
+
+(defn policy-matches? [policy tool-call]
   (let [match (get policy :policy/match {})]
     (every? (fn [[k v]]
               (cond
@@ -127,27 +103,10 @@
                             (if (fn? pv) (pv actual) (= pv actual))))
                         v)
 
-                ;; unknown match key -> conservative: does not match
                 :else false))
             match)))
 
-(def action-severity
-  "Higher number = more severe. Used to pick the strongest action."
-  {:block 3 :warn 2 :note 1 :allow 0})
-
-(defn strongest-action [actions]
-  (->> actions
-       (map #(get action-severity % 0))
-       (apply max 0)
-       (fn [n] (some (fn [[k v]] (when (= v n) k)) action-severity))))
-
 (defn evaluate-policies
-  "Pure reducer. Given a seq of policy maps and a tool-call map, returns a
-  result map describing the strongest matching policy action.
-
-  Nearest-wins TTL: policies with :policy/ttl-ms are considered time-sensitive;
-  pass `now-ms` and `loaded-at` (ms) to enable TTL filtering.
-  If ttl-ms is omitted, the policy is always active."
   ([policies tool-call]
    (evaluate-policies policies tool-call nil nil))
   ([policies tool-call now-ms loaded-at]

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/contract_runtime_v2_test.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/contract_runtime_v2_test.cljs
@@ -53,18 +53,13 @@
   (testing "actor emits :system as prompt block"
     (let [acc (core/apply-map-dispatch {} {:actor/id :x :system "sys-text"} "raw")]
       (is (some #{"sys-text"} (:prompt-blocks acc)))))
-
   (testing "unknown block emits :raw as prompt block"
     (let [acc (core/apply-map-dispatch {} {:contract/kind :unknown :raw "raw-block"} "fallback")]
       (is (some #{"raw-block"} (:prompt-blocks acc)))))
-
   (testing "structured kind with no :raw falls through to raw-text arg"
-    ;; policy/fulfillment/capability/role with schema issues become prompt material —
-    ;; intent is preserved even when validation would fail
     (let [raw-text "{:contract/kind :policy :contract/id \"p1\"}"
-          acc (core/apply-map-dispatch {} {:contract/kind :policy :contract/id "p1"} raw-text)]
+          acc      (core/apply-map-dispatch {} {:contract/kind :policy :contract/id "p1"} raw-text)]
       (is (some #{raw-text} (:prompt-blocks acc)))))
-
   (testing "structured kind with blank raw-text emits no prompt block"
     (let [acc (core/apply-map-dispatch {} {:contract/kind :policy :contract/id "p1"} "")]
       (is (empty? (:prompt-blocks acc))))))
@@ -77,15 +72,114 @@
     (is (.includes out "unknown text"))))
 
 (deftest cache-freshness-test
-  (is (true? (core/cache-entry-fresh? 1000 {"loaded-at" 900} 200)))
+  (is (true?  (core/cache-entry-fresh? 1000 {"loaded-at" 900} 200)))
   (is (false? (core/cache-entry-fresh? 1000 {"loaded-at" 500} 200)))
-  (is (nil? (core/cache-entry-fresh? 1000 nil 200))))
+  (is (nil?   (core/cache-entry-fresh? 1000 nil 200))))
 
 (deftest walk-up-paths-test
-  (let [existing #{"/repo/CONTRACT.edn" "/repo/a/b/CONTRACT.edn"}
-        join-path (fn [a b] (str a "/" b))
-        dirname (fn [p]
-                  (let [idx (.lastIndexOf p "/")]
-                    (if (pos? idx) (subs p 0 idx) p)))
+  (let [existing   #{"/repo/CONTRACT.edn" "/repo/a/b/CONTRACT.edn"}
+        join-path  (fn [a b] (str a "/" b))
+        dirname    (fn [p]
+                     (let [idx (.lastIndexOf p "/")]
+                       (if (pos? idx) (subs p 0 idx) p)))
         out (core/walk-up-paths join-path dirname "/repo/a/b" "/repo" #(contains? existing %))]
     (is (= ["/repo/CONTRACT.edn" "/repo/a/b/CONTRACT.edn"] out))))
+
+;; ── Policy evaluation tests ──────────────────────────────────────
+
+(def p-block
+  {:contract/kind :policy
+   :contract/id   "block-write"
+   :policy/on     :before-tool-call
+   :policy/match  {:tool/name "write_file"}
+   :policy/action :block
+   :policy/reason "write_file is restricted"})
+
+(def p-warn
+  {:contract/kind :policy
+   :contract/id   "warn-read"
+   :policy/on     :before-tool-call
+   :policy/match  {:tool/name "read_file"}
+   :policy/action :warn
+   :policy/reason "read_file should be reviewed"})
+
+(def p-note
+  {:contract/kind :policy
+   :contract/id   "note-search"
+   :policy/on     :before-tool-call
+   :policy/match  {:tool/name "web_search"}
+   :policy/action :note
+   :policy/reason "web_search noted"})
+
+(def p-param
+  {:contract/kind :policy
+   :contract/id   "block-etc"
+   :policy/on     :before-tool-call
+   :policy/match  {:tool/name "write_file"
+                   :tool/params {:path "/etc/passwd"}}
+   :policy/action :block
+   :policy/reason "writing /etc/passwd is forbidden"})
+
+(def p-ttl
+  {:contract/kind  :policy
+   :contract/id    "ttl-warn"
+   :policy/on      :before-tool-call
+   :policy/match   {:tool/name "write_file"}
+   :policy/action  :warn
+   :policy/reason  "transient warning"
+   :policy/ttl-ms  1000})
+
+(deftest policy-no-match-test
+  (let [res (core/evaluate-policies [p-block] {:tool/name "read_file"})]
+    (is (= :allow (:action res)))
+    (is (nil? (:policy res)))
+    (is (empty? (:matches res)))))
+
+(deftest policy-block-test
+  (let [res (core/evaluate-policies [p-block] {:tool/name "write_file"})]
+    (is (= :block (:action res)))
+    (is (= "write_file is restricted" (:reason res)))
+    (is (= p-block (:policy res)))))
+
+(deftest policy-warn-test
+  (let [res (core/evaluate-policies [p-warn] {:tool/name "read_file"})]
+    (is (= :warn (:action res)))
+    (is (= "read_file should be reviewed" (:reason res)))))
+
+(deftest policy-note-test
+  (let [res (core/evaluate-policies [p-note] {:tool/name "web_search"})]
+    (is (= :note (:action res)))))
+
+(deftest policy-strongest-action-test
+  (testing "block beats warn when both match"
+    (let [p-warn2 (assoc p-warn :policy/match {:tool/name "write_file"}
+                               :policy/reason "also warns")
+          res     (core/evaluate-policies [p-warn2 p-block] {:tool/name "write_file"})]
+      (is (= :block (:action res)))
+      (is (= 2 (count (:matches res)))))))
+
+(deftest policy-param-match-test
+  (testing "matches on exact param value"
+    (let [res (core/evaluate-policies
+                [p-param]
+                {:tool/name "write_file" :tool/params {:path "/etc/passwd"}})]
+      (is (= :block (:action res)))))
+  (testing "does not match on different param value"
+    (let [res (core/evaluate-policies
+                [p-param]
+                {:tool/name "write_file" :tool/params {:path "/tmp/safe"}})]
+      (is (= :allow (:action res))))))
+
+(deftest policy-ttl-test
+  (testing "policy active within TTL"
+    (let [res (core/evaluate-policies [p-ttl] {:tool/name "write_file"} 500 0)]
+      (is (= :warn (:action res)))))
+  (testing "policy expired outside TTL"
+    (let [res (core/evaluate-policies [p-ttl] {:tool/name "write_file"} 2000 0)]
+      (is (= :allow (:action res)))))
+  (testing "policy with no TTL always active"
+    (let [res (core/evaluate-policies [p-block] {:tool/name "write_file"} 99999 0)]
+      (is (= :block (:action res))))))
+
+(deftest policy-empty-test
+  (is (= :allow (:action (core/evaluate-policies [] {:tool/name "anything"})))))


### PR DESCRIPTION
## What

Adds `evaluate-policies` as a pure reducer in `contract_runtime_v2/core.cljs` — no side effects, no Node deps, fully tested.

## Policy shape

```edn
{:contract/kind  :policy
 :contract/id    "block-write"
 :policy/on      :before-tool-call
 :policy/match   {:tool/name "write_file"
                  :tool/params {:path "/etc/passwd"}}
 :policy/action  :block   ; :block | :warn | :note
 :policy/reason  "reason string"
 :policy/ttl-ms  60000}   ; optional — nil = always active
```

## Result shape

```clojure
{:action  :block | :warn | :note | :allow
 :reason  str | nil
 :policy  map | nil   ; strongest matching policy
 :matches [map ...]}  ; all matching policies
```

## Semantics

- **Matching**: AND across all keys in `:policy/match` — `:tool/name` (exact), `:tool/params` (exact value or predicate fn)
- **Strongest-action wins**: `:block` > `:warn` > `:note` > `:allow`
- **Nearest-wins TTL**: policies with `:policy/ttl-ms` expire relative to their `loaded-at` timestamp; policies without it are always active
- **Unknown match keys**: conservative — do not match (safe default)

## Tests

9 new test cases: no-match, block, warn, note, strongest-action precedence, param exact match, param non-match, TTL active/expired/no-ttl, empty policy list.

## Next

Wire `evaluate-policies` into the `before_tool_call` hook in `contract_runtime_v2.cljs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced policy evaluation system that matches tool calls against active policies and selects the highest-priority action based on severity and TTL (time-to-live) windows.

* **Refactor**
  * Streamlined conditional dispatch logic for improved clarity.

* **Tests**
  * Added comprehensive test coverage for policy matching, action precedence, TTL expiry, and parameter-specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->