### PR TITLE
feat(runtime): add CLJS boundary adapters

### DIFF
--- a/docs/cljs-runtime-rewrite-boundary-adapter-plan.md
+++ b/docs/cljs-runtime-rewrite-boundary-adapter-plan.md
@@ -17,8 +17,9 @@ The goal is not to ban interop. The goal is to make every interop boundary named
 Raw host objects and JS interop may be born only in:
 
 - `eta_mu.runtime.extern.*`
-- tiny JS/CLJS facades whose only job is API compatibility
 - test doubles under `test/cljs/**` where explicitly allowed
+
+Tiny JS/CLJS facades must call named `extern.*` adapters for API compatibility conversion instead of owning raw interop directly.
 
 Disallowed in ordinary runtime namespaces:
 
@@ -106,8 +107,7 @@ Inputs:
 Allowed file patterns:
 
 - `src/cljs/**/extern/**/*.cljs`
-- `src/cljs/**/facade.cljs`
-- explicit allowlist comments for rare one-line facade conversions
+- explicit allowlist comments for rare one-line facade conversions, only after review
 
 Disallowed tokens:
 
@@ -258,7 +258,6 @@ Do not migrate all providers in one slice.
 For the first package:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --dir packages/eta-mu-runtime cljs:boundary
 pnpm --dir packages/eta-mu-runtime cljs:verify
 ```
@@ -266,7 +265,6 @@ pnpm --dir packages/eta-mu-runtime cljs:verify
 For later extension/tool slices:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm -C packages/eta-mu-extensions test
 pnpm -C packages/eta-mu-extensions build
 ```
@@ -274,19 +272,22 @@ pnpm -C packages/eta-mu-extensions build
 For coding-agent runtime slices:
 
 ```bash
-cd orgs/open-hax/eta-mu
 pnpm --filter @open-hax/eta-mu-cli test
 ```
 
 ## Acceptance checklist
 
-- [ ] Boundary scanner exists and is wired into CLJS verification.
-- [ ] Raw interop in new runtime CLJS appears only in `extern.*` or facade namespaces.
-- [ ] Each added adapter has at least one conversion/regression test.
-- [ ] Adapter public APIs use CLJS maps/vectors/scalars or opaque handles.
-- [ ] Domain/law/shape namespaces do not import provider SDKs, Node modules, browser globals, or OpenCode/pi host objects.
-- [ ] No new `utils` namespace is introduced.
+- [x] Boundary scanner exists and is wired into CLJS verification.
+- [x] Raw interop in new runtime CLJS appears only in `extern.*` namespaces.
+- [x] Each added adapter has at least one conversion/regression test.
+- [x] Adapter public APIs use CLJS maps/vectors/scalars or opaque handles.
+- [x] Domain/law/shape namespaces do not import provider SDKs, Node modules, browser globals, or OpenCode/pi host objects.
+- [x] No new `utils` namespace is introduced.
+
+## Implementation note
+
+The boundary-adapter PR moved facade JS conversion and timestamp defaults through `eta-mu.runtime.extern.js` and `eta-mu.runtime.extern.time`, added JSON/HTTP/process adapters, and added `eta-mu.runtime.infra.boundary` inventory data. The scanner now treats `extern.*` as the only raw-interop allow zone; facade code must call named adapters.
 
 ## Recommended next planning handoff
 
-Use this plan during the shadow-spine implementation to add the scanner early. The scanner should start strict and local to `packages/eta-mu-runtime`; broaden it only as new CLJS packages join the rewrite.
+Use this plan during the next surface-parity implementation to broaden adapter coverage only where a migrated runtime path actually touches the world. Keep the scanner strict and local to `packages/eta-mu-runtime` until additional CLJS packages join the rewrite.

--- a/docs/cljs-runtime-rewrite-boundary-adapter-plan.md
+++ b/docs/cljs-runtime-rewrite-boundary-adapter-plan.md
@@ -107,7 +107,8 @@ Inputs:
 Allowed file patterns:
 
 - `src/cljs/**/extern/**/*.cljs`
-- explicit allowlist comments for rare one-line facade conversions, only after review
+
+Allowlist comments are not implemented; the current scanner enforces an extern-only raw-interop boundary.
 
 Disallowed tokens:
 

