### PR TITLE
feat(runtime): add CLJS shadow spine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 dist/
+dist-cljs/
 build/
 lib/
 !packages/eta-mu-extensions/lib/

--- a/docs/cljs-runtime-rewrite-shadow-spine-plan.md
+++ b/docs/cljs-runtime-rewrite-shadow-spine-plan.md
@@ -1,0 +1,219 @@
+# Eta-mu CLJS Runtime Rewrite — Shadow-CLJS Spine Plan
+
+Date: 2026-05-29
+Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+Kanban task: `kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md`
+Inventory: `docs/cljs-runtime-rewrite-architecture-inventory.md`
+
+## Purpose
+
+Define the first CLJS build spine for the eta-mu runtime rewrite before writing implementation code.
+
+The spine must prove that eta-mu can compile CLJS to Node-importable ESM, run CLJS tests, and preserve existing package compatibility while TypeScript wrappers remain in place.
+
+## Decision recommendation
+
+Start inside `packages/eta-mu-runtime`, not in a new temporary package.
+
+Rationale:
+
+- `@open-hax/eta-mu-runtime` is the smallest central package with pure state/envelope/planner semantics.
+- Keeping the first spine in the target package avoids a throwaway package name and publish confusion.
+- Existing TS exports can stay as the public contract until CLJS parity is proven.
+- The package can expose compiled CLJS through a private smoke path first, then switch the public `exports["."]` only after tests pass.
+
+Rejected for first slice:
+
+- `packages/eta-mu-runtime-cljs`: lower risk to the existing package, but creates temporary package-management and publish semantics.
+- root-level `shadow-cljs.edn` only: useful for the existing browser app, but too broad for a package-level runtime proof.
+- starting in `packages/coding-agent`: too many I/O and UI boundaries before the CLJS ESM proof exists.
+
+## Proposed package layout
+
+```text
+packages/eta-mu-runtime/
+  shadow-cljs.edn
+  src/
+    cljs/
+      eta_mu/runtime/facade.cljs
+      eta_mu/runtime/domain/state.cljs
+      eta_mu/runtime/domain/planner.cljs
+      eta_mu/runtime/shape/envelope.cljs
+      eta_mu/runtime/law/envelope.cljs
+  test/
+    cljs/
+      eta_mu/runtime/domain/state_test.cljs
+      eta_mu/runtime/shape/envelope_test.cljs
+      eta_mu/runtime/facade_test.cljs
+  scripts/
+    smoke-cljs-runtime.mjs
+    check-cljs-boundaries.mjs
+  dist/           # existing TS public output remains initially
+  dist-cljs/      # compiled CLJS ESM output, ignored or packaged only after cutover
+  target/         # CLJS test output
+```
+
+Namespace rule:
+
+- Clojure namespace root: `eta-mu.runtime.*`
+- Filesystem path: `eta_mu/runtime/**`
+- JS-facing exports: only from `eta-mu.runtime.facade` until the cutover task expands exports.
+
+## Proposed `shadow-cljs.edn` shape
+
+```clojure
+{:source-paths ["src/cljs" "test/cljs"]
+ :dependencies [[metosin/malli "0.16.4"]]
+ :js-options {:js-provider :import}
+ :builds
+ {:runtime
+  {:target :esm
+   :runtime :node
+   :output-dir "dist-cljs"
+   :modules {:index {:exports {:normalizeEnvelope eta-mu.runtime.facade/normalize-envelope
+                                :initialState eta-mu.runtime.facade/initial-state
+                                :planNext eta-mu.runtime.facade/plan-next}}}
+   :compiler-options {:output-feature-set :es-next
+                      :optimizations :simple
+                      :source-map true}}
+
+  :test
+  {:target :node-test
+   :output-to "target/cljs-test.cjs"
+   :ns-regex ["eta-mu.runtime.*-test$"]
+   :autorun true
+   :compiler-options {:output-feature-set :es-next
+                      :optimizations :none
+                      :source-map true}}}}
+```
+
+This is intentionally smaller than Knoxx's backend build. Eta-mu should add server/runtime targets only when a migrated slice needs them.
+
+## Proposed `package.json` script additions
+
+Do not replace existing TS scripts during spine setup. Add CLJS-specific scripts first:
+
+```json
+{
+  "scripts": {
+    "cljs:compile": "shadow-cljs compile runtime",
+    "cljs:test": "shadow-cljs compile test && node target/cljs-test.cjs",
+    "cljs:smoke": "node scripts/smoke-cljs-runtime.mjs",
+    "cljs:boundary": "node scripts/check-cljs-boundaries.mjs",
+    "cljs:verify": "pnpm cljs:compile && pnpm cljs:test && pnpm cljs:smoke && pnpm cljs:boundary"
+  }
+}
+```
+
+Existing scripts stay authoritative for the published package until cutover:
+
+```bash
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+```
+
+## ESM runtime smoke requirement
+
+After every `shadow-cljs compile runtime`, run a real Node import smoke, not just compilation.
+
+Example smoke:
+
+```js
+// packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
+const mod = await import("../dist-cljs/index.js");
+const expected = ["normalizeEnvelope", "initialState", "planNext"];
+for (const key of expected) {
+  if (typeof mod[key] !== "function") {
+    throw new Error(`missing CLJS ESM export: ${key}`);
+  }
+}
+console.log(JSON.stringify({ ok: true, exports: expected }));
+```
+
+Why this gate is mandatory:
+
+- shadow-cljs `:esm` builds can compile while runtime imports expose `undefined` if namespace init/export wiring drifts.
+- Node import catches package/module semantics that the compiler does not.
+- Heavy I/O should remain in `.mjs` shims or named `extern.*` adapters rather than being forced through early CLJS exports.
+
+## Boundary gate shape
+
+The first boundary scanner can be intentionally simple. It should fail if raw interop appears outside allowed paths.
+
+Allowed initially:
+
+- `src/cljs/eta_mu/runtime/extern/**`
+- `src/cljs/eta_mu/runtime/facade.cljs`
+- `test/cljs/**` for test doubles only, if annotated in a small allowlist
+
+Disallowed elsewhere:
+
+- `js/`
+- `js->clj`
+- `clj->js`
+- `#js`
+- `aget`
+- `aset`
+- `js/Promise`
+- `js/JSON`
+- `js/Array.from`
+- Node globals or SDK-native object access
+- namespace path segment `/utils/` or namespace segment `.utils`
+
+First script behavior:
+
+```text
+node scripts/check-cljs-boundaries.mjs
+- walk src/cljs/**/*.cljs
+- ignore allowed extern/facade files
+- report line-numbered disallowed raw interop tokens
+- report any namespace containing utils
+- exit 1 on findings
+```
+
+## First export set
+
+Use tiny pure exports first. They should map to the current TS runtime concepts without owning provider/session I/O.
+
+Candidate exports:
+
+- `normalizeEnvelope`: validates and normalizes an action/movement envelope
+- `initialState`: returns a canonical initial runtime state map
+- `planNext`: computes the next pure planner decision from state plus signal
+
+Do not export provider calls, filesystem access, process execution, git operations, web fetches, or package-manager behavior in the first spine.
+
+## Test plan
+
+Minimum CLJS tests:
+
+- envelope accepts a minimal valid shape
+- envelope rejects malformed required fields
+- initial state returns a map matching existing TS defaults
+- planner returns a deterministic no-op/next-step decision for a simple input
+- facade exports are callable from CLJS tests
+
+Minimum JS/Node tests:
+
+- smoke import sees all expected ESM exports as functions
+- representative payload can round-trip from JS object to CLJS normalization and back to plain JSON-compatible data
+
+## Cutover guardrails
+
+Do not switch `package.json` public `main`, `types`, or `exports` in the spine task.
+
+The spine task is done when CLJS compile/test/smoke/boundary gates pass while existing TS gates still pass. Public export replacement belongs to `eta-mu-cljs-rewrite-surface-parity` or `eta-mu-cljs-rewrite-cutover-ratchet`.
+
+## Acceptance checklist for the spine task
+
+- [ ] `packages/eta-mu-runtime/shadow-cljs.edn` exists with `:runtime` and `:test` targets.
+- [ ] `pnpm --dir packages/eta-mu-runtime cljs:compile` passes.
+- [ ] `pnpm --dir packages/eta-mu-runtime cljs:test` passes.
+- [ ] `pnpm --dir packages/eta-mu-runtime cljs:smoke` proves Node can import CLJS ESM exports.
+- [ ] `pnpm --dir packages/eta-mu-runtime cljs:boundary` rejects disallowed raw JS interop outside allowed namespaces.
+- [ ] Existing TS gates still pass: `test` and `typecheck`.
+- [ ] No public package export is changed until parity tasks approve it.
+
+## Recommended next implementation move
+
+Implement only the minimal spine in `packages/eta-mu-runtime` and export placeholder-compatible pure functions backed by tests. Treat the Node import smoke as a blocking gate after every shadow-cljs build.

