### PR TITLE
feat(receipt-river): EDN refactor — pure-fn namespaces + red/green tests

### DIFF
--- a/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river/edn.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river/edn.cljs
@@ -1,0 +1,37 @@
+(ns eta-mu.extensions.receipt-river.edn
+  "Pure EDN serialization for receipt-river events.
+  No I/O. No side effects. Inject everywhere."
+  (:require [clojure.string :as str]))
+
+(def ^:private required-keys
+  [:ts :kind :repo :origin :owner :dod :pi :host :manifest :refs])
+
+(def ^:private optional-keys
+  [:note :tests :decisions :drift])
+
+(defn edn-event
+  "Serializes a receipt event map to a single-line EDN string.
+  Optional keys are omitted when nil/blank."
+  [m]
+  (let [base (reduce (fn [acc k]
+                       (assoc acc k (get m k)))
+                     {} required-keys)
+        with-opts (reduce (fn [acc k]
+                            (let [v (get m k)]
+                              (if (and v (not (str/blank? (str v))))
+                                (assoc acc k v)
+                                acc)))
+                          base optional-keys)]
+    ;; pr-str produces valid EDN; replace internal newlines to keep single-line
+    (-> (pr-str with-opts)
+        (.replace (js/RegExp. "\\n" "g") " "))))
+
+(defn parse-edn-event
+  "Parses a single EDN line back to a map.
+  Returns nil on any parse failure, non-map result, or blank/nil input."
+  [line]
+  (when (and line (not (str/blank? (str line))))
+    (try
+      (let [result (cljs.reader/read-string (str line))]
+        (when (map? result) result))
+      (catch :default _ nil))))

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river/repo.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river/repo.cljs
@@ -1,0 +1,83 @@
+(ns eta-mu.extensions.receipt-river.repo
+  "Pure repo-detection and contract logic for receipt-river.
+  All filesystem access is injected — no direct fs calls here.")
+
+;; ── Git root detection ────────────────────────────────────────────────────────
+
+(defn find-git-root
+  "Walks up from `start-path` looking for a directory containing `.git`.
+  Returns the directory path containing `.git`, or nil if not found.
+
+  Args are injected for purity:
+    join-fn    :: (parent child) -> path string
+    dirname-fn :: path -> parent path (nil at filesystem root)
+    exists-fn  :: path -> boolean"
+  [join-fn dirname-fn exists-fn start-path]
+  (when start-path
+    (loop [dir start-path]
+      (when dir
+        (if (exists-fn (join-fn dir ".git"))
+          dir
+          (let [parent (dirname-fn dir)]
+            (when (and parent (not= parent dir))
+              (recur parent))))))))
+
+;; ── Path param extraction ─────────────────────────────────────────────────────
+
+(def ^:private path-param-keys
+  ["path" "file" "dest" "destination" "target" "filename" "filepath"])
+
+(defn- path-param-from-call [tool-call]
+  (let [params (or (:tool/params tool-call) {})]
+    (some (fn [k]
+            (or (get params k)
+                (get params (keyword k))))
+          path-param-keys)))
+
+;; ── Touched repos ─────────────────────────────────────────────────────────────
+
+(defn touched-repos
+  "Reduces a seq of tool-call maps to {repo-root -> call-count}.
+  `find-git-root-fn` :: path -> repo-root-string|nil
+  Tool calls without a resolvable path param are ignored."
+  [find-git-root-fn tool-calls]
+  (reduce (fn [acc call]
+            (if-let [p (path-param-from-call call)]
+              (if-let [root (find-git-root-fn p)]
+                (update acc root (fnil inc 0))
+                acc)
+              acc))
+          {}
+          tool-calls))
+
+;; ── Ledger activation ─────────────────────────────────────────────────────────
+
+(def ^:private default-threshold 3)
+
+(defn should-activate?
+  "Returns true if the per-repo ledger should become active.
+  A repo-state map has keys:
+    :call-count  number of tool calls into this repo this turn
+    :threshold   (optional) activation threshold, defaults to 3
+    :active?     whether the ledger is already active"
+  [{:keys [call-count threshold active?]}]
+  (or active?
+      (>= call-count (or threshold default-threshold))))
+
+;; ── Contract violation detection ──────────────────────────────────────────────
+
+(def ^:private read-only-threshold 1)
+
+(defn contract-violations
+  "Returns a sorted seq of repo roots that were touched substantively
+  (call-count > read-only-threshold) but have no receipt this turn.
+
+  touched-repos  :: {repo-root -> call-count}
+  receipts-by-repo :: #{repo-root} (set of repos that got a receipt this turn)"
+  [touched-repos receipts-by-repo]
+  (->> touched-repos
+       (keep (fn [[repo cnt]]
+               (when (and (> cnt read-only-threshold)
+                          (not (contains? receipts-by-repo repo)))
+                 repo)))
+       sort))

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river_test.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river_test.cljs
@@ -65,7 +65,7 @@
       (is (keyword? (:kind back))))))
 
 (deftest parse-edn-event-returns-nil-on-garbage
-  (is (nil? (rr-edn/parse-edn-event "not edn at all {{{"))))
+  (is (nil? (rr-edn/parse-edn-event "not edn at all {{{"  )))
   (is (nil? (rr-edn/parse-edn-event "")))
   (is (nil? (rr-edn/parse-edn-event nil))))
 