--- a/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
@@ -1,7 +1,7 @@
 ---
 uuid: "eta-mu-cljs-rewrite-boundary-adapters"
 title: "Eta-mu CLJS Rewrite — Boundary Adapters"
-status: todo
+status: review
 priority: P0
 labels: ["tasks", "cljs", "rewrite", "extern", "13sp"]
 created_at: "2026-05-29T21:18:48Z"
@@ -30,22 +30,30 @@ Create the named `extern.*` and `infra.*` boundary layers needed for CLJS runtim
 
 ## Work items
 
-- [ ] Define one named `extern.*` namespace per real boundary.
-- [ ] Keep adapter public APIs CLJS-first: maps, vectors, scalars, or opaque handles.
-- [ ] Move `js->clj`, `clj->js`, `#js`, `aget`, `aset`, `Promise.all`, Node globals, and SDK-native object access into extern adapters only.
-- [ ] Add conversion tests for each adapter that is used by migrated runtime code.
-- [ ] Add a boundary inventory/check script similar to Knoxx's `boundary:check` pattern.
+- [x] Define one named `extern.*` namespace per real boundary.
+- [x] Keep adapter public APIs CLJS-first: maps, vectors, scalars, or opaque handles.
+- [x] Move `js->clj`, `clj->js`, `#js`, `aget`, `aset`, `Promise.all`, Node globals, and SDK-native object access into extern adapters only.
+- [x] Add conversion tests for each adapter that is used by migrated runtime code.
+- [x] Add a boundary inventory/check script similar to Knoxx's `boundary:check` pattern.
 
 ## Acceptance criteria
 
-- [ ] Boundary inventory runs and reports no disallowed raw JS interop outside `extern.*`/facade namespaces.
-- [ ] Each migrated effectful runtime path has an adapter-level test.
-- [ ] Infra orchestration namespaces remain data-in/data-out and do not own domain policy.
+- [x] Boundary inventory runs and reports no disallowed raw JS interop outside `extern.*` namespaces.
+- [x] Each migrated effectful runtime path has an adapter-level test.
+- [x] Infra orchestration namespaces remain data-in/data-out and do not own domain policy.
 
 ## Verification
 
 ```bash
 pnpm --dir packages/eta-mu-runtime cljs:boundary
 pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime build
+pnpm test
 pnpm -C packages/eta-mu-extensions test
 ```
+
+## Notes
+
+Implemented the first runtime boundary adapter slice in `packages/eta-mu-runtime` with named `extern.*` adapters for JS value conversion, time/timestamps, JSON, HTTP request encoding, and process snapshots. Added `infra.boundary` inventory data for implemented and planned boundaries, moved facade JS conversion/time defaults through extern adapters, and tightened the boundary scanner so raw interop is allowed only under `extern.*`.

