### PR TITLE
docs(runtime): reconcile CLJS inventory after fork-tax merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@
 - Root: `AGENTS.md` (this file) links operational conventions and connects all docs.
 - Workspace docs: [Workspace AGENTS](../../AGENTS.md) ↔ [Repository Index](../../REPOSITORY_INDEX.md) ↔ [CROSS_REFERENCES.md](./CROSS_REFERENCES.md).
 - Backend/agentd: [spec/agentd-tests.md](./spec/agentd-tests.md) → vitest harness/tests; [spec/run-readiness.md](./spec/run-readiness.md) → install/run checklist; [spec/pm2-ecosystem.md](./spec/pm2-ecosystem.md) → PM2 setup.
+- CLJS runtime rewrite: [kanban/epics/eta-mu-cljs-runtime-rewrite.md](./kanban/epics/eta-mu-cljs-runtime-rewrite.md) ↔ [docs/cljs-runtime-rewrite-architecture-inventory.md](./docs/cljs-runtime-rewrite-architecture-inventory.md) ↔ [docs/cljs-runtime-rewrite-shadow-spine-plan.md](./docs/cljs-runtime-rewrite-shadow-spine-plan.md).
 - Frontend/opencode-reactant: [packages/opencode-reactant/README.md](./packages/opencode-reactant/README.md) ↔ [DEVELOPMENT.md](./packages/opencode-reactant/DEVELOPMENT.md) ↔ [CROSS_REFERENCES.md](./packages/opencode-reactant/CROSS_REFERENCES.md).
 - Notes: [docs/notes/*](./docs/notes/) hold dated investigations; treat as append-only references.
 - Memories: [.serena/memories/*.md](./.serena/memories/) capture conventions, error-handling plans, and suggested commands.

--- a/docs/cljs-runtime-rewrite-architecture-inventory.md
+++ b/docs/cljs-runtime-rewrite-architecture-inventory.md
@@ -3,6 +3,7 @@
 Date: 2026-05-29
 Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
 Kanban task: `kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md`
+Knowledge graph anchor: `AGENTS.md` → `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
 Reference style: `orgs/open-hax/openplanner/packages/agents/knoxx/AGENTS.md`
 
 ## Purpose
@@ -27,12 +28,12 @@ Source counts below exclude obvious build/output folders such as `node_modules`,
 |---|---|---:|---:|---|
 | `packages/agent` | `@open-hax/eta-mu-agent-core` | 10 | 0 | `src`, `test` |
 | `packages/ai` | `@open-hax/eta-mu-ai` | 115 | 0 | `scripts`, `src`, `test` |
-| `packages/coding-agent` | `@open-hax/eta-mu-cli` | 260 | 0 | `scripts`, `src`, `test` |
+| `packages/coding-agent` | `@open-hax/eta-mu-cli` | 258 | 0 | `scripts`, `src`, `test` |
 | `packages/eta-mu-docs` | `@open-hax/eta-mu-docs` | 1 | 0 | `tests` |
-| `packages/eta-mu-extensions` | `@open-hax/eta-mu-extensions` | 7 | 60 | `externs`, `lib`, `scripts`, `src` |
+| `packages/eta-mu-extensions` | `@open-hax/eta-mu-extensions` | 7 | 63 | `externs`, `lib`, `scripts`, `src` |
 | `packages/eta-mu-extensions-e2e` | `@open-hax/eta-mu-extensions-e2e` | 0 | 3 | `src` |
 | `packages/eta-mu-github` | `@open-hax/eta-mu-github` | 14 | 0 | `src`, `tests` |
-| `packages/eta-mu-runtime` | `@open-hax/eta-mu-runtime` | 16 | 0 | `src`, `tests` |
+| `packages/eta-mu-runtime` | `@open-hax/eta-mu-runtime` | 18 | 15 | `scripts`, `src`, `test`, `tests` |
 | `packages/eta-mu-truth` | `@open-hax/eta-mu-truth` | 1 | 0 | `tests` |
 | `packages/kanban` | `@open-hax/kanban-legacy` | 18 | 0 | `e2e`, `src`, `tests`, `web` |
 | `packages/mom` | `@open-hax/pi-mom` | 19 | 0 | `scripts`, `src`, `test` |
@@ -49,7 +50,7 @@ Source counts below exclude obvious build/output folders such as `node_modules`,
 | `services/agentd` | `@open-hax/agentd` | 8 | 0 | `src`, `tests` |
 | `services/eta-mu-truth-workbench` | `@open-hax/eta-mu-truth-workbench` | 9 | 0 | `src` |
 
-Inventory caveat: `packages/eta-mu-runtime/src` currently contains `.js`, `.js.map`, and `.d.ts` siblings alongside `.ts` files. First implementation planning should decide whether those are intentional source artifacts, stale generated files, or compatibility shims that must be preserved during the CLJS facade phase.
+Inventory caveat: `packages/eta-mu-runtime` now contains the first CLJS shadow spine under `src/cljs` and `test/cljs`, while `packages/eta-mu-runtime/src` still contains `.js`, `.js.map`, and `.d.ts` siblings alongside `.ts` files. Runtime-core planning should decide whether those checked-in JS artifacts are intentional compatibility shims, stale generated files, or source artifacts that must be preserved during the facade phase.
 
 ## Public compatibility surfaces
 
@@ -122,11 +123,10 @@ Target categories:
 Verification:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --dir packages/eta-mu-runtime test
 pnpm --dir packages/eta-mu-runtime typecheck
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
-node -e "import('<compiled-entry>').then(m => console.log(Object.keys(m)))"
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime cljs:smoke
 ```
 
 ### Slice 2 — `packages/output-contract-gate` law/shape port
@@ -148,10 +148,9 @@ Target categories:
 Verification:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --dir packages/output-contract-gate test
 pnpm --dir packages/output-contract-gate typecheck
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
+pnpm --dir packages/eta-mu-runtime cljs:verify
 ```
 
 ### Slice 3 — `packages/coding-agent` message/content/session core bridge
@@ -174,9 +173,8 @@ Target categories:
 Verification:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --filter @open-hax/eta-mu-cli test
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
+pnpm --dir packages/eta-mu-runtime cljs:verify
 ```
 
 ## Later migration lanes
@@ -239,12 +237,11 @@ Owner categories:
 
 Rule: UI layers consume stable runtime maps and should not define provider/session contract meaning.
 
-## Verification baseline to gather before implementation
+## Verification baseline for remaining implementation
 
-Run these before the first port PR/slice and record current failures instead of treating historical failures as rewrite failures:
+Run these before each parity slice and record current failures instead of treating historical failures as rewrite failures:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --dir packages/eta-mu-runtime test
 pnpm --dir packages/eta-mu-runtime typecheck
 pnpm --dir packages/output-contract-gate test
@@ -256,11 +253,10 @@ pnpm test
 
 ## Open decisions
 
-1. First CLJS home: either `packages/eta-mu-runtime-cljs` as a bridge package or a CLJS source subtree inside `packages/eta-mu-runtime`.
-2. Public artifact strategy: whether npm packages should expose compiled CLJS directly or keep JS wrappers around compiled CLJS exports during transition.
-3. Generated artifacts: whether checked-in `.js`/`.d.ts` siblings in `packages/eta-mu-runtime/src` are intentionally source-compatible files.
-4. Boundary gate: whether to port Knoxx's `boundary:check` pattern directly or write a smaller eta-mu-specific scanner first.
+1. Public artifact strategy: whether npm packages should expose compiled CLJS directly or keep JS wrappers around compiled CLJS exports during transition.
+2. Generated artifacts: whether checked-in `.js`/`.d.ts` siblings in `packages/eta-mu-runtime/src` are intentionally source-compatible files.
+3. Boundary gate expansion: whether the first `packages/eta-mu-runtime` scanner should grow into a repo-wide Knoxx-style `boundary:check`.
 
 ## Recommended next planning move
 
-Proceed to `eta-mu-cljs-rewrite-shadow-spine` after human review of this inventory. The least risky implementation choice is to prove a CLJS ESM export for `packages/eta-mu-runtime` before touching `packages/coding-agent` or provider SDK code.
+Proceed to `eta-mu-cljs-rewrite-runtime-core` after human review of this inventory and the merged shadow-spine PRs. The least risky implementation choice remains to expand pure CLJS runtime data contracts inside `packages/eta-mu-runtime` before touching `packages/coding-agent` or provider SDK code.

--- a/kanban/epics/eta-mu-cljs-runtime-rewrite.md
+++ b/kanban/epics/eta-mu-cljs-runtime-rewrite.md
@@ -102,7 +102,7 @@ Inventory output: `docs/cljs-runtime-rewrite-architecture-inventory.md`
 
 ### Phase 2 — Shadow-CLJS spine and namespace gates
 
-- Define the CLJS build spine for runtime/server/test targets.
+- Define the CLJS build spine for runtime/test targets.
 - Add lint and boundary inventory gates before broad porting begins.
 - Establish `extern.*` adapter patterns and sample tests.
 - Keep JS facade exports stable for current Node consumers.
@@ -160,7 +160,6 @@ Child task: `kanban/tasks/eta-mu-cljs-rewrite-cutover-ratchet.md`
 Use the narrowest relevant gate per slice, but do not report a slice done while its gate is red.
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --filter @open-hax/eta-mu-cli test
 pnpm -C packages/eta-mu-extensions test
 pnpm test
@@ -169,9 +168,9 @@ pnpm test
 For new CLJS runtime targets, add and use shadow-cljs gates analogous to Knoxx:
 
 ```bash
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile server
-pnpm -C <cljs-runtime-package> lint
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime cljs:boundary
+pnpm --dir packages/eta-mu-runtime typecheck
 ```
 
 ## Reference points
@@ -186,6 +185,6 @@ pnpm -C <cljs-runtime-package> lint
 
 ## Open questions
 
-- Should the first CLJS runtime home be a new package, a replacement inside `packages/coding-agent`, or a staged `packages/eta-mu-runtime-cljs` bridge?
-- Which existing TS package is the least risky first parity slice: `packages/eta-mu-runtime`, `packages/output-contract-gate`, `packages/agent`, or a command path inside `packages/coding-agent`?
+- Which existing TS package is the least risky second parity slice: `packages/output-contract-gate`, `packages/agent`, or a command path inside `packages/coding-agent`?
 - Which public package names must remain frozen for npm compatibility versus only workspace-local compatibility?
+- How broad should the first `packages/eta-mu-runtime` CLJS boundary scanner become before repo-wide boundary enforcement?

--- a/kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-architecture-inventory.md
@@ -20,31 +20,32 @@ Create the package-by-package map that makes the CLJS rewrite safe and path-scop
 
 ## Scope
 
-- `orgs/open-hax/eta-mu/packages/**`
-- `orgs/open-hax/eta-mu/services/**`
+- `packages/**`
+- `services/**`
 - root `package.json`, `pnpm-workspace.yaml`, `deps.edn`, `shadow-cljs.edn`
 - existing CLJS packages such as `packages/eta-mu-extensions` and `packages/opencode-reactant`
 
 ## Work items
 
-- [ ] Count TS/JS/CLJS source by package and identify generated/dist folders to ignore.
-- [ ] Catalog public compatibility surfaces: binaries, package exports, SDK exports, tool manifests, provider adapters, session storage, TUI/web entrypoints, and service runners.
-- [ ] Classify each source cluster as `domain`, `shape`, `law`, `extern`, `infra`, `cli`, `tui`, or `web`.
-- [ ] Record known red tests or warning baselines before rewrite work starts.
-- [ ] Produce a migration map linked from the parent epic.
+- [x] Count TS/JS/CLJS source by package and identify generated/dist folders to ignore.
+- [x] Catalog public compatibility surfaces: binaries, package exports, SDK exports, tool manifests, provider adapters, session storage, TUI/web entrypoints, and service runners.
+- [x] Classify each source cluster as `domain`, `shape`, `law`, `extern`, `infra`, `cli`, `tui`, or `web`.
+- [x] Record known red tests or warning baselines before rewrite work starts.
+- [x] Produce a migration map linked from the parent epic.
 
 ## Acceptance criteria
 
-- [ ] Inventory document exists in the eta-mu repo and links every package to a target CLJS ownership category.
-- [ ] The first three parity slices are named with risk and verification gates.
-- [ ] No code rewrite begins from this task except inventory scripts/docs.
+- [x] Inventory document exists in the eta-mu repo and links every package to a target CLJS ownership category.
+- [x] The first three parity slices are named with risk and verification gates.
+- [x] No code rewrite begins from this task except inventory scripts/docs.
 
 ## Verification
 
 ```bash
-cd orgs/open-hax/eta-mu
-find packages services -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \) | wc -l
-pnpm test
+find packages services \( -path '*/node_modules' -o -path '*/dist' -o -path '*/dist-cljs' -o -path '*/target' -o -path '*/.shadow-cljs' -o -path '*/.build' -o -path '*/out' \) -prune -o -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \) -print | wc -l
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/presence-core test
+pnpm -C packages/eta-mu-extensions build
 ```
 
 ---

--- a/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
@@ -45,8 +45,7 @@ Create the named `extern.*` and `infra.*` boundary layers needed for CLJS runtim
 ## Verification
 
 ```bash
-cd orgs/open-hax/eta-mu
-pnpm -C <cljs-runtime-package> boundary:check
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
+pnpm --dir packages/eta-mu-runtime cljs:boundary
+pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm -C packages/eta-mu-extensions test
 ```

--- a/kanban/tasks/eta-mu-cljs-rewrite-cutover-ratchet.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-cutover-ratchet.md
@@ -45,9 +45,8 @@ Retire TypeScript/JavaScript runtime slices only after CLJS parity is proven, wi
 ## Verification
 
 ```bash
-cd orgs/open-hax/eta-mu
 git diff --stat
 pnpm --filter @open-hax/eta-mu-cli test
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
+pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm test
 ```

--- a/kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md
@@ -47,8 +47,7 @@ Port the pure eta-mu runtime core into CLJS before migrating effectful command p
 ## Verification
 
 ```bash
-cd orgs/open-hax/eta-mu
-pnpm -C <cljs-runtime-package> exec shadow-cljs compile test
-pnpm -C <cljs-runtime-package> test
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
 pnpm --filter @open-hax/eta-mu-cli test
 ```

--- a/kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md
@@ -44,7 +44,6 @@ Prove existing eta-mu user-facing surfaces can be served by CLJS-backed implemen
 ## Verification
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --filter @open-hax/eta-mu-cli test
 pnpm -C packages/opencode-reactant exec shadow-cljs compile app
 pnpm test


### PR DESCRIPTION
## Summary

- Reconcile the CLJS rewrite inventory after the fork-tax branch merged the planning docs into `main`.
- Add the CLJS rewrite docs to the AGENTS knowledge graph and back-link the inventory doc.
- Update source counts/package names, remove stale `cd`/placeholder CLJS commands, include `*.cjs`, and align generated-dir pruning.

## Context

This replaces #31, which became duplicate/conflicting after #28 landed the architecture inventory files on `main`.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `find packages services \( -path '*/node_modules' -o -path '*/dist' -o -path '*/dist-cljs' -o -path '*/target' -o -path '*/.shadow-cljs' -o -path '*/.build' -o -path '*/out' \\) -prune -o -type f \\( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' -o -name '*.cjs' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' \\) -print | wc -l` => `1093`\n- `pnpm --dir packages/eta-mu-runtime cljs:verify`\n- `pnpm --dir packages/presence-core test`\n- `pnpm -C packages/eta-mu-extensions build`\n- `git diff --check`\n\n## Merge discipline\n\nPlease do not merge this PR until CodeRabbit has completed review/acceptance.\n\n@coderabbitai review\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined internal architecture documentation for CLJS runtime rewrite, including updated inventory snapshots and verification processes.
  * Clarified verification command sequences across planning and task documentation.
  * Updated scope definitions and acceptance criteria for runtime rewrite initiatives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-hax/eta-mu/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->