### PR TITLE
feat(runtime): route version surface through CLJS

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: '21'
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: '21'
@@ -142,10 +142,11 @@ jobs:
             node -e "
               const s = JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json','utf8')).total;
               const fmt = (x) => (x.pct + '%').padStart(7);
-              console.log('Statements : ' + fmt(s.statements) + '  (' + s.covered + '/' + s.total + ')');
-              console.log('Branches   : ' + fmt(s.branches)   + '  (' + s.covered + '/' + s.total + ')');
-              console.log('Functions  : ' + fmt(s.functions)  + '  (' + s.covered + '/' + s.total + ')');
-              console.log('Lines      : ' + fmt(s.lines)      + '  (' + s.covered + '/' + s.total + ')');
+              const row = (label, metric) => console.log(label + fmt(metric) + '  (' + metric.covered + '/' + metric.total + ')');
+              row('Statements : ', s.statements);
+              row('Branches   : ', s.branches);
+              row('Functions  : ', s.functions);
+              row('Lines      : ', s.lines);
             "
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - uses: pnpm/action-setup@v4
         with:
           version: '10.14.0'
@@ -24,7 +29,7 @@ jobs:
 
       - name: Get pnpm store path
         id: pnpm-cache
-        run: echo "store=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "store=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         with:
@@ -88,7 +93,7 @@ jobs:
 
       - name: Get pnpm store path
         id: pnpm-cache
-        run: echo "store=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "store=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         with:
@@ -131,17 +136,19 @@ jobs:
         if: always()
         working-directory: packages/eta-mu-extensions
         run: |
-          echo '## CLJS Extension Coverage' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat coverage/coverage-summary.json | node -e "
-            const s = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).total;
-            const fmt = (x) => (x.pct + '%').padStart(7);
-            console.log('Statements : ' + fmt(s.statements) + '  (' + s.covered + '/' + s.total + ')');
-            console.log('Branches   : ' + fmt(s.branches)   + '  (' + s.covered + '/' + s.total + ')');
-            console.log('Functions  : ' + fmt(s.functions)  + '  (' + s.covered + '/' + s.total + ')');
-            console.log('Lines      : ' + fmt(s.lines)      + '  (' + s.covered + '/' + s.total + ')');
-          " >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo '## CLJS Extension Coverage'
+            echo '```'
+            node -e "
+              const s = JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json','utf8')).total;
+              const fmt = (x) => (x.pct + '%').padStart(7);
+              console.log('Statements : ' + fmt(s.statements) + '  (' + s.covered + '/' + s.total + ')');
+              console.log('Branches   : ' + fmt(s.branches)   + '  (' + s.covered + '/' + s.total + ')');
+              console.log('Functions  : ' + fmt(s.functions)  + '  (' + s.covered + '/' + s.total + ')');
+              console.log('Lines      : ' + fmt(s.lines)      + '  (' + s.covered + '/' + s.total + ')');
+            "
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage report
         if: always()

--- a/kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-surface-parity.md
@@ -1,7 +1,7 @@
 ---
 uuid: "eta-mu-cljs-rewrite-surface-parity"
 title: "Eta-mu CLJS Rewrite — CLI/TUI/Web Surface Parity"
-status: todo
+status: review
 priority: P1
 labels: ["tasks", "cljs", "rewrite", "parity", "8sp"]
 created_at: "2026-05-29T21:18:48Z"
@@ -29,22 +29,44 @@ Prove existing eta-mu user-facing surfaces can be served by CLJS-backed implemen
 
 ## Work items
 
-- [ ] Select one thin end-to-end command path for first CLJS-backed parity.
-- [ ] Route that path through a compiled CLJS export while preserving its current CLI/API contract.
-- [ ] Add parity fixtures for command output, exit codes, and structured return values.
-- [ ] Document known gaps instead of silently changing behavior.
-- [ ] Keep TS compatibility wrappers small and path-scoped.
+- [x] Select one thin end-to-end command path for first CLJS-backed parity.
+- [x] Route that path through a compiled CLJS export while preserving its current CLI/API contract.
+- [x] Add parity fixtures for command output, exit codes, and structured return values.
+- [x] Document known gaps instead of silently changing behavior.
+- [x] Keep TS compatibility wrappers small and path-scoped.
 
 ## Acceptance criteria
 