--- a/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
+++ b/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
@@ -22,7 +22,7 @@ const disallowedTokens = [
 
 function isAllowedInteropFile(filePath) {
   const normalized = filePath.split(path.sep).join("/");
-  return normalized.includes("/extern/") || normalized.endsWith("/facade.cljs");
+  return normalized.includes("/extern/");
 }
 
 function hasForbiddenUtilsSegment(filePath) {
@@ -47,15 +47,18 @@ async function walk(dir) {
 const violations = [];
 const files = await walk(sourceRoot);
 
+let externCount = 0;
+
 for (const file of files) {
   const relative = path.relative(root, file);
 
-  if (isAllowedInteropFile(file)) {
-    continue;
-  }
-
   if (hasForbiddenUtilsSegment(file)) {
     violations.push(`${relative}: forbidden utils namespace/path segment`);
+  }
+
+  if (isAllowedInteropFile(file)) {
+    externCount += 1;
+    continue;
   }
 
   const text = await readFile(file, "utf8");
@@ -65,7 +68,7 @@ for (const file of files) {
       // Intentional first-pass scanner: this flags mentions in comments/docstrings too.
       // Prefer occasional false positives over silently allowing raw interop to leak.
       if (line.includes(token)) {
-        violations.push(`${relative}:${index + 1}: raw interop token outside extern/facade: ${token}`);
+        violations.push(`${relative}:${index + 1}: raw interop token outside extern: ${token}`);
       }
     }
   });
@@ -76,4 +79,4 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
-console.log(JSON.stringify({ ok: true, checked: files.length }));
+console.log(JSON.stringify({ ok: true, checked: files.length, extern: externCount }));

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/http.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/http.cljs
@@ -1,0 +1,34 @@
+(ns eta-mu.runtime.extern.http
+  (:require [clojure.string :as str]
+            [eta-mu.runtime.extern.js :as extern-js]
+            [eta-mu.runtime.extern.json :as json]
+            [eta-mu.runtime.law.boundary :as boundary-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(defn- method-name
+  [method]
+  (-> (or method :get) name str/upper-case))
+
+(defn request->fetch-init
+  "Convert a CLJS HTTP request map into an opaque JS fetch init object.
+   The raw object must not leave extern/infra code except as an opaque handle."
+  [request]
+  (let [request (law/validate! boundary-law/http-request-schema request "http request")
+        headers (merge (when (:json request)
+                         {"content-type" "application/json"})
+                       (:headers request))
+        body (cond
+               (contains? request :json) (json/stringify (:json request))
+               (contains? request :body) (:body request)
+               :else nil)
+        init (cond-> {:method (method-name (:method request))
+                      :headers headers}
+               body (assoc :body body)
+               (:signal request) (assoc :signal (:signal request)))]
+    (extern-js/clj->value init)))
+
+(defn response-map
+  [status headers body]
+  {:status status
+   :headers headers
+   :body body})

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/js.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/js.cljs
@@ -1,0 +1,37 @@
+(ns eta-mu.runtime.extern.js)
+
+(defn value->clj
+  "Decode a JavaScript value into keywordized CLJS data at a named boundary."
+  [value]
+  (js->clj value :keywordize-keys true))
+
+(defn object->clj
+  "Decode a possibly nil JavaScript object into a keywordized CLJS map."
+  [value]
+  (js->clj (or value #js {}) :keywordize-keys true))
+
+(defn array->clj-vector
+  "Decode a possibly nil JavaScript array into a CLJS vector."
+  [value]
+  (vec (js->clj (or value #js []) :keywordize-keys true)))
+
+(defn clj->value
+  "Encode CLJS data as a JavaScript value at a named boundary."
+  [value]
+  (clj->js value))
+
+(defn success
+  [boundary value]
+  {:ok true
+   :boundary boundary
+   :value value})
+
+(defn error
+  ([boundary message]
+   (error boundary message nil nil))
+  ([boundary message code cause]
+   (cond-> {:ok false
+            :boundary boundary
+            :message message}
+     code (assoc :code code)
+     cause (assoc :cause cause))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/json.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/json.cljs
@@ -1,0 +1,13 @@
+(ns eta-mu.runtime.extern.json
+  (:require [eta-mu.runtime.extern.js :as extern-js]))
+
+(defn stringify
+  [value]
+  (js/JSON.stringify (extern-js/clj->value value)))
+
+(defn parse
+  [text]
+  (try
+    (extern-js/success :json (extern-js/value->clj (js/JSON.parse text)))
+    (catch js/Error error
+      (extern-js/error :json "Invalid JSON" (.-name error) (.-message error)))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/process.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/process.cljs
@@ -1,0 +1,39 @@
+(ns eta-mu.runtime.extern.process
+  (:require [eta-mu.runtime.extern.js :as extern-js]
+            [eta-mu.runtime.law.boundary :as boundary-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(defn- process-handle
+  []
+  (.-process js/globalThis))
+
+(defn argv
+  []
+  (if-let [process (process-handle)]
+    (extern-js/array->clj-vector (.-argv process))
+    []))
+
+(defn cwd
+  []
+  (if-let [process (process-handle)]
+    (if-let [cwd-fn (.-cwd process)]
+      (cwd-fn)
+      ".")
+    "."))
+
+(defn env
+  []
+  (if-let [process (process-handle)]
+    (->> (js/Object.entries (or (.-env process) #js {}))
+         array-seq
+         (map (fn [entry] [(aget entry 0) (aget entry 1)]))
+         (into {}))
+    {}))
+
+(defn snapshot
+  []
+  (law/validate! boundary-law/process-snapshot-schema
+                 {:argv (argv)
+                  :cwd (cwd)
+                  :env (env)}
+                 "process snapshot"))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/time.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/time.cljs
@@ -1,0 +1,29 @@
+(ns eta-mu.runtime.extern.time)
+
+(defn finite-number!
+  [value label]
+  (if (and (number? value) (js/Number.isFinite value))
+    value
+    (throw (ex-info (str "Invalid eta-mu runtime " label)
+                    {:label label
+                     :value value}))))
+
+(defn now-ms
+  []
+  (finite-number! (.getTime (js/Date.)) "timestamp"))
+
+(defn now-iso
+  []
+  (.toISOString (js/Date.)))
+
+(defn timestamp-ms
+  [value]
+  (cond
+    (number? value)
+    (finite-number! value "timestamp")
+
+    (string? value)
+    (finite-number! (.getTime (js/Date. value)) "timestamp")
+
+    :else
+    (now-ms)))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
@@ -7,6 +7,8 @@
             [eta-mu.runtime.domain.session :as session]
             [eta-mu.runtime.domain.state :as state]
             [eta-mu.runtime.domain.tool :as tool]
+            [eta-mu.runtime.extern.js :as host]
+            [eta-mu.runtime.extern.time :as extern-time]
             [eta-mu.runtime.shape.compat :as compat]
             [eta-mu.runtime.shape.message :as message-shape]
             [eta-mu.runtime.shape.model :as model-shape]
@@ -15,39 +17,23 @@
 
 (defn- now-iso
   []
-  (.toISOString (js/Date.)))
+  (extern-time/now-iso))
 
 (defn- js-value
   [value]
-  (js->clj value :keywordize-keys true))
+  (host/value->clj value))
 
 (defn- js-map
   [value]
-  (js->clj (or value #js {}) :keywordize-keys true))
-
-(defn- finite-number!
-  [value label]
-  (if (and (number? value) (js/Number.isFinite value))
-    value
-    (throw (ex-info (str "Invalid eta-mu runtime " label)
-                    {:label label
-                     :value value}))))
+  (host/object->clj value))
 
 (defn- timestamp-ms
   [value]
-  (cond
-    (number? value)
-    (finite-number! value "timestamp")
-
-    (string? value)
-    (finite-number! (.getTime (js/Date. value)) "timestamp")
-
-    :else
-    (finite-number! (.getTime (js/Date.)) "timestamp")))
+  (extern-time/timestamp-ms value))
 
 (defn- ->js
   [value]
-  (clj->js value))
+  (host/clj->value value))
 
 (defn create-eta-belief
   "JS facade for createEtaBelief."
@@ -112,7 +98,7 @@
   ([context actions]
    (let [context (-> context js-map compat/planning-context-from-external)
          actions (when actions
-                   (mapv compat/candidate-from-external (js->clj actions :keywordize-keys true)))]
+                   (mapv compat/candidate-from-external (host/value->clj actions)))]
      (-> context
          (breath/recommend actions)
          compat/breath-recommendation->external

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/infra/boundary.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/infra/boundary.cljs
@@ -1,0 +1,45 @@
+(ns eta-mu.runtime.infra.boundary
+  (:require [eta-mu.runtime.law.boundary :as boundary-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(def implemented-boundaries
+  [{:boundary :js
+    :namespace "eta-mu.runtime.extern.js"
+    :contract "JS value <-> CLJS data conversion"}
+   {:boundary :time
+    :namespace "eta-mu.runtime.extern.time"
+    :contract "timestamps and ISO clock values"}
+   {:boundary :json
+    :namespace "eta-mu.runtime.extern.json"
+    :contract "JSON string <-> CLJS data conversion"}
+   {:boundary :http
+    :namespace "eta-mu.runtime.extern.http"
+    :contract "HTTP request map <-> opaque fetch init"}
+   {:boundary :process
+    :namespace "eta-mu.runtime.extern.process"
+    :contract "argv/cwd/env snapshots as CLJS data"}])
+
+(def planned-boundaries
+  [{:boundary :fs
+    :namespace "eta-mu.runtime.extern.fs"}
+   {:boundary :path
+    :namespace "eta-mu.runtime.extern.path"}
+   {:boundary :process-exec
+    :namespace "eta-mu.runtime.extern.process-exec"}
+   {:boundary :git
+    :namespace "eta-mu.runtime.extern.git"}
+   {:boundary :opencode
+    :namespace "eta-mu.runtime.extern.opencode"}
+   {:boundary :pi-host
+    :namespace "eta-mu.runtime.extern.pi-host"}
+   {:boundary :provider-proxx
+    :namespace "eta-mu.runtime.extern.provider.proxx"}])
+
+(defn boundary-inventory
+  []
+  {:implemented implemented-boundaries
+   :planned planned-boundaries})
+
+(defn validate-result
+  [result]
+  (law/validate! boundary-law/normalized-result-schema result "boundary result"))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/infra/boundary.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/infra/boundary.cljs
@@ -33,7 +33,7 @@
    {:boundary :pi-host
     :namespace "eta-mu.runtime.extern.pi-host"}
    {:boundary :provider-proxx
-    :namespace "eta-mu.runtime.extern.provider.proxx"}])
+    :namespace "eta-mu.runtime.extern.provider-proxx"}])
 
 (defn boundary-inventory
   []

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/boundary.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/boundary.cljs
@@ -1,7 +1,20 @@
 (ns eta-mu.runtime.law.boundary)
 
 (def boundary-name-schema
-  [:enum :js :time :json :http :process :fs :path :process-exec :git :opencode :pi-host :provider-proxx])
+  ;; `proxx` is the project/provider name, not a typo for proxy.
+  [:enum
+   :js
+   :time
+   :json
+   :http
+   :process
+   :fs
+   :path
+   :process-exec
+   :git
+   :opencode
+   :pi-host
+   :provider-proxx])
 
 (def normalized-error-schema
   [:map

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/boundary.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/boundary.cljs
@@ -1,0 +1,39 @@
+(ns eta-mu.runtime.law.boundary)
+
+(def boundary-name-schema
+  [:enum :js :time :json :http :process :fs :path :process-exec :git :opencode :pi-host :provider-proxx])
+
+(def normalized-error-schema
+  [:map
+   [:ok [:= false]]
+   [:boundary boundary-name-schema]
+   [:message [:string {:min 1}]]
+   [:code {:optional true} [:string {:min 1}]]
+   [:cause {:optional true} any?]])
+
+(def normalized-success-schema
+  [:map
+   [:ok [:= true]]
+   [:boundary boundary-name-schema]
+   [:value any?]])
+
+(def normalized-result-schema
+  [:or normalized-success-schema normalized-error-schema])
+
+(def http-method-schema
+  [:enum :get :post :put :patch :delete :head :options])
+
+(def http-request-schema
+  [:map
+   [:url [:string {:min 1}]]
+   [:method {:optional true} http-method-schema]
+   [:headers {:optional true} map?]
+   [:body {:optional true} any?]
+   [:json {:optional true} any?]
+   [:signal {:optional true} any?]])
+
+(def process-snapshot-schema
+  [:map
+   [:argv [:vector string?]]
+   [:cwd [:string {:min 1}]]
+   [:env map?]])

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/extern/core_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/extern/core_test.cljs
@@ -1,0 +1,58 @@
+(ns eta-mu.runtime.extern.core-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.extern.http :as http]
+            [eta-mu.runtime.extern.js :as extern-js]
+            [eta-mu.runtime.extern.json :as json]
+            [eta-mu.runtime.extern.process :as process]
+            [eta-mu.runtime.extern.time :as time]
+            [eta-mu.runtime.infra.boundary :as boundary]))
+
+(deftest js-boundary-roundtrip-test
+  (testing "JS extern converts values at a named boundary"
+    (let [value (extern-js/value->clj #js {:alpha 1 :nested #js {:beta true}})
+          encoded (extern-js/clj->value {:items [1 2]})]
+      (is (= {:alpha 1 :nested {:beta true}} value))
+      (is (= [1 2] (extern-js/value->clj (.-items encoded)))))))
+
+(deftest time-boundary-test
+  (testing "time extern validates timestamps before domain code receives them"
+    (is (= 1780099200000 (time/timestamp-ms "2026-05-30T00:00:00.000Z")))
+    (is (number? (time/now-ms)))
+    (is (thrown? js/Error (time/timestamp-ms "not-a-date")))))
+
+(deftest json-boundary-test
+  (testing "json extern returns normalized parse results"
+    (let [encoded (json/stringify {:ok true :items [1 2]})
+          parsed (json/parse encoded)
+          invalid (json/parse "{not json")]
+      (is (:ok parsed))
+      (is (= {:ok true :items [1 2]} (:value parsed)))
+      (is (false? (:ok invalid)))
+      (is (= :json (:boundary invalid))))))
+
+(deftest http-boundary-test
+  (testing "http extern builds an opaque fetch init from a CLJS request map"
+    (let [init (http/request->fetch-init {:url "https://example.test/api"
+                                          :method :post
+                                          :headers {"authorization" "Bearer token"}
+                                          :json {:query "eta"}})
+          decoded (extern-js/value->clj init)]
+      (is (= "POST" (:method decoded)))
+      (is (= "application/json" (get-in decoded [:headers :content-type])))
+      (is (= "Bearer token" (get-in decoded [:headers :authorization])))
+      (is (= {:query "eta"} (:value (json/parse (:body decoded))))))))
+
+(deftest process-boundary-test
+  (testing "process extern exposes argv/cwd/env as validated CLJS data"
+    (let [snapshot (process/snapshot)]
+      (is (vector? (:argv snapshot)))
+      (is (string? (:cwd snapshot)))
+      (is (map? (:env snapshot))))))
+
+(deftest boundary-inventory-test
+  (testing "infra boundary inventory separates implemented from planned adapters"
+    (let [{:keys [implemented planned]} (boundary/boundary-inventory)]
+      (is (some #(= :js (:boundary %)) implemented))
+      (is (some #(= :http (:boundary %)) implemented))
+      (is (some #(= :git (:boundary %)) planned))
+      (is (boundary/validate-result (extern-js/success :json {:a 1}))))))


### PR DESCRIPTION
## Summary

- Add named CLJS `extern.*` adapters for JS value conversion, time/timestamps, JSON, HTTP request encoding, and process snapshots.
- Move runtime facade JS conversion/time defaults through those adapters so raw interop is confined to `extern.*`.
- Add `law.boundary` schemas, `infra.boundary` inventory data, adapter tests, and tighten the boundary scanner to allow raw interop only under `extern.*`.

## Kanban task

`eta-mu-cljs-rewrite-boundary-adapters`

## Verification

- `git merge --ff-only origin/main` before push: already up to date
- `pnpm install --offline --frozen-lockfile`
- `pnpm --dir packages/eta-mu-runtime cljs:verify`
  - 27 CLJS tests, 81 assertions, 0 failures/errors
  - runtime compile: 0 warnings
  - boundary scanner: 32 files checked, 5 extern files
- `pnpm --dir packages/eta-mu-runtime cljs:boundary`
- `pnpm --dir packages/eta-mu-runtime test`
- `pnpm --dir packages/eta-mu-runtime typecheck`
- `pnpm --dir packages/eta-mu-runtime build`
- `pnpm test`
- `pnpm -C packages/eta-mu-extensions test`
- `pnpm -C packages/eta-mu-extensions build`
- `git diff --check`

## Review

Branch is current with `origin/main` before opening so OpenCode/Kimi reviews against current main. CodeRabbit should run automatically on push/PR open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Established runtime boundary adapter infrastructure for managed JavaScript/ClojureScript interop across HTTP, time, JSON, and process operations
  * Added result validation schemas and boundary inventory tracking system

* **Tests**
  * Added comprehensive test suite validating boundary adapter functionality

* **Chores**
  * Strengthened boundary enforcement to restrict raw interop to designated paths only
  * Updated task documentation and acceptance criteria

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-hax/eta-mu/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->