### PR TITLE
fix(ci): expand coverage to all testable packages, retire agentd relic

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,15 +65,9 @@ jobs:
       - name: signal-watchlists
         run: node --test packages/signal-watchlists/tests/*.test.cjs
 
-      - name: Test summary
-        if: always()
-        run: |
-          echo '## TS Package Test Results' >> $GITHUB_STEP_SUMMARY
-          echo 'All steps above report individually.' >> $GITHUB_STEP_SUMMARY
-
-  # ── ClojureScript extensions ─────────────────────────────────────────────
+  # ── ClojureScript extensions + coverage ─────────────────────────────
   cljs-extensions:
-    name: CLJS extension tests + pi smoke
+    name: CLJS extension tests + coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -129,9 +123,33 @@ jobs:
         working-directory: packages/eta-mu-extensions
         run: pnpm exec shadow-cljs compile node-test
 
-      - name: Run CLJS unit tests
+      - name: Run tests with coverage
         working-directory: packages/eta-mu-extensions
-        run: node target/test.cjs
+        run: pnpm run test:coverage
+
+      - name: Post coverage summary
+        if: always()
+        working-directory: packages/eta-mu-extensions
+        run: |
+          echo '## CLJS Extension Coverage' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat coverage/coverage-summary.json | node -e "
+            const s = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).total;
+            const fmt = (x) => (x.pct + '%').padStart(7);
+            console.log('Statements : ' + fmt(s.statements) + '  (' + s.covered + '/' + s.total + ')');
+            console.log('Branches   : ' + fmt(s.branches)   + '  (' + s.covered + '/' + s.total + ')');
+            console.log('Functions  : ' + fmt(s.functions)  + '  (' + s.covered + '/' + s.total + ')');
+            console.log('Lines      : ' + fmt(s.lines)      + '  (' + s.covered + '/' + s.total + ')');
+          " >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cljs-coverage
+          path: packages/eta-mu-extensions/coverage/
+          if-no-files-found: ignore
 
       - name: Upload shadow-cljs logs
         if: failure()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,25 +6,137 @@ on:
   pull_request:
 
 jobs:
-  coverage:
+  # ── TypeScript / Node packages ──────────────────────────────────────────
+  ts-packages:
+    name: TS package tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4
         with:
           version: '10.14.0'
           run_install: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '20'
 
-      - name: Install dependencies
-        run: pnpm install:all
+      - name: Get pnpm store path
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Run coverage
-        run: pnpm coverage
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+
+      - name: Install deps
+        run: pnpm install --no-frozen-lockfile
+
+      - name: eta-mu-runtime
+        run: pnpm --dir packages/eta-mu-runtime test
+
+      - name: eta-mu-github
+        run: pnpm --dir packages/eta-mu-github test
+
+      - name: eta-mu-docs
+        run: node --test packages/eta-mu-docs/tests/*.test.cjs
+
+      - name: eta-mu-truth
+        run: node --test packages/eta-mu-truth/tests/*.test.cjs
+
+      - name: presence-core
+        run: pnpm --dir packages/presence-core test
+
+      - name: kanban
+        run: pnpm --dir packages/kanban test
+
+      - name: signal-contracts
+        run: node --test packages/signal-contracts/tests/*.test.cjs
+
+      - name: signal-radar-core
+        run: node --test packages/signal-radar-core/tests/*.test.cjs
+
+      - name: signal-source-utils
+        run: node --test packages/signal-source-utils/tests/*.test.cjs
+
+      - name: signal-watchlists
+        run: node --test packages/signal-watchlists/tests/*.test.cjs
+
+      - name: Test summary
+        if: always()
+        run: |
+          echo '## TS Package Test Results' >> $GITHUB_STEP_SUMMARY
+          echo 'All steps above report individually.' >> $GITHUB_STEP_SUMMARY
+
+  # ── ClojureScript extensions ─────────────────────────────────────────────
+  cljs-extensions:
+    name: CLJS extension tests + pi smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.14.0'
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get pnpm store path
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+
+      - name: Install deps
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build extensions
+        working-directory: packages/eta-mu-extensions
+        run: pnpm build
+
+      - name: Deploy runtimes to e2e dir
+        working-directory: packages/eta-mu-extensions
+        run: node scripts/deploy-ci.mjs
+
+      - name: Smoke test — pi loads all extensions
+        working-directory: packages/eta-mu-extensions-e2e
+        run: |
+          output=$(pnpm exec pi -p "smoke" 2>&1 || true)
+          echo "$output"
+          if echo "$output" | grep -q "Failed to load extension"; then
+            echo "FAIL: one or more extensions failed to load"
+            echo "$output" | grep "Failed to load extension"
+            exit 1
+          fi
+          echo "OK: all extensions loaded cleanly"
+
+      - name: Compile CLJS unit tests
+        working-directory: packages/eta-mu-extensions
+        run: pnpm exec shadow-cljs compile node-test
+
+      - name: Run CLJS unit tests
+        working-directory: packages/eta-mu-extensions
+        run: node target/test.cjs
+
+      - name: Upload shadow-cljs logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shadow-cljs-logs
+          path: packages/eta-mu-extensions/.shadow-cljs/
+          if-no-files-found: ignore

--- a/packages/eta-mu-extensions/package.json
+++ b/packages/eta-mu-extensions/package.json
@@ -7,12 +7,14 @@
     "build": "node scripts/build.mjs release",
     "watch": "node scripts/build.mjs watch",
     "clean": "node scripts/build.mjs clean",
-    "test": "shadow-cljs compile node-test && node target/test.cjs"
+    "test": "shadow-cljs compile node-test && node target/test.cjs",
+    "test:coverage": "shadow-cljs compile node-test && c8 --reporter=text --reporter=lcov --reporter=json-summary --all --src-dir=src node target/test.cjs"
   },
   "dependencies": {
     "@open-hax/output-contract-gate": "workspace:*"
   },
   "devDependencies": {
+    "c8": "^10.1.2",
     "shadow-cljs": "^3.3.5",
     "source-map-support": "^0.5.21"
   },


### PR DESCRIPTION
## What

Replaces the `coverage.yml` workflow that only ran `pnpm coverage` (which pointed at the defunct `agentd` package) with two proper jobs:

### `ts-packages`
Runs tests for all 10 Node/TS packages individually:
- `eta-mu-runtime`, `eta-mu-github`, `eta-mu-docs`, `eta-mu-truth`
- `presence-core`, `kanban`
- `signal-contracts`, `signal-radar-core`, `signal-source-utils`, `signal-watchlists`

### `cljs-extensions`
- `pnpm build` (shadow-cljs release)
- `deploy-ci.mjs` → copies runtimes into e2e extensions dir
- `pnpm exec pi -p "smoke"` → fails if any `"Failed to load extension"` in output
- `shadow-cljs compile node-test && node target/test.cjs` → CLJS unit tests

## Why
The old `pnpm coverage` script was a relic wired to `agentd` which no longer exists in the monorepo. Nothing was being tested on every PR/push to main.