### PR TITLE
docs(kanban): plan quality ratchet

### DIFF
--- a/kanban/epics/eta-mu-quality-ratchet.md
+++ b/kanban/epics/eta-mu-quality-ratchet.md
@@ -1,0 +1,104 @@
+---
+uuid: "eta-mu-quality-ratchet"
+title: "Eta-mu Quality Ratchet — Delinting, Warning Cleanup, and Testing"
+status: accepted
+priority: P0
+labels: ["epics", "quality", "lint", "warnings", "testing", "coverage", "26sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "user-request:2026-05-31"
+points: 26
+category: epics
+---
+
+# Eta-mu Quality Ratchet — Delinting, Warning Cleanup, and Testing
+
+> Source: user request, 2026-05-31
+> Board source: `orgs/open-hax/eta-mu/kanban/`
+> Process: one PR per child task, OpenCode PR review required, CodeRabbit automatic review observed but not manually spammed
+> Points: 26
+
+## Purpose
+
+Make eta-mu boringly reliable after the CLJS runtime cutover: every common local and CI path should have an explicit lint/warning/test gate, every known warning class should have an owner, and startup regressions like missing generated extension targets should be caught before users hit them.
+
+This epic is a ratchet, not a cosmetic cleanup. Each child task should reduce the set of allowed warnings, flaky tests, stale generated artifacts, or unverified startup paths.
+
+## Quality thesis
+
+> Warnings are work items. Missing generated runtime files are regressions. Tests must prove the shipped package, not only the source tree.
+
+Recent work proved the CLJS runtime path and added a 90% runtime line/statement coverage gate. The next layer is to bring the broader eta-mu repo into the same discipline:
+
+- extension builds should not emit surprise infer warnings forever;
+- default/beta CLI startup should smoke-test built-in extension package metadata;
+- lint/test scripts should be discoverable and CI-owned;
+- coverage should expand beyond the first runtime CLJS ratchet;
+- failures should be recorded as blockers instead of hidden behind broad rebuilds.
+
+## Process constraints
+
+- One PR per child task.
+- Work from clean task worktrees branched from current `origin/main`.
+- Keep path-scoped staging; do not stage root or nested `receipts.edn` unless the PR explicitly owns receipts.
+- Keep package names, binaries, extension names, and public exports stable unless a task explicitly changes them.
+- OpenCode PR code review is required before merge.
+- CodeRabbit runs automatically; do not manually request review after every push. If automatic reruns are quota/usage-credit blocked after fixes, document addressed findings in a PR comment and proceed only when branch protection, CI, and OpenCode are green.
+
+## Child tasks
+
+1. `kanban/tasks/eta-mu-quality-ratchet-baseline-inventory.md`
+   - Establish the current lint/warning/test/coverage baseline and blocker ledger.
+
+2. `kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md`
+   - Remove or explicitly classify CLJS extension build warnings, starting with `task_timing.cljs` and `lib/eta_mu/opencode.cljs` infer warnings.
+
+3. `kanban/tasks/eta-mu-quality-ratchet-cli-startup-smoke.md`
+   - Add smoke coverage so `eta-mu-beta`/package startup cannot regress on missing extension dist targets such as `cljs-lisp-decomp-nudge/index.ts`.
+
+4. `kanban/tasks/eta-mu-quality-ratchet-lint-gates.md`
+   - Define and wire repo-local lint/format/static checks for TypeScript, markdown, workflows, package metadata, and CLJS boundaries.
+
+5. `kanban/tasks/eta-mu-quality-ratchet-test-suite-hardening.md`
+   - Stabilize the full test matrix, isolate known flaky/local-environment failures, and make failure output actionable.
+
+6. `kanban/tasks/eta-mu-quality-ratchet-coverage-expansion.md`
+   - Expand meaningful coverage gates beyond `packages/eta-mu-runtime` while avoiding noisy shadow-cljs branch/function false precision.
+
+## Acceptance criteria
+
+- [ ] A baseline report names every current lint, warning, coverage, and test gate plus known blockers.
+- [ ] Extension build warnings are either eliminated or tracked with task-level owner/justification and no silent drift.
+- [ ] CLI/package startup smoke tests catch missing built-in extension dist paths before release/local beta use.
+- [ ] Repo-local lint and workflow checks are scriptable and documented.
+- [ ] Full test-suite failures are reproducible, classified, and either fixed or recorded with a narrow blocker.
+- [ ] Coverage gates cover the CLJS runtime and at least one additional high-value package/surface.
+- [ ] CI and PR workflow require OpenCode review and expose quality summaries.
+
+## Verification map
+
+Use the narrowest relevant gate per child task, then run broader gates before merge when package metadata, workflows, or startup behavior changed.
+
+Baseline candidate commands:
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime cljs:coverage
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-extensions test
+pnpm --dir packages/eta-mu-extensions build
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm test
+pnpm coverage
+git diff --check
+```
+
+Add task-specific gates such as `actionlint`, package smoke tests, or markdown lint only in the task that owns wiring those tools.
+
+## Known starting signals
+
+- `packages/eta-mu-runtime` CLJS coverage currently enforces >=90% statements/lines and reports 93.77% at the time this epic was created.
+- `packages/eta-mu-extensions build` currently completes but emits CLJS infer warnings in `task_timing.cljs` and `lib/eta_mu/opencode.cljs`.
+- `eta-mu-beta` previously failed when the primary checkout was stale and `dist/pi/cljs-lisp-decomp-nudge/index.ts` was absent; rebuilding `packages/eta-mu-extensions` regenerated the target.
+- Root and nested receipt ledgers are intentionally dirty during agent work and must not be swept into quality PRs accidentally.

--- a/kanban/epics/eta-mu-quality-ratchet.md
+++ b/kanban/epics/eta-mu-quality-ratchet.md
@@ -81,7 +81,7 @@ Use the narrowest relevant gate per child task, then run broader gates before me
 Baseline candidate commands:
 
 ```bash
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/eta-mu-runtime cljs:coverage
 pnpm --dir packages/eta-mu-runtime test
@@ -98,7 +98,7 @@ Add task-specific gates such as `actionlint`, package smoke tests, or markdown l
 
 ## Known starting signals
 
-- `packages/eta-mu-runtime` CLJS coverage currently enforces >=90% statements/lines and reports 93.77% at the time this epic was created.
+- `packages/eta-mu-runtime` CLJS coverage currently enforces >=90% statements/lines and was above that gate in the 2026-05-31 coverage ratchet baseline.
 - `packages/eta-mu-extensions build` currently completes but emits CLJS infer warnings in `task_timing.cljs` and `lib/eta_mu/opencode.cljs`.
 - `eta-mu-beta` previously failed when the primary checkout was stale and `dist/pi/cljs-lisp-decomp-nudge/index.ts` was absent; rebuilding `packages/eta-mu-extensions` regenerated the target.
 - Root and nested receipt ledgers are intentionally dirty during agent work and must not be swept into quality PRs accidentally.

--- a/kanban/tasks/eta-mu-quality-ratchet-baseline-inventory.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-baseline-inventory.md
@@ -1,0 +1,58 @@
+---
+uuid: "eta-mu-quality-ratchet-baseline-inventory"
+title: "Eta-mu Quality Ratchet — Baseline Inventory"
+status: todo
+priority: P0
+labels: ["tasks", "quality", "baseline", "lint", "testing", "3sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+points: 3
+category: tasks
+---
+
+# Eta-mu Quality Ratchet — Baseline Inventory
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 3
+
+## Purpose
+
+Create a truthful, reproducible quality baseline before cleanup begins so future PRs know which warnings/tests are regressions and which are known blockers.
+
+## Scope
+
+- lint/test/build/coverage command inventory
+- warning baseline for CLJS extension/runtime builds
+- known local-vs-CI blocker ledger
+- package/surface ownership map for quality gates
+- no source behavior changes except docs/task metadata
+
+## Work items
+
+- [ ] Enumerate existing package scripts for lint, test, typecheck, build, and coverage.
+- [ ] Run the current high-value gates and capture pass/fail/warning summaries.
+- [ ] Record known warnings with exact files, warning classes, and proposed owners.
+- [ ] Record known flaky/local-environment failures separately from product regressions.
+- [ ] Produce a short baseline report under `docs/`.
+- [ ] Update this task with verification evidence.
+
+## Acceptance criteria
+
+- [ ] A docs baseline report exists and names commands, outcomes, warning counts, and blockers.
+- [ ] Baseline distinguishes source failures from local environment/generated-dist issues.
+- [ ] The next cleanup tasks have enough evidence to avoid rediscovering the same warnings.
+- [ ] No unrelated workspace dirt is staged.
+
+## Verification
+
+```bash
+git diff --stat
+git diff --check
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime cljs:coverage
+pnpm --dir packages/eta-mu-extensions test
+pnpm --dir packages/eta-mu-extensions build
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm test
+```

--- a/kanban/tasks/eta-mu-quality-ratchet-baseline-inventory.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-baseline-inventory.md
@@ -48,7 +48,7 @@ Create a truthful, reproducible quality baseline before cleanup begins so future
 ```bash
 git diff --stat
 git diff --check
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/eta-mu-runtime cljs:coverage
 pnpm --dir packages/eta-mu-extensions test

--- a/kanban/tasks/eta-mu-quality-ratchet-cli-startup-smoke.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-cli-startup-smoke.md
@@ -54,7 +54,7 @@ Rebuilding `packages/eta-mu-extensions` regenerated the missing path, so this ta
 ## Verification
 
 ```bash
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --dir packages/eta-mu-extensions build
 pnpm --dir packages/coding-agent build
 ETA_MU_NO_DEFAULT_EXTENSIONS=0 timeout 20s node packages/coding-agent/dist/cli.js --help

--- a/kanban/tasks/eta-mu-quality-ratchet-cli-startup-smoke.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-cli-startup-smoke.md
@@ -1,0 +1,63 @@
+---
+uuid: "eta-mu-quality-ratchet-cli-startup-smoke"
+title: "Eta-mu Quality Ratchet — CLI Startup Smoke"
+status: todo
+priority: P0
+labels: ["tasks", "quality", "startup", "extensions", "smoke", "3sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+points: 3
+category: tasks
+---
+
+# Eta-mu Quality Ratchet — CLI Startup Smoke
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 3
+
+## Purpose
+
+Catch missing built-in extension package targets before `eta-mu-beta` or release users see startup errors.
+
+## Starting regression
+
+A current-main checkout produced:
+
+```text
+Failed to load extension ".../packages/eta-mu-extensions/dist/pi/cljs-lisp-decomp-nudge/index.ts": Extension path does not exist
+```
+
+Rebuilding `packages/eta-mu-extensions` regenerated the missing path, so this task should convert that incident into an automated smoke gate.
+
+## Scope
+
+- package metadata extension path validation
+- `packages/eta-mu-extensions` build output materialization
+- `eta-mu`/`pi` startup smoke with built-in extensions enabled
+- generated dist freshness checks without committing generated build output unless required by package policy
+
+## Work items
+
+- [ ] Add a script that validates every path in `@open-hax/eta-mu-extensions` `pi.extensions` exists after build.
+- [ ] Add a CLI smoke test that starts the built CLI with built-in extensions and fails on `Failed to load extension`.
+- [ ] Ensure the smoke runs after the extension build in CI or package tests.
+- [ ] Document the local recovery command for missing extension dist targets.
+- [ ] Verify the smoke catches `cljs-lisp-decomp-nudge` if its target is absent.
+
+## Acceptance criteria
+
+- [ ] Missing `dist/pi/*/index.ts` paths fail a package test or CI step.
+- [ ] Normal `eta-mu-beta`/built CLI startup no longer depends on stale local generated artifacts.
+- [ ] `packages/eta-mu-extensions build` still materializes `cljs-lisp-decomp-nudge`.
+- [ ] No unrelated workspace dirt is staged.
+
+## Verification
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-extensions build
+pnpm --dir packages/coding-agent build
+ETA_MU_NO_DEFAULT_EXTENSIONS=0 timeout 20s node packages/coding-agent/dist/cli.js --help
+# plus the new extension-path smoke script/test
+git diff --check
+```

--- a/kanban/tasks/eta-mu-quality-ratchet-coverage-expansion.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-coverage-expansion.md
@@ -21,7 +21,7 @@ Extend coverage discipline beyond the first `packages/eta-mu-runtime` CLJS ratch
 
 ## Starting baseline
 
-`packages/eta-mu-runtime` currently gates CLJS line and statement coverage at 90% and reports 93.77%. `packages/eta-mu-extensions` has a coverage script, but raw c8 defaults can produce zero totals unless shadow-cljs generated runtime files are explicitly included.
+`packages/eta-mu-runtime` currently gates CLJS line and statement coverage at 90% and was above that gate in the 2026-05-31 coverage ratchet baseline. `packages/eta-mu-extensions` has a coverage script, but raw c8 defaults can produce zero totals unless shadow-cljs generated runtime files are explicitly included.
 
 ## Scope
 
@@ -50,7 +50,7 @@ Extend coverage discipline beyond the first `packages/eta-mu-runtime` CLJS ratch
 ## Verification
 
 ```bash
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --dir packages/eta-mu-runtime cljs:coverage
 pnpm coverage
 # plus the new package coverage command added by this task

--- a/kanban/tasks/eta-mu-quality-ratchet-coverage-expansion.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-coverage-expansion.md
@@ -1,0 +1,58 @@
+---
+uuid: "eta-mu-quality-ratchet-coverage-expansion"
+title: "Eta-mu Quality Ratchet — Coverage Expansion"
+status: todo
+priority: P1
+labels: ["tasks", "quality", "coverage", "cljs", "testing", "5sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+points: 5
+category: tasks
+---
+
+# Eta-mu Quality Ratchet — Coverage Expansion
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 5
+
+## Purpose
+
+Extend coverage discipline beyond the first `packages/eta-mu-runtime` CLJS ratchet without creating fake precision from noisy generated metrics.
+
+## Starting baseline
+
+`packages/eta-mu-runtime` currently gates CLJS line and statement coverage at 90% and reports 93.77%. `packages/eta-mu-extensions` has a coverage script, but raw c8 defaults can produce zero totals unless shadow-cljs generated runtime files are explicitly included.
+
+## Scope
+
+- `packages/eta-mu-extensions` meaningful c8 include/exclude configuration
+- additional TypeScript/Vitest package coverage where stable
+- coverage summaries and artifacts in CI
+- documented threshold choices per package
+- no branch/function 90% gate unless measured ranges are stable
+
+## Work items
+
+- [ ] Establish nonzero coverage totals for `packages/eta-mu-extensions` by targeting generated `eta_mu.extensions*` files and excluding tests.
+- [ ] Decide an initial threshold per package based on measured baseline, with a plan to ratchet upward.
+- [ ] Add coverage summaries/artifacts for the next high-value package.
+- [ ] Document why any metric is advisory rather than enforced.
+- [ ] Keep runtime's existing 90% statement/line ratchet green.
+
+## Acceptance criteria
+
+- [ ] At least one additional package has meaningful nonzero coverage reporting.
+- [ ] Any enforced threshold is backed by a measured baseline and fails below that threshold.
+- [ ] Runtime CLJS coverage remains >=90% statements/lines.
+- [ ] CI exposes coverage summaries for the covered packages.
+- [ ] No unrelated workspace dirt is staged.
+
+## Verification
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-runtime cljs:coverage
+pnpm coverage
+# plus the new package coverage command added by this task
+git diff --check
+```

--- a/kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md
@@ -44,7 +44,7 @@ Make `packages/eta-mu-extensions` builds stop normalizing CLJS infer warnings as
 ## Verification
 
 ```bash
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --dir packages/eta-mu-extensions test
 pnpm --dir packages/eta-mu-extensions build
 git diff --check

--- a/kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md
@@ -1,0 +1,51 @@
+---
+uuid: "eta-mu-quality-ratchet-extension-warning-cleanup"
+title: "Eta-mu Quality Ratchet — Extension Warning Cleanup"
+status: todo
+priority: P0
+labels: ["tasks", "quality", "cljs", "warnings", "eta-mu-extensions", "5sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+points: 5
+category: tasks
+---
+
+# Eta-mu Quality Ratchet — Extension Warning Cleanup
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 5
+
+## Purpose
+
+Make `packages/eta-mu-extensions` builds stop normalizing CLJS infer warnings as background noise.
+
+## Scope
+
+- `packages/eta-mu-extensions/src/eta_mu/extensions/task_timing.cljs`
+- `packages/eta-mu-extensions/lib/eta_mu/opencode.cljs`
+- shadow-cljs warning output for extension release builds
+- warning-ratchet documentation or scanner if zero warnings cannot land in one slice
+
+## Work items
+
+- [ ] Reproduce current extension warning output from a clean checkout.
+- [ ] Fix target inference warnings by adding type hints, extracting JS interop helpers, or moving raw host access behind named adapter helpers.
+- [ ] Avoid broad rewrites of extension behavior.
+- [ ] Add a narrow warning assertion or documented baseline so warnings cannot grow silently.
+- [ ] Keep generated `dist/` artifacts out of source commits unless the task explicitly requires them.
+
+## Acceptance criteria
+
+- [ ] `pnpm --dir packages/eta-mu-extensions build` emits zero warnings, or any remaining warning is captured in a blocker ledger with owner and rationale.
+- [ ] `pnpm --dir packages/eta-mu-extensions test` passes.
+- [ ] OpenCode review confirms no behavior drift in extension registration.
+- [ ] No unrelated workspace dirt is staged.
+
+## Verification
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-extensions test
+pnpm --dir packages/eta-mu-extensions build
+git diff --check
+```

--- a/kanban/tasks/eta-mu-quality-ratchet-lint-gates.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-lint-gates.md
@@ -1,0 +1,52 @@
+---
+uuid: "eta-mu-quality-ratchet-lint-gates"
+title: "Eta-mu Quality Ratchet — Lint and Static Gates"
+status: todo
+priority: P1
+labels: ["tasks", "quality", "lint", "format", "ci", "5sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+points: 5
+category: tasks
+---
+
+# Eta-mu Quality Ratchet — Lint and Static Gates
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 5
+
+## Purpose
+
+Make lint/static checks discoverable, reproducible, and CI-owned inside eta-mu instead of relying on ad hoc agent memory.
+
+## Scope
+
+- TypeScript lint/static checks available in this repo
+- markdown/frontmatter hygiene for kanban/docs
+- GitHub workflow linting
+- package metadata checks for extension paths and exports
+- CLJS boundary scanner integration where it already exists
+
+## Work items
+
+- [ ] Inventory existing lint/static tooling and gaps.
+- [ ] Add or normalize repo-local scripts for lint/static gates without importing unrelated workspace assumptions.
+- [ ] Add a workflow lint path, either as documented optional host-local check or devDependency-backed script.
+- [ ] Wire CLJS boundary/static checks into the relevant package gate.
+- [ ] Document what is intentionally out of scope for this pass.
+
+## Acceptance criteria
+
+- [ ] A developer can run one documented command for eta-mu static quality checks.
+- [ ] CI runs the same command or equivalent named steps on PRs.
+- [ ] Kanban/docs markdown changed in this epic remains parseable by `eta-mu kanban` tooling.
+- [ ] No broad formatting churn or unrelated file rewrites are included.
+
+## Verification
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --dir packages/eta-mu-runtime cljs:boundary
+# plus the new lint/static command added by this task
+git diff --check
+```

--- a/kanban/tasks/eta-mu-quality-ratchet-lint-gates.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-lint-gates.md
@@ -45,7 +45,7 @@ Make lint/static checks discoverable, reproducible, and CI-owned inside eta-mu i
 ## Verification
 
 ```bash
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --dir packages/eta-mu-runtime cljs:boundary
 # plus the new lint/static command added by this task
 git diff --check

--- a/kanban/tasks/eta-mu-quality-ratchet-test-suite-hardening.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-test-suite-hardening.md
@@ -48,7 +48,7 @@ Make eta-mu's test suite trustworthy enough that failures point to product regre
 ## Verification
 
 ```bash
-pnpm install --offline --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm --filter @open-hax/eta-mu-cli test
 pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/eta-mu-runtime test

--- a/kanban/tasks/eta-mu-quality-ratchet-test-suite-hardening.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-test-suite-hardening.md
@@ -1,0 +1,58 @@
+---
+uuid: "eta-mu-quality-ratchet-test-suite-hardening"
+title: "Eta-mu Quality Ratchet — Test Suite Hardening"
+status: todo
+priority: P1
+labels: ["tasks", "quality", "testing", "flaky", "ci", "5sp"]
+created_at: "2026-05-31T00:45:00Z"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+points: 5
+category: tasks
+---
+
+# Eta-mu Quality Ratchet — Test Suite Hardening
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 5
+
+## Purpose
+
+Make eta-mu's test suite trustworthy enough that failures point to product regressions rather than local environment drift, stale generated files, or hidden test ordering assumptions.
+
+## Scope
+
+- root `pnpm test`
+- `@open-hax/eta-mu-cli` Vitest suite
+- `packages/eta-mu-runtime` CLJS/Vitest tests
+- `packages/eta-mu-extensions` CLJS tests
+- generated-file setup required before tests
+- known skipped/flaky tests and local-environment blockers
+
+## Work items
+
+- [ ] Run the full local test matrix from a clean checkout.
+- [ ] Identify tests that depend on SSH, clipboard, generated bins, network, or local shell state.
+- [ ] Fix deterministic local-environment leaks with explicit stubs or setup scripts.
+- [ ] Split slow or optional tests only when their gate is named and documented.
+- [ ] Improve failure summaries for CI logs where current output hides the failing package.
+- [ ] Update blocker ledger for any failures not fixed in this slice.
+
+## Acceptance criteria
+
+- [ ] `pnpm test` passes from a clean checkout after documented setup.
+- [ ] `pnpm --filter @open-hax/eta-mu-cli test` passes without relying on host-specific SSH/clipboard state.
+- [ ] Generated bin/dist prerequisites are either built by pretest hooks or tested with clear errors.
+- [ ] Any skipped/flaky tests have explicit rationale.
+- [ ] No unrelated workspace dirt is staged.
+
+## Verification
+
+```bash
+pnpm install --offline --frozen-lockfile
+pnpm --filter @open-hax/eta-mu-cli test
+pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-extensions test
+pnpm test
+git diff --check
+```


### PR DESCRIPTION
## Summary
- add a quality-ratchet Kanban epic for delinting, warning cleanup, and testing
- break the work into six child tasks: baseline inventory, extension warnings, CLI startup smoke, lint gates, test hardening, and coverage expansion
- encode one-PR-per-task and OpenCode/CodeRabbit review expectations in the epic

## Verification
- python frontmatter smoke over the new epic/tasks
- git diff --check

## Notes
- `eta-mu kanban count --tasks-dir kanban/tasks` could not run locally because `@open-hax/kanban-legacy` was not installed in this checkout.
- This PR is planning-only; no source/runtime behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added quality improvement initiative documentation with detailed planning, task definitions, acceptance criteria, and verification procedures for reliability enhancements, test suite hardening, coverage expansion, and build quality processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->