-- [ ] At least one real command path runs through CLJS and passes existing CLI tests.
-- [ ] Existing package consumers can still import the same public symbols for the migrated path.
-- [ ] TUI/web behavior touched by the migrated path has smoke evidence or an explicit blocker.
+- [x] At least one real command path runs through CLJS and passes existing CLI tests.
+- [x] Existing package consumers can still import the same public symbols for the migrated path.
+- [x] TUI/web behavior touched by the migrated path has smoke evidence or an explicit blocker.
 
 ## Verification
 
 ```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime build
+pnpm --dir packages/ai build
+pnpm --dir packages/agent build
+pnpm --dir packages/tui build
+pnpm --dir packages/kanban build
+pnpm --dir packages/coding-agent build
+ETA_MU_NO_DEFAULT_EXTENSIONS=1 node packages/coding-agent/dist/cli.js --version
+pnpm --dir packages/coding-agent exec vitest run test/version-command-cljs-parity.test.ts
 pnpm --filter @open-hax/eta-mu-cli test
 pnpm -C packages/opencode-reactant exec shadow-cljs compile app
 pnpm test
+pnpm -C packages/eta-mu-extensions test
+pnpm -C packages/eta-mu-extensions build
 ```
+
+## Notes
+
+Selected the existing `eta-mu`/`pi --version` path as the first thin surface-parity slice. The command now routes through the compiled CLJS ESM export `createSurfaceCommandResult` from the additive `@open-hax/eta-mu-runtime/cljs` subpath while preserving the CLI output (`0.70.15`) and exit code (`0`). The default `@open-hax/eta-mu-runtime` TypeScript entrypoint remains unchanged.
+
+TUI/web smoke evidence: `pnpm -C packages/opencode-reactant exec shadow-cljs compile app` completed with 0 warnings. The command rewrote tracked generated CLJS resources locally; those generated deltas were intentionally restored and are not part of this task PR.
+
+Full CLI suite evidence: `pnpm --filter @open-hax/eta-mu-cli test` passes with 110 files passed / 7 skipped and 1120 tests passed / 47 skipped. A small test-harness fix stubs SSH clipboard environment variables in `clipboard.test.ts` so local runs from SSH sessions do not accidentally exercise remote OSC52 behavior in tests named as local clipboard cases.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -32,10 +32,12 @@
   "scripts": {
     "clean": "shx rm -rf dist",
     "dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+    "prebuild": "pnpm --dir ../eta-mu-runtime build",
     "build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js && npm run copy-assets",
     "build:binary": "npm --prefix ../tui run build && npm --prefix ../ai run build && npm --prefix ../agent run build && npm run build && bun build --compile ./dist/bun/cli.js --outfile dist/pi && npm run copy-binary-assets",
     "copy-assets": "shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/",
     "copy-binary-assets": "shx cp package.json dist/ && shx cp README.md dist/ && shx cp CHANGELOG.md dist/ && shx mkdir -p dist/theme && shx cp src/modes/interactive/theme/*.json dist/theme/ && shx mkdir -p dist/assets && shx cp src/modes/interactive/assets/*.png dist/assets/ && shx mkdir -p dist/export-html/vendor && shx cp src/core/export-html/template.html dist/export-html/ && shx cp src/core/export-html/vendor/*.js dist/export-html/vendor/ && shx cp -r docs dist/ && shx cp -r examples dist/ && shx cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm dist/",
+    "pretest": "pnpm --dir ../eta-mu-runtime cljs:compile",
     "test": "vitest --run",
     "prepublishOnly": "npm run clean && npm run build"
   },
@@ -44,6 +46,7 @@
     "@open-hax/eta-mu-agent-core": "workspace:*",
     "@open-hax/eta-mu-ai": "workspace:*",
     "@open-hax/eta-mu-extensions": "workspace:*",
+    "@open-hax/eta-mu-runtime": "workspace:*",
     "@open-hax/eta-mu-tui": "workspace:*",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "chalk": "^5.5.0",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -8,7 +8,6 @@
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { type AttachmentContent, type ImageContent, modelsAreEqual, supportsXhigh } from "@open-hax/eta-mu-ai";
-import { createSurfaceCommandResult } from "@open-hax/eta-mu-runtime/cljs";
 import { ProcessTerminal, setKeybindings, TUI } from "@open-hax/eta-mu-tui";
 import chalk from "chalk";
 import { type Args, type Mode, parseArgs, printHelp } from "./cli/args.js";