--- a/kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md
@@ -43,8 +43,9 @@ Create the CLJS build spine that lets eta-mu migrate runtime slices behind stabl
 
 ## Verification
 
+Run from the repository root:
+
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/eta-mu-runtime test
 pnpm --dir packages/eta-mu-runtime typecheck

--- a/kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md
@@ -1,0 +1,58 @@
+---
+uuid: "eta-mu-cljs-rewrite-shadow-spine"
+title: "Eta-mu CLJS Rewrite — Shadow-CLJS Spine"
+status: review
+priority: P0
+labels: ["tasks", "cljs", "rewrite", "shadow-cljs", "8sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "kanban/epics/eta-mu-cljs-runtime-rewrite.md"
+points: 8
+category: tasks
+---
+# Eta-mu CLJS Rewrite — Shadow-CLJS Spine
+
+> Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+> Planning output: `docs/cljs-runtime-rewrite-shadow-spine-plan.md`
+> Points: 8
+
+## Purpose
+
+Create the CLJS build spine that lets eta-mu migrate runtime slices behind stable JS exports.
+
+## Scope
+
+- shadow-cljs build targets for runtime/server/test slices
+- package scripts for compile, test, lint, and typecheck-equivalent gates
+- JS facade export strategy for existing Node/CLI consumers
+- CLJS namespace layout conventions copied from Knoxx style, not Knoxx product behavior
+
+## Work items
+
+- [x] Decide whether the first spine lives in a new bridge package or inside an existing eta-mu package.
+- [x] Add `:target :esm` runtime build output that Node can import.
+- [x] Add `:target :node-test` gate for migrated runtime tests.
+- [x] Add lint/boundary gates that reject broad `utils` namespaces and raw JS interop outside `extern.*`.
+- [x] Create CLJS exported functions and prove Node can import them at runtime.
+
+## Acceptance criteria
+
+- [x] `shadow-cljs compile test` passes for the new spine.
+- [x] A Node smoke command imports a compiled ESM export without `undefined` exports.
+- [x] Package scripts document how to run compile/test/lint gates.
+- [x] The parent epic is updated with the chosen package/home.
+
+## Verification
+
+```bash
+cd orgs/open-hax/eta-mu
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime build
+```
+
+---
+
+Implemented in `packages/eta-mu-runtime` with `shadow-cljs.edn`, CLJS `:runtime` and `:test` targets, ESM facade exports, Node smoke import, and a strict CLJS boundary scanner. Verification passed on 2026-05-29.
+
+---

--- a/packages/eta-mu-runtime/package.json
+++ b/packages/eta-mu-runtime/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "typescript": "^5.6.3",
     "vitest": "^2.1.0",
-    "shadow-cljs": "^3.3.5",
+    "shadow-cljs": "^3.4.11",
     "source-map-support": "^0.5.21"
   },
   "keywords": [

--- a/packages/eta-mu-runtime/package.json
+++ b/packages/eta-mu-runtime/package.json
@@ -14,17 +14,24 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist dist-cljs target",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --config vitest.config.ts",
-    "test:watch": "vitest --config vitest.config.ts"
+    "test:watch": "vitest --config vitest.config.ts",
+    "cljs:compile": "shadow-cljs compile runtime",
+    "cljs:test": "shadow-cljs compile test && node target/cljs-test.cjs",
+    "cljs:smoke": "node scripts/smoke-cljs-runtime.mjs",
+    "cljs:boundary": "node scripts/check-cljs-boundaries.mjs",
+    "cljs:verify": "pnpm cljs:compile && pnpm cljs:test && pnpm cljs:smoke && pnpm cljs:boundary"
   },
   "dependencies": {
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "^5.6.3",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "shadow-cljs": "^3.3.5",
+    "source-map-support": "^0.5.21"
   },
   "keywords": [
     "eta-mu",

--- a/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
+++ b/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
@@ -1,0 +1,76 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const sourceRoot = path.join(root, "src", "cljs");
+
+const disallowedTokens = [
+  "js/",
+  "js->clj",
+  "clj->js",
+  "#js",
+  "aget",
+  "aset",
+  "js/Promise",
+  "js/JSON",
+  "js/Array.from",
+  "js/Buffer",
+  "js/process",
+  "js/window",
+  "js/document",
+];
+
+function isAllowedInteropFile(filePath) {
+  const normalized = filePath.split(path.sep).join("/");
+  return normalized.includes("/extern/") || normalized.endsWith("/facade.cljs");
+}
+
+function hasForbiddenUtilsSegment(filePath) {
+  const normalized = filePath.split(path.sep).join("/");
+  return normalized.includes("/utils/") || normalized.endsWith("/utils.cljs");
+}
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith(".cljs")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+const violations = [];
+const files = await walk(sourceRoot);
+
+for (const file of files) {
+  const relative = path.relative(root, file);
+  if (hasForbiddenUtilsSegment(file)) {
+    violations.push(`${relative}: forbidden utils namespace/path segment`);
+  }
+
+  if (isAllowedInteropFile(file)) {
+    continue;
+  }
+
+  const text = await readFile(file, "utf8");
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    for (const token of disallowedTokens) {
+      if (line.includes(token)) {
+        violations.push(`${relative}:${index + 1}: raw interop token outside extern/facade: ${token}`);
+      }
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error(violations.map((violation) => `boundary violation: ${violation}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ ok: true, checked: files.length }));

--- a/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
+++ b/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
@@ -49,12 +49,13 @@ const files = await walk(sourceRoot);
 
 for (const file of files) {
   const relative = path.relative(root, file);
-  if (hasForbiddenUtilsSegment(file)) {
-    violations.push(`${relative}: forbidden utils namespace/path segment`);
-  }
 
   if (isAllowedInteropFile(file)) {
     continue;
+  }
+
+  if (hasForbiddenUtilsSegment(file)) {
+    violations.push(`${relative}: forbidden utils namespace/path segment`);
   }
 
   const text = await readFile(file, "utf8");

--- a/packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
+++ b/packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
@@ -1,0 +1,36 @@
+const mod = await import("../dist-cljs/index.js");
+
+const expected = [
+  "createEtaBelief",
+  "createBreathEpisode",
+  "createEtaMuState",
+  "selectPanelsFromContext",
+  "rankCheapMuCandidates",
+  "recommendBreath",
+  "createActionBatch",
+];
+
+for (const key of expected) {
+  if (typeof mod[key] !== "function") {
+    throw new Error(`missing CLJS ESM export: ${key}`);
+  }
+}
+
+const belief = mod.createEtaBelief({ urgency: 2, ambiguity: -1 });
+if (belief.urgency !== 1 || belief.ambiguity !== 0) {
+  throw new Error(`createEtaBelief smoke failed: ${JSON.stringify(belief)}`);
+}
+
+const batch = mod.createActionBatch({
+  repo: "open-hax/proxx",
+  trigger: "scheduler.tick",
+  target: "open-hax/proxx",
+  summary: "cheap reconcile loop found no action",
+  belief: mod.createEtaBelief(),
+});
+
+if (batch.kind !== "eta-mu-action-batch.v1") {
+  throw new Error(`createActionBatch smoke failed: ${JSON.stringify(batch)}`);
+}
+
+console.log(JSON.stringify({ ok: true, exports: expected, batchKind: batch.kind }));

--- a/packages/eta-mu-runtime/shadow-cljs.edn
+++ b/packages/eta-mu-runtime/shadow-cljs.edn
@@ -1,0 +1,27 @@
+{:source-paths ["src/cljs" "test/cljs"]
+ :dependencies [[metosin/malli "0.16.4"]]
+ :js-options {:js-provider :import}
+ :builds
+ {:runtime
+  {:target :esm
+   :runtime :node
+   :output-dir "dist-cljs"
+   :modules {:index {:exports {:createEtaBelief eta-mu.runtime.facade/create-eta-belief
+                                :createBreathEpisode eta-mu.runtime.facade/create-breath-episode
+                                :createEtaMuState eta-mu.runtime.facade/create-eta-mu-state
+                                :selectPanelsFromContext eta-mu.runtime.facade/select-panels-from-context
+                                :rankCheapMuCandidates eta-mu.runtime.facade/rank-cheap-mu-candidates
+                                :recommendBreath eta-mu.runtime.facade/recommend-breath
+                                :createActionBatch eta-mu.runtime.facade/create-action-batch}}}
+   :compiler-options {:output-feature-set :es-next
+                      :optimizations :simple
+                      :source-map true}}
+
+  :test
+  {:target :node-test
+   :output-to "target/cljs-test.cjs"
+   :ns-regexp "-test$"
+   :autorun false
+   :compiler-options {:output-feature-set :es-next
+                      :optimizations :none
+                      :source-map true}}}}

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/breath.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/breath.cljs
@@ -1,0 +1,26 @@
+(ns eta-mu.runtime.domain.breath
+  (:require [eta-mu.runtime.domain.planner :as planner]
+            [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.planning :as planning-law]))
+
+(defn recommend
+  "Recommend whether the current breath episode should commit."
+  ([context]
+   (recommend context nil))
+  ([context actions]
+   (let [context (law/validate! planning-law/eta-mu-planning-context-schema context "planning context")
+         actions (or actions (planner/rank-cheap-candidates context))
+         has-meaningful-movement (some #(not= :noop (:kind %)) actions)
+         recommendation (cond
+                          (:pending-commit context)
+                          {:should-commit true
+                           :reason "Episode is already marked pending commit."}
+
+                          (and (:quiet-window-detected context) has-meaningful-movement)
+                          {:should-commit true
+                           :reason "Quiet window detected after meaningful movement planning."}
+
+                          :else
+                          {:should-commit false
+                           :reason "Continue sensing; breath boundary has not been justified yet."})]
+     (law/validate! planning-law/breath-recommendation-schema recommendation "breath recommendation"))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/candidate.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/candidate.cljs
@@ -1,0 +1,34 @@
+(ns eta-mu.runtime.domain.candidate
+  (:require [eta-mu.runtime.law.candidate :as candidate-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(defn candidate-priority
+  "Return the baseline priority for a candidate kind."
+  [kind]
+  (case kind
+    :defer 1.0
+    :request-human-attention 0.95
+    :request-evidence 0.92
+    :comment 0.82
+    :summary 0.8
+    :noop 0.1
+    0.5))
+
+(defn candidate-score
+  "Return the sort score used by cheap-candidate ranking."
+  [candidate]
+  (+ (:confidence candidate) (candidate-priority (:kind candidate))))
+
+(defn create-candidate
+  "Create a candidate with the current eta-mu id format."
+  [context index candidate]
+  (law/validate! candidate-law/mu-candidate-schema
+                 (assoc candidate
+                        :id (str (:repo context)
+                                 ":"
+                                 (:trigger context)
+                                 ":"
+                                 (name (:kind candidate))
+                                 ":"
+                                 (inc index)))
+                 "mu candidate"))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/envelope.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/envelope.cljs
@@ -1,0 +1,22 @@
+(ns eta-mu.runtime.domain.envelope
+  (:require [eta-mu.runtime.domain.breath :as breath]
+            [eta-mu.runtime.domain.planner :as planner]
+            [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.planning :as planning-law]))
+
+(defn create-action-batch
+  "Create an auditable eta-mu action batch from a normalized planning context."
+  [context]
+  (let [context (law/validate! planning-law/eta-mu-planning-context-schema context "planning context")
+        actions (planner/rank-cheap-candidates context)
+        panels (planner/select-panels context)
+        recommendation (breath/recommend context actions)
+        batch {:kind "eta-mu-action-batch.v1"
+               :repo (:repo context)
+               :trigger (:trigger context)
+               :summary (:summary context)
+               :panels panels
+               :belief (:belief context)
+               :actions actions
+               :breath recommendation}]
+    (law/validate! planning-law/eta-mu-action-batch-schema batch "action batch")))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/planner.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/planner.cljs
@@ -1,0 +1,111 @@
+(ns eta-mu.runtime.domain.planner
+  (:require [clojure.string :as str]
+            [eta-mu.runtime.domain.candidate :as candidate]
+            [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.planning :as planning-law]))
+
+(defn- push-panel
+  [panels panel]
+  (if (some #{panel} panels)
+    panels
+    (conj panels panel)))
+
+(defn select-panels
+  "Select visible eta-mu panels from a normalized planning context."
+  [context]
+  (let [context (law/validate! planning-law/eta-mu-planning-context-schema context "planning context")
+        belief (:belief context)]
+    (cond-> [:field :movement]
+      (or (>= (:review-debt belief) 0.4)
+          (>= (:deploy-risk belief) 0.4)
+          (>= (:drift belief) 0.45)
+          (pos? (:unresolved-review-threads context))
+          (seq (:failing-checks context)))
+      (push-panel :truth)
+
+      (or (>= (:urgency belief) 0.6)
+          (>= (:drift belief) 0.55))
+      (push-panel :trajectory)
+
+      (or (>= (:ambiguity belief) 0.55)
+          (>= (:drift belief) 0.6))
+      (push-panel :memory)
+
+      (or (:quiet-window-detected context)
+          (:pending-commit context))
+      (push-panel :breath))))
+
+(defn- add-candidate
+  [candidates context candidate]
+  (conj candidates (candidate/create-candidate context (count candidates) candidate)))
+
+(defn rank-cheap-candidates
+  "Rank cheap eta-mu movement candidates for a normalized planning context."
+  [context]
+  (let [context (law/validate! planning-law/eta-mu-planning-context-schema context "planning context")
+        belief (:belief context)
+        candidates (cond-> []
+                     (seq (:failing-checks context))
+                     (add-candidate context
+                                    {:kind :comment
+                                     :target (:target context)
+                                     :reason (str "Checks failing: " (str/join ", " (:failing-checks context)))
+                                     :confidence (max 0.7 (:deploy-risk belief))
+                                     :cost-class :cheap
+                                     :reversibility :easy
+                                     :needs-proof false})
+
+                     (or (pos? (:unresolved-review-threads context))
+                         (>= (:review-debt belief) 0.4))
+                     (add-candidate context
+                                    {:kind :summary
+                                     :target (:target context)
+                                     :reason "Review debt should be surfaced before movement continues."
+                                     :confidence (max 0.72 (:review-debt belief))
+                                     :cost-class :cheap
+                                     :reversibility :easy
+                                     :needs-proof false})
+
+                     (>= (:ambiguity belief) 0.65)
+                     (add-candidate context
+                                    {:kind :request-evidence
+                                     :target (:target context)
+                                     :reason "Ambiguity is still too high to justify stronger movement."
+                                     :confidence (max 0.78 (:ambiguity belief))
+                                     :cost-class :cheap
+                                     :reversibility :easy
+                                     :needs-proof false})
+
+                     (or (:has-pending-human-attention context)
+                         (>= (:social-friction belief) 0.7))
+                     (add-candidate context
+                                    {:kind :request-human-attention
+                                     :target (:target context)
+                                     :reason "Social friction is high enough that explicit human attention is justified."
+                                     :confidence (max 0.76 (:social-friction belief))
+                                     :cost-class :cheap
+                                     :reversibility :easy
+                                     :needs-proof false})
+
+                     (>= (:deploy-risk belief) 0.75)
+                     (add-candidate context
+                                    {:kind :defer
+                                     :target (:target context)
+                                     :reason "Deploy risk is too high for forward motion right now."
+                                     :confidence (:deploy-risk belief)
+                                     :cost-class :cheap
+                                     :reversibility :easy
+                                     :needs-proof false}))
+        candidates (if (seq candidates)
+                     candidates
+                     [(candidate/create-candidate context 0
+                                                  {:kind :noop
+                                                   :target (:target context)
+                                                   :reason "No cheap movement is justified yet; continue sensing the field."
+                                                   :confidence 0.9
+                                                   :cost-class :cheap
+                                                   :reversibility :easy
+                                                   :needs-proof false})])]
+    (->> candidates
+         (sort-by candidate/candidate-score >)
+         vec)))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/state.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/state.cljs
@@ -1,0 +1,62 @@
+(ns eta-mu.runtime.domain.state
+  (:require [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.state :as state-law]))
+
+(defn clamp-unit
+  "Clamp a numeric value into the unit interval."
+  [value]
+  (-> value
+      (max 0)
+      (min 1)))
+
+(def default-eta-belief
+  {:urgency 0
+   :ambiguity 0.25
+   :social-friction 0
+   :deploy-risk 0
+   :review-debt 0
+   :drift 0
+   :crust 0
+   :bloom-need 0.25
+   :user-intent-confidence 0.5})
+
+(defn create-belief
+  "Create an eta-mu belief map from internal kebab-case overrides."
+  ([]
+   (create-belief {}))
+  ([overrides]
+   (let [belief (reduce-kv
+                  (fn [acc key default-value]
+                    (assoc acc key (clamp-unit (get overrides key default-value))))
+                  {}
+                  default-eta-belief)]
+     (law/validate! state-law/eta-belief-schema belief "belief"))))
+
+(defn create-breath-episode
+  "Create a breath episode. The caller owns time selection."
+  ([id now]
+   (create-breath-episode id now false 0))
+  ([id now pending-commit activity-scalar]
+   (law/validate! state-law/breath-episode-schema
+                  {:id id
+                   :opened-at now
+                   :last-activity-at now
+                   :activity-scalar (clamp-unit activity-scalar)
+                   :pending-commit (boolean pending-commit)}
+                  "breath episode")))
+
+(defn create-state
+  "Create an eta-mu runtime state. The caller must supply :now for dynamic time."
+  ([]
+   (create-state {:now "1970-01-01T00:00:00.000Z"}))
+  ([options]
+   (let [now (:now options)
+         state {:belief (create-belief (:belief options))
+                :panels (vec (or (:panels options) [:field :movement]))
+                :proposed-moves (vec (or (:proposed-moves options) []))
+                :current-episode (create-breath-episode
+                                   (or (:current-episode-id options) "episode:bootstrap")
+                                   now
+                                   (boolean (:pending-commit options))
+                                   (or (:activity-scalar options) 0))}]
+     (law/validate! state-law/eta-mu-state-schema state "state"))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
@@ -1,0 +1,96 @@
+(ns eta-mu.runtime.facade
+  (:require [eta-mu.runtime.domain.breath :as breath]
+            [eta-mu.runtime.domain.envelope :as envelope]
+            [eta-mu.runtime.domain.planner :as planner]
+            [eta-mu.runtime.domain.state :as state]
+            [eta-mu.runtime.shape.compat :as compat]))
+
+(defn- now-iso
+  []
+  (.toISOString (js/Date.)))
+
+(defn- js-map
+  [value]
+  (js->clj (or value #js {}) :keywordize-keys true))
+
+(defn- ->js
+  [value]
+  (clj->js value))
+
+(defn create-eta-belief
+  "JS facade for createEtaBelief."
+  ([]
+   (create-eta-belief nil))
+  ([overrides]
+   (-> overrides
+       js-map
+       compat/belief-from-external
+       state/create-belief
+       compat/belief->external
+       ->js)))
+
+(defn create-breath-episode
+  "JS facade for createBreathEpisode."
+  ([id]
+   (create-breath-episode id (now-iso) false 0))
+  ([id now]
+   (create-breath-episode id now false 0))
+  ([id now pending-commit activity-scalar]
+   (-> (state/create-breath-episode id now pending-commit (or activity-scalar 0))
+       compat/breath-episode->external
+       ->js)))
+
+(defn create-eta-mu-state
+  "JS facade for createEtaMuState."
+  ([]
+   (create-eta-mu-state nil))
+  ([options]
+   (let [options (cond-> (js-map options)
+                   (not (contains? (js-map options) :now))
+                   (assoc :now (now-iso)))]
+     (-> options
+         compat/state-options-from-external
+         state/create-state
+         compat/state->external
+         ->js))))
+
+(defn select-panels-from-context
+  "JS facade for selectPanelsFromContext."
+  [context]
+  (let [panels (-> context
+                   js-map
+                   compat/planning-context-from-external
+                   planner/select-panels)]
+    (->js (mapv compat/panel->external panels))))
+
+(defn rank-cheap-mu-candidates
+  "JS facade for rankCheapMuCandidates."
+  [context]
+  (let [candidates (-> context
+                       js-map
+                       compat/planning-context-from-external
+                       planner/rank-cheap-candidates)]
+    (->js (mapv compat/candidate->external candidates))))
+
+(defn recommend-breath
+  "JS facade for recommendBreath."
+  ([context]
+   (recommend-breath context nil))
+  ([context actions]
+   (let [context (-> context js-map compat/planning-context-from-external)
+         actions (when actions
+                   (mapv compat/candidate-from-external (js->clj actions :keywordize-keys true)))]
+     (-> context
+         (breath/recommend actions)
+         compat/breath-recommendation->external
+         ->js))))
+
+(defn create-action-batch
+  "JS facade for createActionBatch."
+  [context]
+  (-> context
+      js-map
+      compat/planning-context-from-external
+      envelope/create-action-batch
+      compat/action-batch->external
+      ->js))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/candidate.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/candidate.cljs
@@ -1,0 +1,13 @@
+(ns eta-mu.runtime.law.candidate
+  (:require [eta-mu.runtime.law.types :as types]))
+
+(def mu-candidate-schema
+  [:map
+   [:id [:string {:min 1}]]
+   [:kind types/mu-candidate-kind-schema]
+   [:target [:string {:min 1}]]
+   [:reason [:string {:min 1}]]
+   [:confidence types/unit-interval-schema]
+   [:cost-class types/cost-class-schema]
+   [:reversibility types/reversibility-schema]
+   [:needs-proof boolean?]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/core.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/core.cljs
@@ -1,0 +1,24 @@
+(ns eta-mu.runtime.law.core
+  (:require [malli.core :as m]
+            [malli.error :as me]))
+
+(defn valid?
+  "Return true when value satisfies schema."
+  [schema value]
+  (m/validate schema value))
+
+(defn explain
+  "Return a human-oriented explanation map for value against schema."
+  [schema value]
+  (some-> (m/explain schema value)
+          (me/humanize)))
+
+(defn validate!
+  "Return value when schema-valid, otherwise throw an ex-info with schema errors."
+  [schema value label]
+  (if (valid? schema value)
+    value
+    (throw (ex-info (str "Invalid eta-mu runtime " label)
+                    {:label label
+                     :errors (explain schema value)
+                     :value value}))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/planning.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/planning.cljs
@@ -1,0 +1,34 @@
+(ns eta-mu.runtime.law.planning
+  (:require [eta-mu.runtime.law.candidate :as candidate]
+            [eta-mu.runtime.law.state :as state]
+            [eta-mu.runtime.law.types :as types]))
+
+(def eta-mu-planning-context-schema
+  [:map
+   [:repo [:string {:min 1}]]
+   [:trigger [:string {:min 1}]]
+   [:target [:string {:min 1}]]
+   [:summary [:string {:min 1}]]
+   [:belief state/eta-belief-schema]
+   [:unresolved-review-threads [:int {:min 0}]]
+   [:failing-checks [:vector [:string {:min 1}]]]
+   [:has-pending-human-attention boolean?]
+   [:quiet-window-detected boolean?]
+   [:pending-commit boolean?]
+   [:now {:optional true} [:string {:min 1}]]])
+
+(def breath-recommendation-schema
+  [:map
+   [:should-commit boolean?]
+   [:reason [:string {:min 1}]]])
+
+(def eta-mu-action-batch-schema
+  [:map
+   [:kind [:= "eta-mu-action-batch.v1"]]
+   [:repo [:string {:min 1}]]
+   [:trigger [:string {:min 1}]]
+   [:summary [:string {:min 1}]]
+   [:panels [:vector types/panel-name-schema]]
+   [:belief state/eta-belief-schema]
+   [:actions [:vector candidate/mu-candidate-schema]]
+   [:breath breath-recommendation-schema]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/state.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/state.cljs
@@ -1,0 +1,30 @@
+(ns eta-mu.runtime.law.state
+  (:require [eta-mu.runtime.law.candidate :as candidate]
+            [eta-mu.runtime.law.types :as types]))
+
+(def eta-belief-schema
+  [:map
+   [:urgency types/unit-interval-schema]
+   [:ambiguity types/unit-interval-schema]
+   [:social-friction types/unit-interval-schema]
+   [:deploy-risk types/unit-interval-schema]
+   [:review-debt types/unit-interval-schema]
+   [:drift types/unit-interval-schema]
+   [:crust types/unit-interval-schema]
+   [:bloom-need types/unit-interval-schema]
+   [:user-intent-confidence types/unit-interval-schema]])
+
+(def breath-episode-schema
+  [:map
+   [:id [:string {:min 1}]]
+   [:opened-at [:string {:min 1}]]
+   [:last-activity-at [:string {:min 1}]]
+   [:activity-scalar types/unit-interval-schema]
+   [:pending-commit boolean?]])
+
+(def eta-mu-state-schema
+  [:map
+   [:belief eta-belief-schema]
+   [:panels [:vector types/panel-name-schema]]
+   [:proposed-moves [:vector candidate/mu-candidate-schema]]
+   [:current-episode breath-episode-schema]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/types.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/types.cljs
@@ -1,0 +1,27 @@
+(ns eta-mu.runtime.law.types)
+
+(def unit-interval-schema
+  [:and number? [:>= 0] [:<= 1]])
+
+(def panel-name-schema
+  [:enum :field :movement :truth :trajectory :breath :memory :cost])
+
+(def cost-class-schema
+  [:enum :cheap :medium :expensive])
+
+(def reversibility-schema
+  [:enum :easy :moderate :hard])
+
+(def mu-candidate-kind-schema
+  [:enum
+   :comment
+   :summary
+   :label
+   :issue
+   :patch-plan
+   :patch
+   :reroute
+   :defer
+   :request-evidence
+   :request-human-attention
+   :noop])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/compat.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/compat.cljs
@@ -1,0 +1,200 @@
+(ns eta-mu.runtime.shape.compat)
+
+(def belief-key->internal
+  {:urgency :urgency
+   :ambiguity :ambiguity
+   :socialFriction :social-friction
+   :social-friction :social-friction
+   :deployRisk :deploy-risk
+   :deploy-risk :deploy-risk
+   :reviewDebt :review-debt
+   :review-debt :review-debt
+   :drift :drift
+   :crust :crust
+   :bloomNeed :bloom-need
+   :bloom-need :bloom-need
+   :userIntentConfidence :user-intent-confidence
+   :user-intent-confidence :user-intent-confidence})
+
+(def belief-key->external
+  {:urgency :urgency
+   :ambiguity :ambiguity
+   :social-friction :socialFriction
+   :deploy-risk :deployRisk
+   :review-debt :reviewDebt
+   :drift :drift
+   :crust :crust
+   :bloom-need :bloomNeed
+   :user-intent-confidence :userIntentConfidence})
+
+(def candidate-key->internal
+  {:id :id
+   :kind :kind
+   :target :target
+   :reason :reason
+   :confidence :confidence
+   :costClass :cost-class
+   :cost-class :cost-class
+   :reversibility :reversibility
+   :needsProof :needs-proof
+   :needs-proof :needs-proof})
+
+(def candidate-key->external
+  {:id :id
+   :kind :kind
+   :target :target
+   :reason :reason
+   :confidence :confidence
+   :cost-class :costClass
+   :reversibility :reversibility
+   :needs-proof :needsProof})
+
+(defn- contains-any?
+  [m keys]
+  (boolean (some #(contains? m %) keys)))
+
+(defn- first-present
+  ([m keys]
+   (first-present m keys nil))
+  ([m keys default-value]
+   (if-let [key (first (filter #(contains? m %) keys))]
+     (get m key)
+     default-value)))
+
+(defn- maybe-keyword
+  [value]
+  (cond
+    (keyword? value) value
+    (string? value) (keyword value)
+    :else value))
+
+(defn- maybe-name
+  [value]
+  (cond
+    (keyword? value) (name value)
+    :else value))
+
+(defn belief-from-external
+  "Convert a JS-compatible belief map to the internal kebab-key shape."
+  [belief]
+  (reduce-kv
+   (fn [acc external-key internal-key]
+     (if (contains? belief external-key)
+       (assoc acc internal-key (get belief external-key))
+       acc))
+   {}
+   belief-key->internal))
+
+(defn belief->external
+  "Convert an internal belief map to the current public camelCase shape."
+  [belief]
+  (reduce-kv
+   (fn [acc internal-key external-key]
+     (assoc acc external-key (get belief internal-key)))
+   {}
+   belief-key->external))
+
+(defn panel-from-external
+  [panel]
+  (maybe-keyword panel))
+
+(defn panel->external
+  [panel]
+  (maybe-name panel))
+
+(defn candidate-from-external
+  "Convert a JS-compatible candidate map to the internal shape."
+  [candidate]
+  (reduce-kv
+   (fn [acc external-key internal-key]
+     (if (contains? candidate external-key)
+       (assoc acc internal-key
+              (if (#{:kind :cost-class :reversibility} internal-key)
+                (maybe-keyword (get candidate external-key))
+                (get candidate external-key)))
+       acc))
+   {}
+   candidate-key->internal))
+
+(defn candidate->external
+  "Convert an internal candidate map to the public camelCase shape."
+  [candidate]
+  (reduce-kv
+   (fn [acc internal-key external-key]
+     (let [value (get candidate internal-key)]
+       (assoc acc external-key
+              (if (#{:kind :cost-class :reversibility} internal-key)
+                (maybe-name value)
+                value))))
+   {}
+   candidate-key->external))
+
+(defn breath-episode->external
+  [episode]
+  {:id (:id episode)
+   :openedAt (:opened-at episode)
+   :lastActivityAt (:last-activity-at episode)
+   :activityScalar (:activity-scalar episode)
+   :pendingCommit (:pending-commit episode)})
+
+(defn state-options-from-external
+  [options]
+  (cond-> {:now (first-present options [:now])}
+    (contains-any? options [:belief])
+    (assoc :belief (belief-from-external (:belief options)))
+
+    (contains-any? options [:panels])
+    (assoc :panels (mapv panel-from-external (:panels options)))
+
+    (contains-any? options [:proposedMoves :proposed-moves])
+    (assoc :proposed-moves (mapv candidate-from-external
+                                  (first-present options [:proposedMoves :proposed-moves] [])))
+
+    (contains-any? options [:currentEpisodeId :current-episode-id])
+    (assoc :current-episode-id (first-present options [:currentEpisodeId :current-episode-id]))
+
+    (contains-any? options [:pendingCommit :pending-commit])
+    (assoc :pending-commit (first-present options [:pendingCommit :pending-commit]))
+
+    (contains-any? options [:activityScalar :activity-scalar])
+    (assoc :activity-scalar (first-present options [:activityScalar :activity-scalar]))))
+
+(defn state->external
+  [state]
+  {:belief (belief->external (:belief state))
+   :panels (mapv panel->external (:panels state))
+   :proposedMoves (mapv candidate->external (:proposed-moves state))
+   :currentEpisode (breath-episode->external (:current-episode state))})
+
+(defn planning-context-from-external
+  "Convert a JS-compatible planning context to the internal normalized shape."
+  [context]
+  (cond-> {:repo (:repo context)
+           :trigger (:trigger context)
+           :target (:target context)
+           :summary (:summary context)
+           :belief (when (contains? context :belief)
+                     (belief-from-external (:belief context)))
+           :unresolved-review-threads (first-present context [:unresolvedReviewThreads :unresolved-review-threads] 0)
+           :failing-checks (vec (first-present context [:failingChecks :failing-checks] []))
+           :has-pending-human-attention (boolean (first-present context [:hasPendingHumanAttention :has-pending-human-attention] false))
+           :quiet-window-detected (boolean (first-present context [:quietWindowDetected :quiet-window-detected] false))
+           :pending-commit (boolean (first-present context [:pendingCommit :pending-commit] false))}
+    (contains-any? context [:now])
+    (assoc :now (first-present context [:now]))))
+
+(defn breath-recommendation->external
+  [recommendation]
+  {:shouldCommit (:should-commit recommendation)
+   :reason (:reason recommendation)})
+
+(defn action-batch->external
+  [batch]
+  {:kind (:kind batch)
+   :repo (:repo batch)
+   :trigger (:trigger batch)
+   :summary (:summary batch)
+   :panels (mapv panel->external (:panels batch))
+   :belief (belief->external (:belief batch))
+   :actions (mapv candidate->external (:actions batch))
+   :breath (breath-recommendation->external (:breath batch))})

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/planner_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/planner_test.cljs
@@ -1,0 +1,53 @@
+(ns eta-mu.runtime.domain.planner-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.domain.envelope :as envelope]
+            [eta-mu.runtime.domain.planner :as planner]
+            [eta-mu.runtime.domain.state :as state]))
+
+(defn- context
+  [overrides]
+  (merge {:repo "open-hax/proxx"
+          :trigger "scheduler.tick"
+          :target "open-hax/proxx"
+          :summary "cheap reconcile loop"
+          :belief (state/create-belief)
+          :unresolved-review-threads 0
+          :failing-checks []
+          :has-pending-human-attention false
+          :quiet-window-detected false
+          :pending-commit false}
+         overrides))
+
+(deftest select-panels-pressure-test
+  (testing "select-panels surfaces truth, trajectory, memory, and breath under pressure"
+    (let [panels (planner/select-panels
+                  (context {:trigger "check.completed"
+                            :target "staging"
+                            :summary "staging gate changed"
+                            :belief (state/create-belief {:urgency 0.8
+                                                          :review-debt 0.7
+                                                          :drift 0.6})
+                            :unresolved-review-threads 2
+                            :quiet-window-detected true}))]
+      (is (= [:field :movement :truth :trajectory :memory :breath] panels)))))
+
+(deftest rank-cheap-candidates-ambiguity-test
+  (testing "rank-cheap-candidates asks for evidence before stronger movement when ambiguity is high"
+    (let [candidates (planner/rank-cheap-candidates
+                      (context {:trigger "pull_request_review_comment"
+                                :target "pr#42"
+                                :summary "state needs reconciliation"
+                                :belief (state/create-belief {:ambiguity 0.9
+                                                              :social-friction 0.8})
+                                :has-pending-human-attention true}))
+          kinds (set (map :kind candidates))]
+      (is (contains? kinds :request-evidence))
+      (is (contains? kinds :request-human-attention)))))
+
+(deftest create-action-batch-noop-test
+  (testing "create-action-batch emits a noop batch when no cheap movement is justified"
+    (let [batch (envelope/create-action-batch (context {:summary "cheap reconcile loop found no action"}))]
+      (is (= "eta-mu-action-batch.v1" (:kind batch)))
+      (is (= 1 (count (:actions batch))))
+      (is (= :noop (-> batch :actions first :kind)))
+      (is (false? (get-in batch [:breath :should-commit]))))))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/state_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/state_test.cljs
@@ -1,0 +1,18 @@
+(ns eta-mu.runtime.domain.state-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.domain.state :as state]))
+
+(deftest create-belief-clamps-unit-interval-test
+  (testing "create-belief clamps values into the unit interval"
+    (let [belief (state/create-belief {:urgency 2
+                                       :ambiguity -1})]
+      (is (= 1 (:urgency belief)))
+      (is (= 0 (:ambiguity belief)))
+      (is (= 0.5 (:user-intent-confidence belief))))))
+
+(deftest create-state-defaults-test
+  (testing "create-state preserves current runtime defaults when given explicit time"
+    (let [runtime-state (state/create-state {:now "2026-05-29T00:00:00.000Z"})]
+      (is (= [:field :movement] (:panels runtime-state)))
+      (is (= "episode:bootstrap" (get-in runtime-state [:current-episode :id])))
+      (is (= false (get-in runtime-state [:current-episode :pending-commit]))))))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
@@ -1,0 +1,58 @@
+(ns eta-mu.runtime.facade-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.facade :as facade]))
+
+(defn- ->clj
+  [value]
+  (js->clj value :keywordize-keys true))
+
+(def valid-context
+  #js {:repo "open-hax/proxx"
+       :trigger "scheduler.tick"
+       :target "open-hax/proxx"
+       :summary "cheap reconcile loop found no action"
+       :belief #js {:urgency 0
+                    :ambiguity 0.25
+                    :socialFriction 0
+                    :deployRisk 0
+                    :reviewDebt 0
+                    :drift 0
+                    :crust 0
+                    :bloomNeed 0.25
+                    :userIntentConfidence 0.5}})
+
+(deftest js-compat-roundtrip-test
+  (testing "facade preserves camelCase public keys while using internal kebab-case maps"
+    (let [belief (->clj (facade/create-eta-belief #js {:socialFriction 2
+                                                       :deployRisk -1
+                                                       :userIntentConfidence 0.8}))]
+      (is (= 1 (:socialFriction belief)))
+      (is (= 0 (:deployRisk belief)))
+      (is (= 0.8 (:userIntentConfidence belief)))
+      (is (not (contains? belief :social-friction))))))
+
+(deftest facade-action-batch-test
+  (testing "facade returns the current JS action batch shape"
+    (let [batch (->clj (facade/create-action-batch valid-context))]
+      (is (= "eta-mu-action-batch.v1" (:kind batch)))
+      (is (= ["field" "movement"] (:panels batch)))
+      (is (= "noop" (-> batch :actions first :kind)))
+      (is (= false (get-in batch [:breath :shouldCommit]))))))
+
+(deftest malformed-context-rejected-test
+  (testing "facade rejects malformed public planning context payloads"
+    (is (thrown? js/Error
+                 (facade/create-action-batch
+                  #js {:repo "open-hax/proxx"
+                       :trigger "scheduler.tick"
+                       :target "open-hax/proxx"
+                       :summary "bad context"
+                       :belief #js {:urgency 2
+                                    :ambiguity 0.25
+                                    :socialFriction 0
+                                    :deployRisk 0
+                                    :reviewDebt 0
+                                    :drift 0
+                                    :crust 0
+                                    :bloomNeed 0.25
+                                    :userIntentConfidence 0.5}})))))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,12 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      shadow-cljs:
+        specifier: ^3.3.5
+        version: 3.3.8
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,8 +280,8 @@ importers:
         version: 3.25.76
     devDependencies:
       shadow-cljs:
-        specifier: ^3.3.5
-        version: 3.3.8
+        specifier: ^3.4.11
+        version: 3.4.11
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -4405,6 +4405,11 @@ packages:
 
   shadow-cljs@3.3.8:
     resolution: {integrity: sha512-Z220CAdSyAwpyPCE6wC5YWp6ZGyclTpdF5Be/q1mYl3EQfQdA+ZOE7XNAKwYwsJg78xh4BnFqWeRd129oDAe9A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  shadow-cljs@3.4.11:
+    resolution: {integrity: sha512-996uqtadZItXdD80Vtoh9IoE8oUOKoXOXd48gOxkZWUAHcxgcBlcRqMmPYiy4A1QqvSUQkdNGpv9AIWOgLx9Vg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -9542,6 +9547,19 @@ snapshots:
       - utf-8-validate
 
   shadow-cljs@3.3.8:
+    dependencies:
+      buffer: 6.0.3
+      process: 0.11.10
+      readline-sync: 1.4.10
+      shadow-cljs-jar: 1.3.4
+      source-map-support: 0.5.21
+      which: 5.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  shadow-cljs@3.4.11:
     dependencies:
       buffer: 6.0.3
       process: 0.11.10


### PR DESCRIPTION
## Summary

- Add a package-local shadow-cljs spine for `packages/eta-mu-runtime`.
- Add CLJS domain/law/shape/facade namespaces for the first runtime parity surface.
- Add Node ESM smoke import and a strict CLJS boundary scanner.
- Keep public package `main`/`types`/`exports` pointed at existing TS `dist`.

## Kanban task

`eta-mu-cljs-rewrite-shadow-spine`

## Verification

- `pnpm install --filter @eta-mu/runtime --offline --frozen-lockfile`
- `pnpm --dir packages/eta-mu-runtime cljs:verify`
- `pnpm --dir packages/eta-mu-runtime test`
- `pnpm --dir packages/eta-mu-runtime typecheck`
- `pnpm --dir packages/eta-mu-runtime build`

## CodeRabbit

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ETA-MU runtime now available with public APIs for creating beliefs, managing runtime state, selecting planning panels, ranking candidates, and generating action batches.
  * Added runtime validation and boundary checks to enforce code integrity.

* **Chores**
  * Added build configuration, compilation scripts, smoke tests, and boundary verification.
  * Documentation and project tracking updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-hax/eta-mu/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->