### PR TITLE
test(runtime): enforce cljs coverage ratchet

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,6 +43,41 @@ jobs:
       - name: eta-mu-runtime
         run: pnpm --dir packages/eta-mu-runtime test
 
+      - name: eta-mu-runtime CLJS coverage >= 90%
+        run: pnpm --dir packages/eta-mu-runtime cljs:coverage
+
+      - name: Post eta-mu-runtime coverage summary
+        if: always()
+        working-directory: packages/eta-mu-runtime
+        run: |
+          {
+            echo '## eta-mu-runtime CLJS Coverage'
+            echo '```'
+            node -e "
+              const fs = require('fs');
+              if (!fs.existsSync('coverage/coverage-summary.json')) {
+                console.log('coverage summary missing');
+                process.exit(0);
+              }
+              const s = JSON.parse(fs.readFileSync('coverage/coverage-summary.json','utf8')).total;
+              const fmt = (x) => (x.pct + '%').padStart(7);
+              const row = (label, metric) => console.log(label + fmt(metric) + '  (' + metric.covered + '/' + metric.total + ')');
+              row('Statements : ', s.statements);
+              row('Branches   : ', s.branches);
+              row('Functions  : ', s.functions);
+              row('Lines      : ', s.lines);
+            "
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload eta-mu-runtime coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eta-mu-runtime-cljs-coverage
+          path: packages/eta-mu-runtime/coverage/
+          if-no-files-found: ignore
+
       - name: eta-mu-github
         run: pnpm --dir packages/eta-mu-github test
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload eta-mu-runtime coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: eta-mu-runtime-cljs-coverage
           path: packages/eta-mu-runtime/coverage/
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: cljs-coverage
           path: packages/eta-mu-extensions/coverage/
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload shadow-cljs logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: shadow-cljs-logs
           path: packages/eta-mu-extensions/.shadow-cljs/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lib/
 !packages/eta-mu-extensions/src/eta_mu/build/
 !packages/eta-mu-extensions/src/eta_mu/build/**
 *.tsbuildinfo
+**/coverage/
 
 # Dependencies
 node_modules/

--- a/kanban/coverage-workflow.md
+++ b/kanban/coverage-workflow.md
@@ -1,35 +1,68 @@
 ---
 uuid: "orgs-open-hax-eta-mu-kanban-orgs-open-hax-eta-mu-specs-coverage-workflow-md"
-title: "Coverage Workflow and Thresholds"
-status: incoming
-priority: P3
-labels: ["specs", "migrated-spec"]
+title: "Coverage Workflow and Runtime Thresholds"
+status: review
+priority: P1
+labels: ["tasks", "coverage", "runtime", "cljs", "ratchet", "3sp"]
 created_at: "2026-05-29T04:29:39.347Z"
 source: "orgs/open-hax/eta-mu/specs/coverage-workflow.md"
-category: "specs"
+category: "tasks"
 ---
 
 > Source: `orgs/open-hax/eta-mu/specs/coverage-workflow.md`
 > Migrated-to-kanban: `orgs/open-hax/eta-mu/kanban/coverage-workflow.md`
 
-# Coverage Workflow and Thresholds
+# Coverage Workflow and Runtime Thresholds
 
 ## Context
-- Add a reproducible coverage command and enforce minimum coverage via CI for the backend (services/agentd) tests.
 
-## Related Files (refs)
-- package.json: root `coverage` script delegates to agentd (lines 13-22).
-- services/agentd/package.json: `coverage` script uses Vitest coverage and depends on `@vitest/coverage-v8` (lines 7-33).
-- services/agentd/vitest.config.ts: coverage provider/reporters/thresholds (lines 1-20).
-- .github/workflows/coverage.yml: CI job running coverage on push/PR.
+Original eta-mu had partial coverage workflow scaffolding, but the root `coverage` script still pointed at the absorbed `agentd` service and did not enforce the CLJS runtime rewrite. The runtime now needs a real coverage ratchet with a hard 90% floor for the migrated CLJS implementation.
 
-## Definition of Done
-- `pnpm coverage` executes Vitest coverage for agentd with thresholds enforced.
-- CI workflow runs coverage on PRs/pushes and fails on threshold violations.
-- Coverage reporters include text + lcov for future tooling if needed.
+## Scope
 
-## Requirements
-1. Use Vitest coverage (`provider: v8`) with thresholds: lines/statements 20%, functions 50%, branches 40% (current baseline).
-2. Add workspace-level coverage script and service-level coverage script.
-3. Add GitHub Action (`coverage.yml`) triggered on push to main and PRs running install + `pnpm coverage`.
-4. Keep changes limited to backend tests (no frontend tests introduced in this pass).
+- Add a reproducible root `pnpm coverage` command.
+- Add `packages/eta-mu-runtime` CLJS coverage reporting through c8 over shadow-cljs generated runtime files.
+- Enforce at least 90% statement and line coverage for `eta_mu.runtime*` CLJS runtime files.
+- Publish the runtime coverage summary and artifact in CI.
+- Keep existing extension coverage reporting separate; extension branch/function metrics remain noisy and are not part of this ratchet.
+
+## Work items
+
+- [x] Replace stale root coverage script with the eta-mu runtime coverage command.
+- [x] Add runtime CLJS coverage script with c8 reporters: text, lcov, json-summary.
+- [x] Add 90% statement/line threshold enforcement.
+- [x] Add focused shape/message tests to lift runtime CLJS line coverage above 90%.
+- [x] Add CI step summary and coverage artifact upload for runtime CLJS coverage.
+- [x] Ignore local `coverage/` report directories.
+
+## Acceptance criteria
+
+- [x] `pnpm coverage` reports eta-mu-runtime CLJS coverage and fails below 90% lines/statements.
+- [x] CI runs the runtime coverage ratchet on PRs and pushes to `main`.
+- [x] Coverage report has nonzero totals and includes `eta_mu.runtime*` CLJS files.
+- [x] Runtime tests still pass outside coverage mode.
+- [x] No unrelated workspace dirt is staged.
+
+## Verification
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-runtime cljs:coverage
+pnpm coverage
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+git diff --check
+actionlint .github/workflows/coverage.yml
+```
+
+## Baseline after ratchet
+
+Runtime CLJS coverage after adding shape/message coverage:
+
+- Statements: 93.77% (1853/1976)
+- Lines: 93.77% (1853/1976)
+- Functions: 74.46% (70/94)
+- Branches: 61.49% (222/361)
+
+The enforced threshold is intentionally line/statement coverage because shadow-cljs-generated branch/function ranges are not stable enough to use as a 90% merge gate yet.

--- a/kanban/coverage-workflow.md
+++ b/kanban/coverage-workflow.md
@@ -53,8 +53,9 @@ pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/eta-mu-runtime test
 pnpm --dir packages/eta-mu-runtime typecheck
 git diff --check
-actionlint .github/workflows/coverage.yml
 ```
+
+Optional host-local workflow lint used during this slice: `actionlint .github/workflows/coverage.yml`.
 
 ## Baseline after ratchet
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docs:ts": "pnpm --filter @open-hax/agentd doc",
     "docs:cljs": "clojure -X:codox",
     "docs": "pnpm docs:ts && pnpm docs:cljs",
-    "coverage": "pnpm --filter @open-hax/agentd coverage",
+    "coverage": "pnpm --dir packages/eta-mu-runtime cljs:coverage",
     "start": "pnpm --filter @open-hax/agentd start",
     "clean": "pnpm --recursive clean",
     "install:all": "pnpm install && pnpm --recursive install"

--- a/packages/eta-mu-runtime/package.json
+++ b/packages/eta-mu-runtime/package.json
@@ -30,6 +30,7 @@
     "test:watch": "vitest --config vitest.config.ts",
     "cljs:compile": "shadow-cljs compile runtime",
     "cljs:test": "shadow-cljs compile test && node target/cljs-test.cjs",
+    "cljs:coverage": "shadow-cljs compile test && c8 --include '.shadow-cljs/builds/test/dev/out/cljs-runtime/eta_mu.runtime*.js' --exclude '**/*_test.js' --reporter=text --reporter=lcov --reporter=json-summary --check-coverage --lines 90 --statements 90 node target/cljs-test.cjs",
     "cljs:smoke": "node scripts/smoke-cljs-runtime.mjs",
     "cljs:boundary": "node scripts/check-cljs-boundaries.mjs",
     "cljs:verify": "pnpm cljs:compile && pnpm cljs:test && pnpm cljs:smoke && pnpm cljs:boundary"
@@ -38,6 +39,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "c8": "^10.1.2",
     "shadow-cljs": "^3.4.11",
     "source-map-support": "^0.5.21",
     "typescript": "^5.6.3",

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/shape/message_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/shape/message_test.cljs
@@ -30,6 +30,8 @@
       (is (= :wav (-> internal (nth 2) :format)))
       (is (false? (-> internal (nth 3) :redacted)))
       (is (= "sig:tool" (-> internal (nth 4) :thought-signature)))
+      ;; Shape external maps stay in CLJS data with keyword enum values;
+      ;; the facade host adapter stringifies them for public JavaScript callers.
       (is (= [:text :image :audio :thinking :toolCall]
              (mapv :type external)))
       (is (= "sig:text" (-> external first :textSignature)))
@@ -124,6 +126,8 @@
       (is (= "extension.notice" (-> internal (nth 4) :custom-type)))
       (is (= "abc" (-> internal (nth 5) :from-id)))
       (is (= 1200 (-> internal (nth 6) :tokens-before)))
+      ;; Shape external maps stay in CLJS data with keyword enum values;
+      ;; the facade host adapter stringifies them for public JavaScript callers.
       (is (= [:user :assistant :toolResult :bashExecution :custom :branchSummary :compactionSummary]
              (mapv :role external)))
       (is (= "tool-use" (-> external second :stopReason)))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/shape/message_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/shape/message_test.cljs
@@ -1,0 +1,142 @@
+(ns eta-mu.runtime.shape.message-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.shape.message :as shape]))
+
+(def timestamp 1780099200000)
+
+(def usage-external
+  {:input 3
+   :output 5
+   :cacheRead 7
+   :cacheWrite 11
+   :totalTokens 26
+   :cost {:input 0.1
+          :output 0.2
+          :cacheRead 0.03
+          :cacheWrite 0.04
+          :total 0.37}})
+
+(deftest content-shape-roundtrip-test
+  (testing "content parts preserve public camelCase and internal kebab-case keys"
+    (let [parts [{:type "text" :text "hello" :textSignature "sig:text"}
+                 {:type "image" :data "aW1n" :mimeType "image/png"}
+                 {:type "audio" :data "YXVkaW8=" :mimeType "audio/wav" :format "wav"}
+                 {:type "thinking" :thinking "hmm" :thinkingSignature "sig:think" :redacted false}
+                 {:type "toolCall" :id "call-1" :name "read" :arguments {:path "README.md"} :thoughtSignature "sig:tool"}]
+          internal (mapv shape/content-from-external parts)
+          external (mapv shape/content->external internal)]
+      (is (= [:text :image :audio :thinking :tool-call]
+             (mapv :type internal)))
+      (is (= :wav (-> internal (nth 2) :format)))
+      (is (false? (-> internal (nth 3) :redacted)))
+      (is (= "sig:tool" (-> internal (nth 4) :thought-signature)))
+      (is (= [:text :image :audio :thinking :toolCall]
+             (mapv :type external)))
+      (is (= "sig:text" (-> external first :textSignature)))
+      (is (= "wav" (-> external (nth 2) :format)))
+      (is (false? (-> external (nth 3) :redacted)))
+      (is (= "sig:tool" (-> external (nth 4) :thoughtSignature)))))
+
+  (testing "string content and unknown content pass through unchanged"
+    (is (= "plain" (shape/content-list-from-external "plain")))
+    (is (= "plain" (shape/content-list->external "plain")))
+    (is (= {:type "unknown" :value 1}
+           (shape/content-from-external {:type "unknown" :value 1})))
+    (is (= {:type :unknown :value 1}
+           (shape/content->external {:type :unknown :value 1})))))
+
+(deftest usage-shape-roundtrip-test
+  (testing "usage metrics convert cache and total token names both ways"
+    (let [internal (shape/usage-from-external usage-external)
+          external (shape/usage->external internal)]
+      (is (= {:input 3
+              :output 5
+              :cache-read 7
+              :cache-write 11
+              :total-tokens 26
+              :cost {:input 0.1
+                     :output 0.2
+                     :cache-read 0.03
+                     :cache-write 0.04
+                     :total 0.37}}
+             internal))
+      (is (= 7 (:cacheRead external)))
+      (is (= 11 (:cacheWrite external)))
+      (is (= 26 (:totalTokens external)))
+      (is (= 0.03 (get-in external [:cost :cacheRead]))))))
+
+(deftest message-shape-roundtrip-test
+  (testing "all public message roles normalize and externalize"
+    (let [messages [{:role "user"
+                     :content "hello"
+                     :timestamp timestamp}
+                    {:role "assistant"
+                     :content [{:type "text" :text "done" :textSignature "sig:text"}
+                               {:type "thinking" :thinking "trace" :thinkingSignature "sig:think" :redacted true}
+                               {:type "toolCall" :id "call-1" :name "read" :arguments {:path "README.md"} :thoughtSignature "sig:tool"}]
+                     :api "openai-responses"
+                     :provider "openai"
+                     :model "gpt-test"
+                     :responseId "resp-1"
+                     :usage usage-external
+                     :stopReason "tool-use"
+                     :errorMessage "soft failure"
+                     :timestamp timestamp}
+                    {:role "toolResult"
+                     :toolCallId "call-1"
+                     :toolName "read"
+                     :content [{:type "text" :text "ok"}]
+                     :details {:bytes 2}
+                     :isError false
+                     :timestamp timestamp}
+                    {:role "bashExecution"
+                     :command "pnpm test"
+                     :output "ok"
+                     :exitCode 0
+                     :cancelled false
+                     :truncated false
+                     :fullOutputPath "/tmp/full.log"
+                     :excludeFromContext false
+                     :timestamp timestamp}
+                    {:role "custom"
+                     :customType "extension.notice"
+                     :content "notice"
+                     :display true
+                     :details {:source "test"}
+                     :timestamp timestamp}
+                    {:role "branchSummary"
+                     :summary "branch facts"
+                     :fromId "abc"
+                     :timestamp timestamp}
+                    {:role "compactionSummary"
+                     :summary "old facts"
+                     :tokensBefore 1200
+                     :timestamp timestamp}]
+          internal (mapv shape/message-from-external messages)
+          external (mapv shape/message->external internal)]
+      (is (= [:user :assistant :tool-result :bash-execution :custom :branch-summary :compaction-summary]
+             (mapv :role internal)))
+      (is (= :tool-use (-> internal second :stop-reason)))
+      (is (= "resp-1" (-> internal second :response-id)))
+      (is (= "soft failure" (-> internal second :error-message)))
+      (is (= "call-1" (-> internal (nth 2) :tool-call-id)))
+      (is (false? (-> internal (nth 3) :exclude-from-context)))
+      (is (= "extension.notice" (-> internal (nth 4) :custom-type)))
+      (is (= "abc" (-> internal (nth 5) :from-id)))
+      (is (= 1200 (-> internal (nth 6) :tokens-before)))
+      (is (= [:user :assistant :toolResult :bashExecution :custom :branchSummary :compactionSummary]
+             (mapv :role external)))
+      (is (= "tool-use" (-> external second :stopReason)))
+      (is (= "resp-1" (-> external second :responseId)))
+      (is (= "soft failure" (-> external second :errorMessage)))
+      (is (= "call-1" (-> external (nth 2) :toolCallId)))
+      (is (false? (-> external (nth 3) :excludeFromContext)))
+      (is (= "extension.notice" (-> external (nth 4) :customType)))
+      (is (= "abc" (-> external (nth 5) :fromId)))
+      (is (= 1200 (-> external (nth 6) :tokensBefore)))))
+
+  (testing "unknown message roles pass through unchanged"
+    (is (= {:role "unknown" :value 1}
+           (shape/message-from-external {:role "unknown" :value 1})))
+    (is (= {:role :unknown :value 1}
+           (shape/message->external {:role :unknown :value 1})))))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.3
       shadow-cljs:
         specifier: ^3.4.11
         version: 3.4.11


