### PR TITLE
docs(runtime): add CLJS rewrite architecture inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@
 - Root: `AGENTS.md` (this file) links operational conventions and connects all docs.
 - Workspace docs: [Workspace AGENTS](../../AGENTS.md) ↔ [Repository Index](../../REPOSITORY_INDEX.md) ↔ [CROSS_REFERENCES.md](./CROSS_REFERENCES.md).
 - Backend/agentd: [spec/agentd-tests.md](./spec/agentd-tests.md) → vitest harness/tests; [spec/run-readiness.md](./spec/run-readiness.md) → install/run checklist; [spec/pm2-ecosystem.md](./spec/pm2-ecosystem.md) → PM2 setup.
+- CLJS runtime rewrite: [kanban/epics/eta-mu-cljs-runtime-rewrite.md](./kanban/epics/eta-mu-cljs-runtime-rewrite.md) ↔ [docs/cljs-runtime-rewrite-architecture-inventory.md](./docs/cljs-runtime-rewrite-architecture-inventory.md) ↔ [docs/cljs-runtime-rewrite-shadow-spine-plan.md](./docs/cljs-runtime-rewrite-shadow-spine-plan.md).
 - Frontend/opencode-reactant: [packages/opencode-reactant/README.md](./packages/opencode-reactant/README.md) ↔ [DEVELOPMENT.md](./packages/opencode-reactant/DEVELOPMENT.md) ↔ [CROSS_REFERENCES.md](./packages/opencode-reactant/CROSS_REFERENCES.md).
 - Notes: [docs/notes/*](./docs/notes/) hold dated investigations; treat as append-only references.
 - Memories: [.serena/memories/*.md](./.serena/memories/) capture conventions, error-handling plans, and suggested commands.

--- a/docs/cljs-runtime-rewrite-architecture-inventory.md
+++ b/docs/cljs-runtime-rewrite-architecture-inventory.md
@@ -3,6 +3,7 @@
 Date: 2026-05-29
 Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
 Kanban task: `kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md`
+Knowledge graph anchor: `AGENTS.md` → `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
 Reference style: `orgs/open-hax/openplanner/packages/agents/knoxx/AGENTS.md`
 
 ## Purpose
@@ -125,7 +126,7 @@ Verification:
 pnpm --dir packages/eta-mu-runtime test
 pnpm --dir packages/eta-mu-runtime typecheck
 pnpm --dir packages/eta-mu-runtime cljs:verify
-node -e "import('./packages/eta-mu-runtime/dist-cljs/runtime/eta_mu_runtime.js').then(m => console.log(Object.keys(m)))"
+pnpm --dir packages/eta-mu-runtime cljs:smoke
 ```
 
 ### Slice 2 — `packages/output-contract-gate` law/shape port

--- a/docs/cljs-runtime-rewrite-architecture-inventory.md
+++ b/docs/cljs-runtime-rewrite-architecture-inventory.md
@@ -1,0 +1,261 @@
+# Eta-mu CLJS Runtime Rewrite — Architecture Inventory
+
+Date: 2026-05-29
+Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+Kanban task: `kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md`
+Reference style: `orgs/open-hax/openplanner/packages/agents/knoxx/AGENTS.md`
+
+## Purpose
+
+This inventory turns “rewrite eta-mu in ClojureScript” into a path-scoped migration plan. It classifies existing eta-mu packages by public compatibility surface and target CLJS ownership category so implementation can proceed without a big-bang rewrite.
+
+The design target is Knoxx-style organization, not Knoxx product behavior:
+
+- `domain.*` for pure runtime decisions and lawful state transitions
+- `shape.*` for pure data morphisms and DTO compatibility
+- `law.*` for schemas, guards, validation, and evidence contracts
+- `extern.*` for raw JavaScript, Node, browser, SDK, provider, and host-object boundaries
+- `infra.*` for effect orchestration that consumes extern adapters and returns CLJS data
+- no new `utils` junk drawers
+- no raw JS interop outside named boundaries or tiny facade namespaces
+
+## Source count snapshot
+
+Source counts below exclude obvious build/output folders such as `node_modules`, `dist`, `target`, `.shadow-cljs`, `.build`, and `out`, and only count files under source-like roots such as `src`, `test`, `tests`, `lib`, `scripts`, `e2e`, `web`, and `externs`.
+
+| Path | Package | TS/JS | CLJ/CLJS/EDN | Source roots |
+|---|---|---:|---:|---|
+| `packages/agent` | `@open-hax/eta-mu-agent-core` | 10 | 0 | `src, test` |
+| `packages/ai` | `@open-hax/eta-mu-ai` | 115 | 0 | `scripts, src, test` |
+| `packages/coding-agent` | `@open-hax/eta-mu-cli` | 257 | 0 | `scripts, src, test` |
+| `packages/eta-mu-docs` | `@workspace/eta-mu-docs` | 1 | 0 | `tests` |
+| `packages/eta-mu-extensions` | `@open-hax/eta-mu-extensions` | 7 | 63 | `externs, lib, scripts, src` |
+| `packages/eta-mu-extensions-e2e` | `eta-mu-extensions-e2e` | 0 | 3 | `src` |
+| `packages/eta-mu-github` | `@open-hax/eta-mu-github` | 14 | 0 | `src, tests` |
+| `packages/eta-mu-runtime` | `@eta-mu/runtime` | 18 | 15 | `scripts, src, test, tests` |
+| `packages/eta-mu-truth` | `@workspace/eta-mu-truth` | 1 | 0 | `tests` |
+| `packages/kanban` | `@openhax/kanban-legacy` | 15 | 0 | `e2e, src, tests` |
+| `packages/mom` | `@mariozechner/pi-mom` | 19 | 0 | `scripts, src, test` |
+| `packages/opencode-reactant` | `@openhax/opencode-reactant` | 0 | 13 | `src, test` |
+| `packages/output-contract-gate` | `@open-hax/output-contract-gate` | 16 | 0 | `src` |
+| `packages/pods` | `@mariozechner/pi` | 9 | 0 | `src` |
+| `packages/presence-core` | `@eta-mu/presence-core` | 1 | 0 | `src` |
+| `packages/signal-contracts` | `@open-hax/signal-contracts` | 1 | 0 | `tests` |
+| `packages/signal-radar-core` | `@open-hax/signal-radar-core` | 1 | 0 | `tests` |
+| `packages/signal-source-utils` | `@open-hax/signal-source-utils` | 1 | 0 | `tests` |
+| `packages/signal-watchlists` | `@open-hax/signal-watchlists` | 1 | 0 | `tests` |
+| `packages/tui` | `@open-hax/eta-mu-tui` | 52 | 0 | `src, test` |
+| `packages/web-ui` | `@mariozechner/pi-web-ui` | 72 | 0 | `scripts, src` |
+| `services/agentd` | `@openhax/agentd` | 8 | 0 | `src, tests` |
+| `services/eta-mu-truth-workbench` | `@workspace/eta-mu-truth-workbench` | 9 | 0 | `src` |
+
+Inventory caveat: `packages/eta-mu-runtime` now contains the first CLJS shadow spine under `src/cljs` and `test/cljs`, while `packages/eta-mu-runtime/src` still contains `.js`, `.js.map`, and `.d.ts` siblings alongside `.ts` files. Runtime-core planning should decide whether those checked-in JS artifacts are intentional compatibility shims, stale generated files, or source artifacts that must be preserved during the facade phase.
+
+## Public compatibility surfaces
+
+| Path | Public surface | Rewrite role |
+|---|---|---|
+| `packages/coding-agent` | binaries `eta-mu`, `pi`; exports `.`, `./hooks`; main/types in `dist` | Primary CLI/runtime compatibility shell. Keep public API stable while routing small paths through CLJS exports. |
+| `packages/ai` | binary `pi-ai`; many provider exports including Anthropic, Bedrock, Google, OpenAI, Azure, Mistral, Cloudflare | Provider/model boundary. Split pure provider registry/message transforms from SDK/HTTP extern adapters. |
+| `packages/agent` | `dist/index.js` SDK-style runtime exports | Agent loop/session abstractions. Port pure loop decisions after `eta-mu-runtime`. |
+| `packages/eta-mu-runtime` | export `.`; state/envelope/planner modules | Best first pure CLJS parity slice. Small, central, low I/O. |
+| `packages/output-contract-gate` | binary `output-contract-gate`; export `.` | Best second law/shape slice. Central to OPMF/output contracts and has focused tests. |
+| `packages/eta-mu-extensions` | built-in OpenCode/pi extension manifests and generated JS glue | Already CLJS-heavy. Treat as boundary-cleanup and extern-adapter reference, not a fresh port. |
+| `packages/tui` | `@open-hax/eta-mu-tui` library | Presentation/runtime shell. Defer until CLI/runtime state contracts stabilize. |
+| `packages/web-ui` | `@open-hax/pi-web-ui`; export `.` and `./app.css` | Browser shell. Defer until message/session/tool shapes are stable. |
+| `packages/opencode-reactant` | CLJS browser app | Existing CLJS UI reference. It has raw browser interop that should inform browser `extern.*` rules. |
+| `packages/kanban` | binary `openhax-kanban`; multiple board/content/task exports | Keep as operational support unless rewrite scope expands to the board tool itself. |
+| `services/agentd` | dev/runtime service | Runtime service integration. Defer until CLJS CLI/server spine proves a stable Node import. |
+
+## Target ownership map
+
+| Source cluster | Target CLJS owner | Notes |
+|---|---|---|
+| `packages/eta-mu-runtime/src/envelope.ts` | `eta_mu.runtime.shape.envelope`, `eta_mu.runtime.law.envelope` | Pure data, schema, and compatibility transforms. |
+| `packages/eta-mu-runtime/src/state.ts` | `eta_mu.runtime.domain.state`, `eta_mu.runtime.law.state` | State transitions should be category/law explicit. |
+| `packages/eta-mu-runtime/src/planner.ts` | `eta_mu.runtime.domain.planner` | Pure planning decisions first; defer effect execution. |
+| `packages/output-contract-gate/src/*.ts` | `eta_mu.runtime.law.output_contract`, `eta_mu.runtime.shape.markdown`, `eta_mu.runtime.shape.edn` | Keep CLI I/O in `infra.cli`/`extern.fs`; schemas and validation stay pure. |
+| `packages/coding-agent/src/core/messages.ts` | `eta_mu.runtime.domain.message`, `eta_mu.runtime.shape.message`, `eta_mu.runtime.law.message` | First bridge into CLI session compatibility. Include text/image/audio content parts. |
+| `packages/coding-agent/src/core/agent-session*.ts` | `eta_mu.runtime.domain.session`, `eta_mu.runtime.infra.session` | Pure session decisions first; persistence and process boundaries later. |
+| `packages/coding-agent/src/core/model-*.ts` | `eta_mu.runtime.domain.model`, `eta_mu.runtime.law.model`, `eta_mu.runtime.infra.provider` | Keep provider registry data separate from SDK calls. |
+| `packages/coding-agent/src/utils/git.ts`, `exec.ts`, `child-process.ts`, FS/image helpers | `eta_mu.runtime.extern.git`, `eta_mu.runtime.extern.process`, `eta_mu.runtime.extern.fs`, `eta_mu.runtime.extern.image` | Raw host APIs must not enter domain/shape/law. |
+| `packages/ai/src/providers/**` | `eta_mu.runtime.extern.provider.*`, `eta_mu.runtime.infra.provider.*` | One named adapter per provider boundary; pure transforms move to shape/domain. |
+| `packages/eta-mu-extensions/src/eta_mu/extensions/**` | `eta_mu.runtime.extern.opencode`, `eta_mu.runtime.infra.tools.*`, `eta_mu.runtime.law.contract_runtime.*` | Existing CLJS code has useful behavior but raw JS interop must be fenced. |
+| `packages/tui/src/**` | `eta_mu.runtime.tui.*`, `eta_mu.runtime.extern.terminal` | Presentation layer should consume stable runtime maps. |
+| `packages/web-ui/src/**` and `packages/opencode-reactant/src/**` | `eta_mu.runtime.web.*`, `eta_mu.runtime.extern.browser.*` | Browser interop should be named and localized. |
+
+## Boundary hotspot snapshot
+
+Existing CLJS already contains raw JS interop. This is not wrong for current code, but the rewrite should classify it explicitly.
+
+Observed hotspots:
+
+- `packages/eta-mu-extensions/src/eta_mu/extensions/websearch_open_hax.cljs` uses `js/process.env`, `js/fetch`, `js/JSON`, `js/Promise`, `js/Buffer`, `#js`, `aget`.
+- `packages/eta-mu-extensions/src/eta_mu/extensions/opencode_global_instructions.cljs` uses filesystem/process/global state, `js/JSON`, `clj->js`, `js->clj`, `aget`, `aset`, `js/Array.from`.
+- `packages/eta-mu-extensions/src/eta_mu/contracts/core.cljs` uses MarkdownIt JS token objects through `js/Reflect`, `js/Array.from`, `aget`.
+- `packages/opencode-reactant/src/opencode/ui/core.cljs`, `github.cljs`, `files.cljs`, `router.cljs`, `state.cljs`, and `config.cljs` use browser globals, WebSocket, XMLHttpRequest, localStorage, history, JSON parsing, and environment/global config.
+
+Target handling:
+
+- Node and provider interop goes under named `eta_mu.runtime.extern.*` adapters.
+- Browser interop goes under named `eta_mu.runtime.extern.browser.*` adapters.
+- OpenCode/pi host interop goes under `eta_mu.runtime.extern.opencode` or more specific host-boundary adapters.
+- MarkdownIt token access gets an adapter or opaque-handle parser boundary before law/shape code consumes it.
+
+## First three parity slices
+
+### Slice 1 — `packages/eta-mu-runtime` pure CLJS ESM facade
+
+Why first:
+
+- Smallest central package with state/envelope/planner semantics.
+- Low I/O surface.
+- Good place to prove `shadow-cljs :esm` exports and Node import smoke tests.
+
+Target categories:
+
+- `eta_mu.runtime.domain.state`
+- `eta_mu.runtime.domain.planner`
+- `eta_mu.runtime.shape.envelope`
+- `eta_mu.runtime.law.envelope`
+
+Verification:
+
+```bash
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime cljs:verify
+node -e "import('./packages/eta-mu-runtime/dist-cljs/runtime/eta_mu_runtime.js').then(m => console.log(Object.keys(m)))"
+```
+
+### Slice 2 — `packages/output-contract-gate` law/shape port
+
+Why second:
+
+- Core to the OPMF/output-contract runtime already active in this workspace.
+- Naturally maps to `law.*` and `shape.*`.
+- Has focused tests around EDN, markdown, validation, and repair.
+
+Target categories:
+
+- `eta_mu.runtime.law.output_contract`
+- `eta_mu.runtime.shape.edn`
+- `eta_mu.runtime.shape.markdown`
+- `eta_mu.runtime.cli.output_contract_gate`
+- `eta_mu.runtime.extern.fs` for CLI file I/O only
+
+Verification:
+
+```bash
+pnpm --dir packages/output-contract-gate test
+pnpm --dir packages/output-contract-gate typecheck
+pnpm --dir packages/eta-mu-runtime cljs:verify
+```
+
+### Slice 3 — `packages/coding-agent` message/content/session core bridge
+
+Why third:
+
+- This starts replacing the actual `eta-mu`/`pi` runtime without touching every provider, TUI, and filesystem boundary at once.
+- Message/content/session shapes are the durable contract under CLI, TUI, web UI, provider adapters, and extension tools.
+- This is where text/image/audio content-part extensibility should become explicit.
+
+Target categories:
+
+- `eta_mu.runtime.domain.message`
+- `eta_mu.runtime.domain.session`
+- `eta_mu.runtime.shape.message`
+- `eta_mu.runtime.shape.content_part`
+- `eta_mu.runtime.law.message`
+- `eta_mu.runtime.law.session`
+
+Verification:
+
+```bash
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm --dir packages/eta-mu-runtime cljs:verify
+```
+
+## Later migration lanes
+
+### Provider/model lane
+
+Owner categories:
+
+- `domain.model`
+- `law.model`
+- `shape.provider_request`
+- `extern.provider.openai`
+- `extern.provider.anthropic`
+- `extern.provider.google`
+- `extern.provider.bedrock`
+- `extern.provider.proxx`
+
+Rule: provider SDK/native payloads never cross into domain/law; they are decoded to CLJS maps at the adapter edge.
+
+### CLI/runtime lane
+
+Owner categories:
+
+- `cli.args`
+- `cli.commands.*`
+- `infra.session`
+- `infra.tool_execution`
+- `extern.process`
+- `extern.fs`
+- `extern.git`
+
+Rule: the CLI can remain a JS wrapper until each command path has parity evidence.
+
+### Extension-tool lane
+
+Owner categories:
+
+- `infra.tools.apply_patch`
+- `infra.tools.receipt_river`
+- `infra.tools.session_mycology`
+- `infra.tools.graph_memory`
+- `infra.tools.websearch`
+- `law.contract_runtime`
+- `extern.opencode`
+- `extern.http`
+- `extern.fs`
+
+Rule: custom tools should remain plain maps with `:execute` functions; no OO builders.
+
+### TUI/web lane
+
+Owner categories:
+
+- `tui.components.*`
+- `tui.state`
+- `extern.terminal`
+- `web.state`
+- `web.components.*`
+- `extern.browser.*`
+
+Rule: UI layers consume stable runtime maps and should not define provider/session contract meaning.
+
+## Verification baseline for remaining implementation
+
+Run these before each parity slice and record current failures instead of treating historical failures as rewrite failures:
+
+```bash
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/output-contract-gate test
+pnpm --dir packages/output-contract-gate typecheck
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm -C packages/eta-mu-extensions test
+pnpm test
+```
+
+## Open decisions
+
+1. Public artifact strategy: whether npm packages should expose compiled CLJS directly or keep JS wrappers around compiled CLJS exports during transition.
+2. Generated artifacts: whether checked-in `.js`/`.d.ts` siblings in `packages/eta-mu-runtime/src` are intentionally source-compatible files.
+3. Boundary gate expansion: whether the first `packages/eta-mu-runtime` scanner should grow into a repo-wide Knoxx-style `boundary:check`.
+
+## Recommended next planning move
+
+Proceed to `eta-mu-cljs-rewrite-runtime-core` after human review of this inventory and the merged shadow-spine PRs. The least risky implementation choice remains to expand pure CLJS runtime data contracts inside `packages/eta-mu-runtime` before touching `packages/coding-agent` or provider SDK code.

--- a/kanban/epics/eta-mu-cljs-runtime-rewrite.md
+++ b/kanban/epics/eta-mu-cljs-runtime-rewrite.md
@@ -1,0 +1,190 @@
+---
+uuid: "eta-mu-cljs-runtime-rewrite"
+title: "Eta-mu CLJS Runtime Rewrite"
+status: accepted
+priority: P0
+labels: ["epics", "cljs", "rewrite", "knoxx-style", "55sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "user-request:2026-05-29"
+points: 55
+category: epics
+---
+
+# Eta-mu CLJS Runtime Rewrite
+
+> Source: user request, 2026-05-29
+> Reference style: `orgs/open-hax/openplanner/packages/agents/knoxx/`
+> Service board: `services/eta-mu/kanban/openhax.kanban.json` project `orgs-open-hax-eta-mu-kanban`
+> Board source: `orgs/open-hax/eta-mu/kanban/`
+> Points: 55
+
+## Purpose
+
+Rewrite `orgs/open-hax/eta-mu/` into a ClojureScript-first runtime while preserving the useful public surfaces of the current eta-mu/Pi-derived TypeScript packages.
+
+This is not a cosmetic port. The rewrite should use Knoxx as the organizational reference for how source is shaped, verified, and reasoned about:
+
+- categories describe lawful motion and state transitions
+- contracts decide admissibility, evidence, and boundary obligations
+- plain CLJS data is the default medium
+- raw JavaScript interop is isolated behind named `extern.*` adapters
+- zero warnings is treated as a contract, not polish
+
+## Rewrite thesis
+
+> Keep eta-mu's agent-runtime purpose. Replace the spine.
+
+Eta-mu currently contains a mixed TypeScript/CLJS workspace with thousands of TS/JS source files and a smaller set of CLJS extension/UI surfaces. The target is a CLJS-first runtime where TypeScript remains only as compatibility glue, generated output, or narrow boundary code until parity allows deletion.
+
+## Knoxx-derived organizational laws
+
+1. **Categories vs contracts**
+   - `domain.*` names the lawful moves and pure runtime decisions.
+   - `law.*` names schemas, guards, proofs, and admissibility checks.
+   - State transitions cannot be treated as complete unless their contract evidence is visible.
+
+2. **Four-layer namespace split**
+   - `domain.*`: pure agent/session/model/tool decisions; no I/O.
+   - `shape.*`: pure data morphisms and compatibility transforms.
+   - `law.*`: Malli schemas, validators, output-contract gates, and invariants; no I/O.
+   - `infra.*`: file system, git, process, HTTP, provider, PM2, and workspace effects.
+
+3. **Named extern boundary**
+   - Raw JS objects, Node APIs, SDK objects, `#js`, `aget`, `aset`, `js->clj`, `clj->js`, `Promise.all`, and provider-native payloads are born and decoded only in `extern.*` namespaces.
+   - Non-extern namespaces receive CLJS maps, vectors, scalars, or opaque handles.
+
+4. **Data-oriented tools**
+   - Tool definitions are maps: `{:name ... :description ... :parameters ... :execute fn}`.
+   - Composition happens by concatenating tool vectors in orchestration namespaces, not by OO builders.
+
+5. **Modern async and warning ratchet**
+   - Prefer `^:async` functions/tests plus `await` where supported by the active CLJS toolchain.
+   - Every migrated backend/runtime slice must compile, lint, and test with zero new warnings.
+
+6. **No junk drawers**
+   - No new `utils` namespaces.
+   - Every namespace declares the boundary or domain it owns in its name.
+
+## Target architecture map
+
+```text
+eta_mu.runtime.domain.*      pure message/session/model/tool decisions
+eta_mu.runtime.shape.*       compatibility morphisms and DTO transforms
+eta_mu.runtime.law.*         Malli schemas, output-contract gates, invariant checks
+eta_mu.runtime.extern.*      Node/OpenCode/Proxx/provider/FS/Git/PM2 adapters
+eta_mu.runtime.infra.*       effect orchestration using extern adapters
+eta_mu.runtime.cli.*         CLI command routing and JS facade exports
+eta_mu.runtime.tui.*         TUI state and presentation contracts
+eta_mu.runtime.web.*         browser/web UI contracts where needed
+```
+
+Existing package names and binaries should stay compatible until explicit cutover tasks prove a replacement is safe.
+
+## Non-goals
+
+- Do not big-bang delete the TypeScript runtime.
+- Do not rename or republish public packages as part of the first rewrite pass.
+- Do not copy Knoxx product/domain behavior into eta-mu; copy the organizational grammar.
+- Do not move raw JS interop into pure domain, shape, or law namespaces to get a port compiling faster.
+- Do not claim parity while relevant CLI, package, and CLJS test gates are red.
+
+## Phases
+
+### Phase 1 — Inventory and migration map
+
+- Catalog TS/JS/CLJS source by package and runtime responsibility.
+- Classify each source cluster into `domain`, `shape`, `law`, `infra`, `extern`, `cli`, `tui`, or `web`.
+- Identify public compatibility surfaces: binaries, package exports, provider adapters, custom tools, prompt/context protocols, session persistence, TUI/web entrypoints.
+- Produce a cutover risk ledger with blockers and historical tests that already fail.
+
+Child task: `kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md`
+Inventory output: `docs/cljs-runtime-rewrite-architecture-inventory.md`
+
+### Phase 2 — Shadow-CLJS spine and namespace gates
+
+- Define the CLJS build spine for runtime/test targets.
+- Add lint and boundary inventory gates before broad porting begins.
+- Establish `extern.*` adapter patterns and sample tests.
+- Keep JS facade exports stable for current Node consumers.
+
+Child task: `kanban/tasks/eta-mu-cljs-rewrite-shadow-spine.md`
+Planning output: `docs/cljs-runtime-rewrite-shadow-spine-plan.md`
+
+### Phase 3 — Port pure runtime core first
+
+- Port message/content-part/session/model/tool/output-contract logic into pure `domain`, `shape`, and `law` namespaces.
+- Prefer Malli schemas for boundary contracts.
+- Preserve audio/image/text content-part extensibility from the current eta-mu direction.
+- Add regression tests before replacing TS call sites.
+
+Child task: `kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md`
+Planning output: `docs/cljs-runtime-rewrite-runtime-core-plan.md`
+
+### Phase 4 — Boundary adapters and effect orchestration
+
+- Wrap Node filesystem, process execution, git, provider SDKs, OpenCode/Pi APIs, Proxx HTTP calls, web search, image render, graph memory, Chronos, and receipt/session tools in named `extern.*` adapters.
+- Keep `infra.*` orchestration CLJS-first and data-in/data-out.
+- Add conversion regression tests for every adapter used by migrated runtime paths.
+
+Child task: `kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md`
+Planning output: `docs/cljs-runtime-rewrite-boundary-adapter-plan.md`
+
+### Phase 5 — CLI, TUI, web, and extension parity
+
+- Route existing `eta-mu`/`pi` command surfaces through CLJS-backed implementations behind stable JS exports.
+- Preserve TUI/web behavior or explicitly mark gaps.
+- Keep eta-mu extension manifests consumable by OpenCode and pi harnesses.
+
+Child task: `kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md`
+
+### Phase 6 — Cutover ratchet and TypeScript retirement
+
+- Replace TS modules only after equivalent CLJS paths pass parity tests.
+- Remove obsolete TS in small path-scoped commits.
+- Update docs, package exports, and service runners after each proven cutover.
+
+Child task: `kanban/tasks/eta-mu-cljs-rewrite-cutover-ratchet.md`
+
+## Acceptance criteria
+
+- [ ] A package-by-package migration inventory exists and names every public compatibility surface.
+- [ ] A CLJS build/test spine exists for the runtime rewrite and can compile with zero new warnings.
+- [ ] Core runtime data contracts are represented in `law.*` schemas and called at boundaries.
+- [ ] Raw JS interop is isolated to named `extern.*` namespaces with conversion tests.
+- [ ] Existing eta-mu CLI/package tests keep passing or blockers are recorded explicitly with owners.
+- [ ] At least one end-to-end command path runs through the CLJS runtime while preserving the current command/API contract.
+- [ ] TypeScript retirement happens only by parity-proven, path-scoped slices.
+
+## Verification gates
+
+Use the narrowest relevant gate per slice, but do not report a slice done while its gate is red.
+
+```bash
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm -C packages/eta-mu-extensions test
+pnpm test
+```
+
+For new CLJS runtime targets, add and use shadow-cljs gates analogous to Knoxx:
+
+```bash
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime cljs:boundary
+pnpm --dir packages/eta-mu-runtime typecheck
+```
+
+## Reference points
+
+- `orgs/open-hax/openplanner/packages/agents/knoxx/AGENTS.md`
+- `orgs/open-hax/openplanner/packages/agents/knoxx/backend/shadow-cljs.edn`
+- `orgs/open-hax/openplanner/packages/agents/knoxx/docs/shadow-cljs-backend-rewrite.md`
+- `orgs/open-hax/openplanner/packages/agents/knoxx/docs/contract-oriented-backend-refactor.md`
+- `orgs/open-hax/eta-mu/AGENTS.md`
+- `orgs/open-hax/eta-mu/package.json`
+- `orgs/open-hax/eta-mu/shadow-cljs.edn`
+
+## Open questions
+
+- Which existing TS package is the least risky second parity slice: `packages/output-contract-gate`, `packages/agent`, or a command path inside `packages/coding-agent`?
+- Which public package names must remain frozen for npm compatibility versus only workspace-local compatibility?
+- How broad should the first `packages/eta-mu-runtime` CLJS boundary scanner become before repo-wide boundary enforcement?

--- a/kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md
@@ -1,0 +1,53 @@
+---
+uuid: "eta-mu-cljs-rewrite-architecture-inventory"
+title: "Eta-mu CLJS Rewrite — Architecture Inventory"
+status: review
+priority: "P0"
+labels: ["tasks", "cljs", "rewrite", "inventory", "5sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "kanban/epics/eta-mu-cljs-runtime-rewrite.md"
+points: 5
+category: "tasks"
+---
+# Eta-mu CLJS Rewrite — Architecture Inventory
+
+> Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+> Points: 5
+
+## Purpose
+
+Create the package-by-package map that makes the CLJS rewrite safe and path-scoped instead of a big-bang port.
+
+## Scope
+
+- `packages/**`
+- `services/**`
+- root `package.json`, `pnpm-workspace.yaml`, `deps.edn`, `shadow-cljs.edn`
+- existing CLJS packages such as `packages/eta-mu-extensions` and `packages/opencode-reactant`
+
+## Work items
+
+- [x] Count TS/JS/CLJS source by package and identify generated/dist folders to ignore.
+- [x] Catalog public compatibility surfaces: binaries, package exports, SDK exports, tool manifests, provider adapters, session storage, TUI/web entrypoints, and service runners.
+- [x] Classify each source cluster as `domain`, `shape`, `law`, `extern`, `infra`, `cli`, `tui`, or `web`.
+- [x] Record known red tests or warning baselines before rewrite work starts.
+- [x] Produce a migration map linked from the parent epic.
+
+## Acceptance criteria
+
+- [x] Inventory document exists in the eta-mu repo and links every package to a target CLJS ownership category.
+- [x] The first three parity slices are named with risk and verification gates.
+- [x] No code rewrite begins from this task except inventory scripts/docs.
+
+## Verification
+
+```bash
+find packages services -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \) | wc -l
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/presence-core test
+pnpm -C packages/eta-mu-extensions build
+```
+
+---
+Planning inventory drafted at docs/cljs-runtime-rewrite-architecture-inventory.md. It classifies package surfaces, target domain/shape/law/infra/extern ownership, boundary hotspots, and the first three parity slices: eta-mu-runtime, output-contract-gate, and coding-agent message/session core.
+---

--- a/kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md
@@ -42,7 +42,7 @@ Create the package-by-package map that makes the CLJS rewrite safe and path-scop
 ## Verification
 
 ```bash
-find packages services -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \) | wc -l
+find packages services \( -path '*/node_modules' -o -path '*/dist' -o -path '*/dist-cljs' -o -path '*/target' -o -path '*/.shadow-cljs' \) -prune -o -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \) -print | wc -l
 pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/presence-core test
 pnpm -C packages/eta-mu-extensions build

--- a/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
@@ -1,0 +1,51 @@
+---
+uuid: "eta-mu-cljs-rewrite-boundary-adapters"
+title: "Eta-mu CLJS Rewrite — Boundary Adapters"
+status: todo
+priority: P0
+labels: ["tasks", "cljs", "rewrite", "extern", "13sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "kanban/epics/eta-mu-cljs-runtime-rewrite.md"
+points: 13
+category: tasks
+---
+
+# Eta-mu CLJS Rewrite — Boundary Adapters
+
+> Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+> Planning output: `docs/cljs-runtime-rewrite-boundary-adapter-plan.md`
+> Points: 13
+
+## Purpose
+
+Create the named `extern.*` and `infra.*` boundary layers needed for CLJS runtime slices to touch the world without leaking raw JavaScript through the codebase.
+
+## Scope
+
+- Node filesystem/path/process adapters
+- git and workspace command adapters
+- provider/Proxx/OpenCode/Pi SDK adapters
+- custom eta-mu tools: apply_patch, receipt river, session mycology, contract runtime, graph memory, render image, web search, Chronos
+- JSON/EDN codecs and opaque handle rules
+
+## Work items
+
+- [ ] Define one named `extern.*` namespace per real boundary.
+- [ ] Keep adapter public APIs CLJS-first: maps, vectors, scalars, or opaque handles.
+- [ ] Move `js->clj`, `clj->js`, `#js`, `aget`, `aset`, `Promise.all`, Node globals, and SDK-native object access into extern adapters only.
+- [ ] Add conversion tests for each adapter that is used by migrated runtime code.
+- [ ] Add a boundary inventory/check script similar to Knoxx's `boundary:check` pattern.
+
+## Acceptance criteria
+
+- [ ] Boundary inventory runs and reports no disallowed raw JS interop outside `extern.*`/facade namespaces.
+- [ ] Each migrated effectful runtime path has an adapter-level test.
+- [ ] Infra orchestration namespaces remain data-in/data-out and do not own domain policy.
+
+## Verification
+
+```bash
+pnpm --dir packages/eta-mu-runtime cljs:boundary
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm -C packages/eta-mu-extensions test
+```

--- a/kanban/tasks/eta-mu-cljs-rewrite-cutover-ratchet.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-cutover-ratchet.md
@@ -1,0 +1,52 @@
+---
+uuid: "eta-mu-cljs-rewrite-cutover-ratchet"
+title: "Eta-mu CLJS Rewrite — Cutover Ratchet"
+status: todo
+priority: P1
+labels: ["tasks", "cljs", "rewrite", "cutover", "8sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "kanban/epics/eta-mu-cljs-runtime-rewrite.md"
+points: 8
+category: tasks
+---
+
+# Eta-mu CLJS Rewrite — Cutover Ratchet
+
+> Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+> Points: 8
+
+## Purpose
+
+Retire TypeScript/JavaScript runtime slices only after CLJS parity is proven, with no repo-wide destructive cleanup.
+
+## Scope
+
+- path-scoped replacement commits
+- package export updates
+- obsolete TS deletion after parity
+- docs and service runner updates
+- red-suite/blocker ledger maintenance
+
+## Work items
+
+- [ ] Define the cutover checklist every migrated slice must satisfy.
+- [ ] Require parity tests before deleting or bypassing TS modules.
+- [ ] Preserve package names, binary names, and service wiring until explicit compatibility evidence says otherwise.
+- [ ] Record blockers for historical failures instead of hiding them in broad rewrites.
+- [ ] Update kanban task status and comments after each verified slice.
+
+## Acceptance criteria
+
+- [ ] The first TS slice is deleted or demoted only after CLJS replacement tests pass.
+- [ ] Package exports and docs point at the CLJS-backed implementation for the migrated slice.
+- [ ] A rollback path exists for every cutover commit.
+- [ ] No unrelated workspace dirt is staged or committed as part of cutover work.
+
+## Verification
+
+```bash
+git diff --stat
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm test
+```

--- a/kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md
@@ -1,0 +1,53 @@
+---
+uuid: "eta-mu-cljs-rewrite-runtime-core"
+title: "Eta-mu CLJS Rewrite — Runtime Core Port"
+status: todo
+priority: P0
+labels: ["tasks", "cljs", "rewrite", "runtime", "13sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "kanban/epics/eta-mu-cljs-runtime-rewrite.md"
+points: 13
+category: tasks
+---
+
+# Eta-mu CLJS Rewrite — Runtime Core Port
+
+> Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+> Planning output: `docs/cljs-runtime-rewrite-runtime-core-plan.md`
+> Points: 13
+
+## Purpose
+
+Port the pure eta-mu runtime core into CLJS before migrating effectful command paths.
+
+## Scope
+
+- message and content-part domain data
+- session state and context construction
+- model/provider selection data, excluding provider SDK I/O
+- tool descriptor data and composition rules
+- output-contract and prompt-section law
+- receipt/session metadata shapes where pure
+
+## Work items
+
+- [ ] Define Malli schemas in `law.*` for public runtime data crossing package boundaries.
+- [ ] Implement pure `domain.*` decisions with no Node, provider SDK, FS, git, process, or HTTP access.
+- [ ] Implement `shape.*` transforms for existing TS/JS DTO compatibility.
+- [ ] Add regression tests against representative current eta-mu/Pi message and tool payloads.
+- [ ] Keep text/image/audio content-part extensibility explicit.
+
+## Acceptance criteria
+
+- [ ] Pure runtime core tests pass under the CLJS test target.
+- [ ] Current JS callers can round-trip representative runtime payloads through the CLJS facade.
+- [ ] Boundary schemas reject at least one malformed payload per major data type.
+- [ ] No raw JS interop appears outside allowed facade/extern namespaces.
+
+## Verification
+
+```bash
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --filter @open-hax/eta-mu-cli test
+```

--- a/kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md
@@ -1,0 +1,50 @@
+---
+uuid: "eta-mu-cljs-rewrite-surface-parity"
+title: "Eta-mu CLJS Rewrite — CLI/TUI/Web Surface Parity"
+status: todo
+priority: P1
+labels: ["tasks", "cljs", "rewrite", "parity", "8sp"]
+created_at: "2026-05-29T21:18:48Z"
+source: "kanban/epics/eta-mu-cljs-runtime-rewrite.md"
+points: 8
+category: tasks
+---
+
+# Eta-mu CLJS Rewrite — CLI/TUI/Web Surface Parity
+
+> Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+> Points: 8
+
+## Purpose
+
+Prove existing eta-mu user-facing surfaces can be served by CLJS-backed implementations without breaking current commands, packages, or UI entrypoints.
+
+## Scope
+
+- `eta-mu` and `pi` binary behavior
+- package export compatibility for runtime consumers
+- TUI rendering/state flows
+- web UI / opencode-reactant where affected
+- extension manifests consumed by OpenCode and pi harnesses
+
+## Work items
+
+- [ ] Select one thin end-to-end command path for first CLJS-backed parity.
+- [ ] Route that path through a compiled CLJS export while preserving its current CLI/API contract.
+- [ ] Add parity fixtures for command output, exit codes, and structured return values.
+- [ ] Document known gaps instead of silently changing behavior.
+- [ ] Keep TS compatibility wrappers small and path-scoped.
+
+## Acceptance criteria
+
+- [ ] At least one real command path runs through CLJS and passes existing CLI tests.
+- [ ] Existing package consumers can still import the same public symbols for the migrated path.
+- [ ] TUI/web behavior touched by the migrated path has smoke evidence or an explicit blocker.
+
+## Verification
+
+```bash
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm -C packages/opencode-reactant exec shadow-cljs compile app
+pnpm test
+```


### PR DESCRIPTION
## Summary

- Add the eta-mu CLJS runtime rewrite epic and remaining child task cards.
- Add the package-by-package architecture inventory and target ownership map.
- Reconcile the inventory with the already-merged `packages/eta-mu-runtime` shadow spine and current repo-root verification commands.

## Kanban task

`eta-mu-cljs-rewrite-architecture-inventory`

## Verification

- `pnpm install --offline --frozen-lockfile`
- `find packages services -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \\) | wc -l` => `1076`\n- `pnpm --dir packages/eta-mu-runtime cljs:verify`\n- `pnpm --dir packages/presence-core test`\n- `pnpm -C packages/eta-mu-extensions build`\n- `git diff --check`\n\n## Merge discipline\n\nPlease do not merge this PR until CodeRabbit has completed review/acceptance. The prior shadow-spine PRs were merged while CodeRabbit was rate-limited, and this branch is intended to restore the requested review loop.\n\n@coderabbitai review\n