### PR TITLE
fix(runtime): address shadow spine review feedback

### DIFF
--- a/kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md
@@ -21,7 +21,7 @@ Create the CLJS build spine that lets eta-mu migrate runtime slices behind stabl
 
 ## Scope
 
-- shadow-cljs build targets for runtime/server/test slices
+- shadow-cljs build targets for runtime/test slices
 - package scripts for compile, test, lint, and typecheck-equivalent gates
 - JS facade export strategy for existing Node/CLI consumers
 - CLJS namespace layout conventions copied from Knoxx style, not Knoxx product behavior

--- a/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
+++ b/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
@@ -62,6 +62,8 @@ for (const file of files) {
   const lines = text.split(/\r?\n/);
   lines.forEach((line, index) => {
     for (const token of disallowedTokens) {
+      // Intentional first-pass scanner: this flags mentions in comments/docstrings too.
+      // Prefer occasional false positives over silently allowing raw interop to leak.
       if (line.includes(token)) {
         violations.push(`${relative}:${index + 1}: raw interop token outside extern/facade: ${token}`);
       }

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/candidate.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/candidate.cljs
@@ -22,13 +22,14 @@
 (defn create-candidate
   "Create a candidate with the current eta-mu id format."
   [context index candidate]
-  (law/validate! candidate-law/mu-candidate-schema
-                 (assoc candidate
-                        :id (str (:repo context)
-                                 ":"
-                                 (:trigger context)
-                                 ":"
-                                 (name (:kind candidate))
-                                 ":"
-                                 (inc index)))
-                 "mu candidate"))
+  (let [kind-name (some-> (:kind candidate) name)]
+    (law/validate! candidate-law/mu-candidate-schema
+                   (assoc candidate
+                          :id (str (:repo context)
+                                   ":"
+                                   (:trigger context)
+                                   ":"
+                                   kind-name
+                                   ":"
+                                   (inc index)))
+                   "mu candidate")))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/envelope.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/envelope.cljs
@@ -11,7 +11,7 @@
         actions (planner/rank-cheap-candidates context)
         panels (planner/select-panels context)
         recommendation (breath/recommend context actions)
-        batch {:kind "eta-mu-action-batch.v1"
+        batch {:kind planning-law/action-batch-version
                :repo (:repo context)
                :trigger (:trigger context)
                :summary (:summary context)

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
@@ -45,8 +45,9 @@
   ([]
    (create-eta-mu-state nil))
   ([options]
-   (let [options (cond-> (js-map options)
-                   (not (contains? (js-map options) :now))
+   (let [options (js-map options)
+         options (cond-> options
+                   (not (contains? options :now))
                    (assoc :now (now-iso)))]
      (-> options
          compat/state-options-from-external

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/planning.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/planning.cljs
@@ -3,6 +3,8 @@
             [eta-mu.runtime.law.state :as state]
             [eta-mu.runtime.law.types :as types]))
 
+(def action-batch-version "eta-mu-action-batch.v1")
+
 (def eta-mu-planning-context-schema
   [:map
    [:repo [:string {:min 1}]]
@@ -24,7 +26,7 @@
 
 (def eta-mu-action-batch-schema
   [:map
-   [:kind [:= "eta-mu-action-batch.v1"]]
+   [:kind [:= action-batch-version]]
    [:repo [:string {:min 1}]]
    [:trigger [:string {:min 1}]]
    [:summary [:string {:min 1}]]

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/planner_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/planner_test.cljs
@@ -1,5 +1,6 @@
 (ns eta-mu.runtime.domain.planner-test
   (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.domain.breath :as breath]
             [eta-mu.runtime.domain.envelope :as envelope]
             [eta-mu.runtime.domain.planner :as planner]
             [eta-mu.runtime.domain.state :as state]))
@@ -51,3 +52,20 @@
       (is (= 1 (count (:actions batch))))
       (is (= :noop (-> batch :actions first :kind)))
       (is (false? (get-in batch [:breath :should-commit]))))))
+
+(deftest recommend-breath-pending-commit-test
+  (testing "recommend commits immediately when an episode is already pending commit"
+    (let [recommendation (breath/recommend (context {:pending-commit true}))]
+      (is (true? (:should-commit recommendation)))
+      (is (= "Episode is already marked pending commit." (:reason recommendation))))))
+
+(deftest recommend-breath-quiet-window-test
+  (testing "recommend commits during a quiet window after meaningful movement"
+    (let [ctx (context {:quiet-window-detected true
+                        :failing-checks ["unit-tests"]
+                        :belief (state/create-belief {:deploy-risk 0.8})})
+          actions (planner/rank-cheap-candidates ctx)
+          recommendation (breath/recommend ctx actions)]
+      (is (some #(not= :noop (:kind %)) actions))
+      (is (true? (:should-commit recommendation)))
+      (is (= "Quiet window detected after meaningful movement planning." (:reason recommendation))))))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
@@ -41,6 +41,8 @@
 
 (deftest malformed-context-rejected-test
   (testing "facade rejects malformed public planning context payloads"
+    ;; create-eta-belief is a permissive constructor that clamps belief scores;
+    ;; create-action-batch is a strict public boundary and rejects malformed contexts.
     (is (thrown? js/Error
                  (facade/create-action-batch
                   #js {:repo "open-hax/proxx"


### PR DESCRIPTION
## Summary

- Address remaining shadow-spine review feedback after #27 was merged.
- Bind JS option parsing once, avoid pre-validation NPEs, and centralize the action-batch discriminator.
- Clarify scanner/test/task documentation and add breath recommendation coverage.

## Context

PR #27 was merged to `main` before all review feedback was fully carried forward. PR #29 was closed as a duplicate/conflicting branch after #27 landed. This follow-up is the minimal main-based cleanup for the already-merged shadow-spine task.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm --dir packages/eta-mu-runtime cljs:verify`
- `pnpm --dir packages/eta-mu-runtime test`
- `pnpm --dir packages/eta-mu-runtime typecheck`
- `pnpm --dir packages/eta-mu-runtime build`
- `pnpm --dir packages/presence-core test`
- `pnpm -C packages/eta-mu-extensions build`
- `git diff --check`

## Review

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLJS rewrite task scope with revised build target specifications.

* **Tests**
  * Expanded test coverage with additional batch recommendation scenarios.

* **Refactor**
  * Optimized internal code paths to reduce redundant operations and improve code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-hax/eta-mu/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->