@@ -229,8 +229,6 @@
     (let [touched  {"/mono/packages/alpha" 1 "/mono/packages/beta" 4}
           receipts #{}
           result   (rr-repo/contract-violations touched receipts)]
-      ;; alpha only had 1 call — exempt
-      ;; beta had 4 calls — violation
       (is (= 1 (count result)))
       (is (= "/mono/packages/beta" (first result))))))
 

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river_test.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/receipt_river_test.cljs
@@ -1,0 +1,242 @@
+(ns eta-mu.extensions.receipt-river-test
+  "Red phase tests for receipt-river EDN refactor.
+
+  All tests in this ns are expected to FAIL until the following
+  pure-function modules are extracted from receipt_river.cljs:
+
+    eta-mu.extensions.receipt-river.edn
+      - edn-event       :: map -> edn string
+      - parse-edn-event :: string -> map (nil on parse failure)
+
+    eta-mu.extensions.receipt-river.repo
+      - find-git-root         :: (join-fn, dirname-fn, exists-fn) -> path -> string|nil
+      - touched-repos         :: (find-git-root-fn) -> tool-calls -> {repo-root -> call-count}
+      - should-activate?      :: repo-state -> boolean
+      - contract-violations   :: touched-repos -> receipts-by-repo -> [repo-root]
+
+  None of these namespaces exist yet. The shadow-cljs node-test
+  build will fail to compile until they are created (red phase).
+  Create stub namespaces returning nil/empty to enter green phase,
+  then implement to pass."
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.extensions.receipt-river.edn  :as rr-edn]
+            [eta-mu.extensions.receipt-river.repo :as rr-repo]))
+
+;; ============================================================
+;; EDN event format
+;; ============================================================
+
+(def sample-event
+  {:ts      "2026-04-19T05:00:00.000Z"
+   :kind    :observation
+   :repo    "/home/user/projects/eta-mu"
+   :origin  "pi"
+   :owner   "receipt-river"
+   :dod     "receipt-river"
+   :pi      "0.63.1"
+   :host    "local"
+   :manifest "none"
+   :refs    "none"})
+
+(deftest edn-event-produces-valid-edn
+  (testing "round-trips through parse-edn-event"
+    (let [line (rr-edn/edn-event sample-event)
+          back (rr-edn/parse-edn-event line)]
+      (is (string? line))
+      (is (map? back))
+      (is (= (:kind sample-event) (:kind back)))
+      (is (= (:repo sample-event) (:repo back)))
+      (is (= (:ts sample-event)   (:ts back))))))
+
+(deftest edn-event-is-single-line
+  (testing "no embedded newlines — safe to append"
+    (let [line (rr-edn/edn-event sample-event)]
+      (is (not (.includes line "\n"))))))
+
+(deftest edn-event-contains-required-keys
+  (testing "serialized form contains all required keys"
+    (let [line (rr-edn/edn-event sample-event)]
+      (doseq [k [:ts :kind :repo :origin :owner :dod :pi :host :manifest :refs]]
+        (is (.includes line (name k)))))))
+
+(deftest edn-event-kind-is-keyword
+  (testing "kind round-trips as keyword"
+    (let [back (rr-edn/parse-edn-event (rr-edn/edn-event sample-event))]
+      (is (keyword? (:kind back))))))
+
+(deftest parse-edn-event-returns-nil-on-garbage
+  (is (nil? (rr-edn/parse-edn-event "not edn at all {{{"))))
+  (is (nil? (rr-edn/parse-edn-event "")))
+  (is (nil? (rr-edn/parse-edn-event nil))))
+
+(deftest parse-edn-event-returns-nil-on-non-map
+  (testing "vectors and scalars are rejected"
+    (is (nil? (rr-edn/parse-edn-event "[1 2 3]")))
+    (is (nil? (rr-edn/parse-edn-event "42")))))
+
+(deftest edn-event-optional-keys-omitted-when-nil
+  (testing "note/tests/decisions/drift absent when not supplied"
+    (let [line (rr-edn/edn-event sample-event)]
+      (is (not (.includes line ":note")))
+      (is (not (.includes line ":tests")))
+      (is (not (.includes line ":decisions")))
+      (is (not (.includes line ":drift"))))))
+
+(deftest edn-event-optional-keys-present-when-supplied
+  (let [e    (assoc sample-event :note "fixed the thing" :tests "42 pass 0 fail")
+        back (rr-edn/parse-edn-event (rr-edn/edn-event e))]
+    (is (= "fixed the thing" (:note back)))
+    (is (= "42 pass 0 fail" (:tests back)))))
+
+;; ============================================================
+;; Git repo root detection
+;; ============================================================
+
+(defn make-fs
+  "Builds a fake filesystem predicate from a set of existing paths."
+  [existing]
+  (fn [p] (contains? existing p)))
+
+(defn make-join []
+  (fn [a b] (str a "/" b)))
+
+(defn make-dirname []
+  (fn [p]
+    (let [idx (.lastIndexOf p "/")]
+      (if (pos? idx) (subs p 0 idx) nil))))
+
+(deftest find-git-root-direct
+  (testing "finds .git at the given dir"
+    (let [exists? (make-fs #{"/repo/.git"})
+          join    (make-join)
+          dirname (make-dirname)
+          result  (rr-repo/find-git-root join dirname exists? "/repo/src/core")]
+      (is (= "/repo" result)))))
+
+(deftest find-git-root-walks-up
+  (testing "walks up to find .git"
+    (let [exists? (make-fs #{"/mono/.git"})
+          join    (make-join)
+          dirname (make-dirname)
+          result  (rr-repo/find-git-root join dirname exists? "/mono/packages/eta-mu/src")]
+      (is (= "/mono" result)))))
+
+(deftest find-git-root-submodule
+  (testing "stops at the nearest .git (submodule wins over monorepo root)"
+    (let [exists? (make-fs #{"/mono/.git" "/mono/packages/eta-mu/.git"})
+          join    (make-join)
+          dirname (make-dirname)
+          result  (rr-repo/find-git-root join dirname exists? "/mono/packages/eta-mu/src")]
+      (is (= "/mono/packages/eta-mu" result)))))
+
+(deftest find-git-root-returns-nil-when-not-found
+  (let [exists? (make-fs #{})
+        join    (make-join)
+        dirname (make-dirname)
+        result  (rr-repo/find-git-root join dirname exists? "/tmp/no-git")]
+    (is (nil? result))))
+
+(deftest find-git-root-nil-path
+  (let [exists? (make-fs #{})
+        join    (make-join)
+        dirname (make-dirname)]
+    (is (nil? (rr-repo/find-git-root join dirname exists? nil)))))
+
+;; ============================================================
+;; Touched-repos reduction
+;; ============================================================
+
+(def fake-find-git-root
+  "Resolves /mono/packages/X/** -> /mono/packages/X,
+   /mono/shared/** -> /mono, everything else nil."
+  (fn [path]
+    (cond
+      (and path (.startsWith path "/mono/packages/alpha")) "/mono/packages/alpha"
+      (and path (.startsWith path "/mono/packages/beta"))  "/mono/packages/beta"
+      (and path (.startsWith path "/mono/shared"))         "/mono"
+      :else nil)))
+
+(def tool-calls-mixed
+  [{:tool/name "read_file"   :tool/params {:path "/mono/packages/alpha/src/core.cljs"}}
+   {:tool/name "write_file"  :tool/params {:path "/mono/packages/alpha/src/core.cljs"}}
+   {:tool/name "read_file"   :tool/params {:path "/mono/packages/beta/README.md"}}
+   {:tool/name "read_file"   :tool/params {:path "/mono/packages/beta/src/main.cljs"}}
+   {:tool/name "bash"        :tool/params {:command "echo hi"}}])
+
+(deftest touched-repos-counts-calls-per-repo
+  (let [result (rr-repo/touched-repos fake-find-git-root tool-calls-mixed)]
+    (is (= 2 (get result "/mono/packages/alpha")))
+    (is (= 2 (get result "/mono/packages/beta")))))
+
+(deftest touched-repos-ignores-pathless-tools
+  (testing "bash with no path param is not counted"
+    (let [result (rr-repo/touched-repos fake-find-git-root tool-calls-mixed)]
+      (is (not (contains? result nil))))))
+
+(deftest touched-repos-empty
+  (is (= {} (rr-repo/touched-repos fake-find-git-root []))))
+
+(deftest touched-repos-all-outside-git
+  (let [calls  [{:tool/name "read_file" :tool/params {:path "/tmp/scratch.txt"}}]
+        result (rr-repo/touched-repos fake-find-git-root calls)]
+    (is (= {} result))))
+
+;; ============================================================
+;; Ledger activation threshold
+;; ============================================================
+
+(deftest should-activate-below-threshold
+  (testing "fewer than threshold calls -> inactive"
+    (is (false? (rr-repo/should-activate? {:call-count 2 :threshold 3 :active? false})))))
+
+(deftest should-activate-at-threshold
+  (testing "at threshold -> activate"
+    (is (true? (rr-repo/should-activate? {:call-count 3 :threshold 3 :active? false})))))
+
+(deftest should-activate-already-active
+  (testing "already active -> stays active regardless of count"
+    (is (true? (rr-repo/should-activate? {:call-count 0 :threshold 3 :active? true})))))
+
+(deftest should-activate-default-threshold
+  (testing "threshold defaults to 3 when absent"
+    (is (false? (rr-repo/should-activate? {:call-count 2 :active? false})))
+    (is (true?  (rr-repo/should-activate? {:call-count 3 :active? false})))))
+
+;; ============================================================
+;; Contract violation detection
+;; ============================================================
+
+(deftest contract-violations-all-covered
+  (testing "no violations when every touched repo has a receipt this turn"
+    (let [touched  {"/mono/packages/alpha" 3 "/mono/packages/beta" 1}
+          receipts #{"/mono/packages/alpha" "/mono/packages/beta"}
+          result   (rr-repo/contract-violations touched receipts)]
+      (is (empty? result)))))
+
+(deftest contract-violations-missing-receipt
+  (testing "reports repos touched but without a receipt"
+    (let [touched  {"/mono/packages/alpha" 3 "/mono/packages/beta" 2}
+          receipts #{"/mono/packages/alpha"}
+          result   (rr-repo/contract-violations touched receipts)]
+      (is (= 1 (count result)))
+      (is (= "/mono/packages/beta" (first result))))))
+
+(deftest contract-violations-nothing-touched
+  (is (empty? (rr-repo/contract-violations {} #{}))))
+
+(deftest contract-violations-read-only-repo-exempt
+  (testing "repos with only 1 call (read-only recon) are exempt"
+    (let [touched  {"/mono/packages/alpha" 1 "/mono/packages/beta" 4}
+          receipts #{}
+          result   (rr-repo/contract-violations touched receipts)]
+      ;; alpha only had 1 call — exempt
+      ;; beta had 4 calls — violation
+      (is (= 1 (count result)))
+      (is (= "/mono/packages/beta" (first result))))))
+
+(deftest contract-violations-returns-sorted
+  (testing "violation list is deterministically ordered"
+    (let [touched  {"/b" 5 "/a" 5 "/c" 5}
+          receipts #{}
+          result   (rr-repo/contract-violations touched receipts)]
+      (is (= (sort result) result)))))


### PR DESCRIPTION
## What

Red/green TDD phase for the receipt-river EDN + repo-awareness refactor.

### New namespaces (pure, no I/O)

**`eta-mu.extensions.receipt-river.edn`**
- `edn-event` — serializes a receipt map to a single-line EDN string (append-safe)
- `parse-edn-event` — parses EDN line back to map; nil on any failure

**`eta-mu.extensions.receipt-river.repo`**
- `find-git-root` — walks up from a path to find nearest `.git`; injected fs fns
- `touched-repos` — reduces tool-call history to `{repo-root → call-count}`
- `should-activate?` — ledger activation threshold predicate (default 3 calls)
- `contract-violations` — returns sorted seq of repos touched but lacking a receipt

### Tests (34 assertions)
- EDN round-trip, single-line guarantee, nil safety, optional key presence
- `find-git-root`: direct hit, walks up, submodule stops at nearest `.git`, not-found, nil path
- `touched-repos`: per-repo counts, pathless tools ignored, empty/outside-git cases
- `should-activate?`: threshold, already-active, default threshold
- `contract-violations`: all covered, missing receipt, read-only (1 call) exempt, sorted output

## Why

Prerequisite for:
1. Migrating `receipts.log` pipe-delimited format → append-only EDN event log
2. Per-repo ledger at `<git-root>/receipts.edn` instead of `cwd/receipts.log`
3. Implicit fulfillment contract: agent_end fails if any touched repo (>1 call) has no receipt
4. Passive ledger activation via `before_tool_call` threshold injection

## Next
- Wire `receipt-river.edn` + `receipt-river.repo` into main `receipt_river.cljs`
- Migration script: `receipts.log` pipe-delimited → `receipts.edn` EDN format
- PRINCIPAL.edn entry for the implicit contract