@@ -475,6 +474,7 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	if (parsed.version) {
+		const { createSurfaceCommandResult } = await import("@open-hax/eta-mu-runtime/cljs");
 		const versionResult = createSurfaceCommandResult({ command: "version", value: VERSION });
 		console.log(versionResult.stdout);
 		process.exit(versionResult.exitCode);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -8,6 +8,7 @@
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { type AttachmentContent, type ImageContent, modelsAreEqual, supportsXhigh } from "@open-hax/eta-mu-ai";
+import { createSurfaceCommandResult } from "@open-hax/eta-mu-runtime/cljs";
 import { ProcessTerminal, setKeybindings, TUI } from "@open-hax/eta-mu-tui";
 import chalk from "chalk";
 import { type Args, type Mode, parseArgs, printHelp } from "./cli/args.js";
@@ -474,8 +475,9 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	if (parsed.version) {
-		console.log(VERSION);
-		process.exit(0);
+		const versionResult = createSurfaceCommandResult({ command: "version", value: VERSION });
+		console.log(versionResult.stdout);
+		process.exit(versionResult.exitCode);
 	}
 
 	if (parsed.export) {

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -54,6 +54,9 @@ function osc52Writes(): string[] {
 
 beforeEach(() => {
 	vi.unstubAllEnvs();
+	vi.stubEnv("SSH_CONNECTION", "");
+	vi.stubEnv("SSH_CLIENT", "");
+	vi.stubEnv("MOSH_CONNECTION", "");
 	stdoutWrites = [];
 	nativeResolved = false;
 	mocks.clipboard.setText.mockReset();

--- a/packages/coding-agent/test/version-command-cljs-parity.test.ts
+++ b/packages/coding-agent/test/version-command-cljs-parity.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { VERSION } from "../src/config.js";
+import { restoreStdout } from "../src/core/output-guard.js";
+import { main } from "../src/main.js";
+
+type ExitError = Error & { exitCode?: string | number | null };
+
+function mockProcessExit() {
+	return vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+		const error = new Error(`process.exit(${String(code)})`) as ExitError;
+		error.exitCode = code;
+		throw error;
+	}) as typeof process.exit);
+}
+
+describe("version command CLJS parity", () => {
+	afterEach(() => {
+		restoreStdout();
+		vi.restoreAllMocks();
+	});
+
+	it("routes --version through the compiled CLJS surface command result", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const exitSpy = mockProcessExit();
+
+		await expect(main(["--version"])).rejects.toMatchObject({ exitCode: 0 });
+
+		expect(logSpy).toHaveBeenCalledWith(VERSION);
+		expect(exitSpy).toHaveBeenCalledWith(0);
+	});
+});

--- a/packages/eta-mu-runtime/README.md
+++ b/packages/eta-mu-runtime/README.md
@@ -20,6 +20,17 @@ What still belongs above or around it:
 - council UI integration
 - breath receipts and memory writes
 
+## CLJS transition surface
+
+The default package entrypoint remains the stable TypeScript runtime API. During the ClojureScript rewrite, additive CLJS-backed exports are exposed through `@open-hax/eta-mu-runtime/cljs` for narrow parity slices before any default-entrypoint cutover.
+
+```ts
+import { createSurfaceCommandResult } from "@open-hax/eta-mu-runtime/cljs";
+
+const version = createSurfaceCommandResult({ command: "version", value: "0.70.15" });
+console.log(version.stdout);
+```
+
 ## Example
 
 ```ts

--- a/packages/eta-mu-runtime/package.json
+++ b/packages/eta-mu-runtime/package.json
@@ -10,10 +10,20 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./cljs": {
+      "types": "./dist/cljs-runtime.d.ts",
+      "import": "./dist-cljs/index.js",
+      "default": "./dist-cljs/index.js"
     }
   },
+  "files": [
+    "dist",
+    "dist-cljs",
+    "README.md"
+  ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "pnpm cljs:compile && tsc -p tsconfig.json",
     "clean": "rm -rf dist dist-cljs target",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
+++ b/packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
@@ -20,6 +20,7 @@ const expected = [
   "composeToolDescriptors",
   "selectCompatibleModels",
   "createSessionContext",
+  "createSurfaceCommandResult",
 ];
 
 for (const key of expected) {
@@ -64,6 +65,11 @@ const tools = mod.composeToolDescriptors([
 ]);
 if (tools.length !== 1 || tools[0].name !== "read") {
   throw new Error(`composeToolDescriptors smoke failed: ${JSON.stringify(tools)}`);
+}
+
+const versionResult = mod.createSurfaceCommandResult({ command: "version", value: "0.70.15" });
+if (versionResult.stdout !== "0.70.15" || versionResult.exitCode !== 0) {
+  throw new Error(`createSurfaceCommandResult smoke failed: ${JSON.stringify(versionResult)}`);
 }
 
 console.log(JSON.stringify({ ok: true, exports: expected, batchKind: batch.kind, llmMessages: llmMessages.length }));

--- a/packages/eta-mu-runtime/shadow-cljs.edn
+++ b/packages/eta-mu-runtime/shadow-cljs.edn
@@ -24,7 +24,8 @@
                                 :createToolDescriptor eta-mu.runtime.facade/create-tool-descriptor
                                 :composeToolDescriptors eta-mu.runtime.facade/compose-tool-descriptors
                                 :selectCompatibleModels eta-mu.runtime.facade/select-compatible-models
-                                :createSessionContext eta-mu.runtime.facade/create-session-context}}}
+                                :createSessionContext eta-mu.runtime.facade/create-session-context
+                                :createSurfaceCommandResult eta-mu.runtime.facade/create-surface-command-result}}}
    :compiler-options {:output-feature-set :es-next
                       :optimizations :simple
                       :source-map true}}

--- a/packages/eta-mu-runtime/src/cljs-runtime.ts
+++ b/packages/eta-mu-runtime/src/cljs-runtime.ts
@@ -1,0 +1,14 @@
+export type SurfaceCommandName = "version";
+
+export interface SurfaceCommandInput {
+  command: SurfaceCommandName;
+  value: string;
+}
+
+export interface SurfaceCommandResult {
+  command: SurfaceCommandName;
+  stdout: string;
+  exitCode: number;
+}
+
+export declare function createSurfaceCommandResult(input: SurfaceCommandInput): SurfaceCommandResult;

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/surface.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/surface.cljs
@@ -1,0 +1,12 @@
+(ns eta-mu.runtime.domain.surface
+  (:require [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.surface :as surface-law]))
+
+(defn create-command-result
+  "Create a pure command result for a user-facing eta-mu surface path."
+  [input]
+  (let [input (law/validate! surface-law/surface-command-input-schema input "surface command input")
+        result {:command (:command input)
+                :stdout (:value input)
+                :exit-code 0}]
+    (law/validate! surface-law/surface-command-result-schema result "surface command result")))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
@@ -6,6 +6,7 @@
             [eta-mu.runtime.domain.planner :as planner]
             [eta-mu.runtime.domain.session :as session]
             [eta-mu.runtime.domain.state :as state]
+            [eta-mu.runtime.domain.surface :as surface]
             [eta-mu.runtime.domain.tool :as tool]
             [eta-mu.runtime.extern.js :as host]
             [eta-mu.runtime.extern.time :as extern-time]
@@ -13,6 +14,7 @@
             [eta-mu.runtime.shape.message :as message-shape]
             [eta-mu.runtime.shape.model :as model-shape]
             [eta-mu.runtime.shape.session :as session-shape]
+            [eta-mu.runtime.shape.surface :as surface-shape]
             [eta-mu.runtime.shape.tool :as tool-shape]))
 
 (defn- now-iso
@@ -227,3 +229,13 @@
         session/create-session-context
         session-shape/context->external
         ->js)))
+
+(defn create-surface-command-result
+  "JS facade for createSurfaceCommandResult."
+  [input]
+  (-> input
+      js-map
+      surface-shape/command-input-from-external
+      surface/create-command-result
+      surface-shape/command-result->external
+      ->js))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/surface.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/surface.cljs
@@ -1,0 +1,15 @@
+(ns eta-mu.runtime.law.surface)
+
+(def surface-command-schema
+  [:enum :version])
+
+(def surface-command-input-schema
+  [:map
+   [:command surface-command-schema]
+   [:value [:string {:min 1}]]])
+
+(def surface-command-result-schema
+  [:map
+   [:command surface-command-schema]
+   [:stdout string?]
+   [:exit-code [:int {:min 0 :max 255}]]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/surface.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/surface.cljs
@@ -1,0 +1,19 @@
+(ns eta-mu.runtime.shape.surface)
+
+(def command->internal
+  {:version :version
+   "version" :version})
+
+(def command->external
+  {:version "version"})
+
+(defn command-input-from-external
+  [input]
+  {:command (get command->internal (:command input))
+   :value (:value input)})
+
+(defn command-result->external
+  [result]
+  {:command (get command->external (:command result))
+   :stdout (:stdout result)
+   :exitCode (:exit-code result)})

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
@@ -153,6 +153,19 @@
                     #js {:inputs #js ["text"]
                          :reasoningRequired "false"}))))))
 
+(deftest surface-command-facade-test
+  (testing "facade creates JS-compatible command results for CLI parity paths"
+    (let [result (->clj (facade/create-surface-command-result
+                         #js {:command "version"
+                              :value "0.70.15"}))]
+      (is (= "version" (:command result)))
+      (is (= "0.70.15" (:stdout result)))
+      (is (= 0 (:exitCode result)))
+      (is (thrown? js/Error
+                   (facade/create-surface-command-result
+                    #js {:command "unknown"
+                         :value "0.70.15"}))))))
+
 (deftest invalid-timestamp-rejected-test
   (testing "facade rejects invalid timestamp inputs before domain validation"
     (is (thrown? js/Error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@open-hax/eta-mu-extensions':
         specifier: workspace:*
         version: link:../eta-mu-extensions
+      '@open-hax/eta-mu-runtime':
+        specifier: workspace:*
+        version: link:../eta-mu-runtime
       '@open-hax/eta-mu-tui':
         specifier: workspace:*
         version: link:../tui


### PR DESCRIPTION
## Summary

- Add an additive `@open-hax/eta-mu-runtime/cljs` ESM subpath backed by compiled shadow-cljs output.
- Add a CLJS `surface` domain/law/shape slice and `createSurfaceCommandResult` export.
- Route the existing `eta-mu`/`pi --version` command path through the compiled CLJS export while preserving output and exit code.
- Add CLI parity coverage and make clipboard tests robust when local test runs happen over SSH.

## Kanban task

`eta-mu-cljs-rewrite-surface-parity`

## Verification

- Merged current `origin/main` into the branch before push/PR so reviews include current main, including the OpenCode workflow update.
- `pnpm install --offline --frozen-lockfile`
- `pnpm --dir packages/eta-mu-runtime cljs:verify`
  - 28 CLJS tests, 85 assertions, 0 failures/errors
  - runtime compile: 0 warnings
  - boundary scanner: 35 files checked, 5 extern files
- `pnpm --dir packages/eta-mu-runtime test`
- `pnpm --dir packages/eta-mu-runtime typecheck`
- `pnpm --dir packages/eta-mu-runtime build`
- `pnpm --dir packages/ai build`
- `pnpm --dir packages/agent build`
- `pnpm --dir packages/tui build`
- `pnpm --dir packages/kanban build`
- `pnpm --dir packages/coding-agent build`
- `ETA_MU_NO_DEFAULT_EXTENSIONS=1 node packages/coding-agent/dist/cli.js --version`
- `cd packages/coding-agent && node --input-type=module -e ... import @open-hax/eta-mu-runtime/cljs ...`
- `pnpm --dir packages/coding-agent exec vitest run test/version-command-cljs-parity.test.ts`
- `pnpm --dir packages/coding-agent exec vitest run test/clipboard.test.ts test/tools.test.ts test/version-command-cljs-parity.test.ts`
- `pnpm --filter @open-hax/eta-mu-cli test`
  - 110 files passed, 7 skipped; 1120 tests passed, 47 skipped
- `pnpm -C packages/opencode-reactant exec shadow-cljs compile app`
  - 0 warnings; generated CLJS resource deltas restored, not staged
- `pnpm test`
- `pnpm -C packages/eta-mu-extensions test`
- `pnpm -C packages/eta-mu-extensions build`
- `git diff --check`
- Post-merge-from-main spot checks: `pnpm --dir packages/eta-mu-runtime cljs:verify`; `pnpm --dir packages/coding-agent exec vitest run test/version-command-cljs-parity.test.ts`; `git diff --check origin/main...HEAD`

## Review workflow

OpenCode PR review is required in this workflow and should run via the repo check (`Review pull request with OpenCode`). CodeRabbit should run automatically on push/PR open; I will not manually invoke Rabbit unless explicitly needed after an automation blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ClojureScript-backed surface command API available via `/cljs` subpath export
  * CLI version command now routes through the new surface command implementation

* **Documentation**
  * Added documentation for CLJS transition surface and API usage examples

* **Tests**
  * Added parity test validating version command routing
  * Updated clipboard test environment setup for consistency

* **Chores**
  * Updated CI/CD workflow for Java 21 and improved coverage reporting
  * Updated build process to compile ClojureScript alongside TypeScript

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-hax/eta-mu/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->