### PR DESCRIPTION
## Summary
- add a real eta-mu-runtime CLJS coverage ratchet with c8 text/lcov/json-summary reporters
- enforce >=90% CLJS runtime statement and line coverage via `pnpm coverage` and CI
- add shape/message coverage that raises runtime CLJS line+statement coverage to 93.77%
- replace the stale root coverage script and publish runtime coverage summaries/artifacts in the coverage workflow

## Workflow notes
- OpenCode PR code review is a required gate for this workflow; this PR should wait for that check before merge
- CodeRabbit is expected to run automatically; I did not manually request a review
- The 90% ratchet intentionally gates line/statements because shadow-cljs-generated function/branch ranges are noisy

## Verification
- `pnpm install --offline --frozen-lockfile`
- `pnpm --dir packages/eta-mu-runtime cljs:coverage` -> statements/lines 93.77% with 90% threshold enforced
- `pnpm coverage` -> statements/lines 93.77% with 90% threshold enforced
- `pnpm --dir packages/eta-mu-runtime cljs:verify`
- `pnpm --dir packages/eta-mu-runtime test`
- `pnpm --dir packages/eta-mu-runtime typecheck`
- `pnpm --dir packages/eta-mu-runtime build`
- `pnpm test`
- `actionlint .github/workflows/coverage.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced code coverage measurement and reporting in CI pipeline with automated metric publishing.

* **Tests**
  * Extended test coverage for runtime shape and message handling modules.

* **Chores**
  * Updated CI workflow to enforce coverage quality thresholds.
  * Refined coverage collection tooling and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-hax/eta-mu/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->