### PR TITLE
fix(extensions): enforce zero-warning build

### DIFF
--- a/kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-extension-warning-cleanup.md
@@ -1,7 +1,7 @@
 ---
 uuid: "eta-mu-quality-ratchet-extension-warning-cleanup"
 title: "Eta-mu Quality Ratchet — Extension Warning Cleanup"
-status: todo
+status: review
 priority: P0
 labels: ["tasks", "quality", "cljs", "warnings", "eta-mu-extensions", "5sp"]
 created_at: "2026-05-31T00:45:00Z"
@@ -28,18 +28,18 @@ Make `packages/eta-mu-extensions` builds stop normalizing CLJS infer warnings as
 
 ## Work items
 
-- [ ] Reproduce current extension warning output from a clean checkout.
-- [ ] Fix target inference warnings by adding type hints, extracting JS interop helpers, or moving raw host access behind named adapter helpers.
-- [ ] Avoid broad rewrites of extension behavior.
-- [ ] Add a narrow warning assertion or documented baseline so warnings cannot grow silently.
-- [ ] Keep generated `dist/` artifacts out of source commits unless the task explicitly requires them.
+- [x] Reproduce current extension warning output from a clean checkout.
+- [x] Fix target inference warnings by adding type hints, extracting JS interop helpers, or moving raw host access behind named adapter helpers.
+- [x] Avoid broad rewrites of extension behavior.
+- [x] Add a narrow warning assertion or documented baseline so warnings cannot grow silently.
+- [x] Keep generated `dist/` artifacts out of source commits unless the task explicitly requires them.
 
 ## Acceptance criteria
 
-- [ ] `pnpm --dir packages/eta-mu-extensions build` emits zero warnings, or any remaining warning is captured in a blocker ledger with owner and rationale.
-- [ ] `pnpm --dir packages/eta-mu-extensions test` passes.
+- [x] `pnpm --dir packages/eta-mu-extensions build` emits zero warnings, or any remaining warning is captured in a blocker ledger with owner and rationale.
+- [x] `pnpm --dir packages/eta-mu-extensions test` passes.
 - [ ] OpenCode review confirms no behavior drift in extension registration.
-- [ ] No unrelated workspace dirt is staged.
+- [x] No unrelated workspace dirt is staged.
 
 ## Verification
 
@@ -49,3 +49,18 @@ pnpm --dir packages/eta-mu-extensions test
 pnpm --dir packages/eta-mu-extensions build
 git diff --check
 ```
+
+## Verification results
+
+- `pnpm install --frozen-lockfile`: passed.
+- Baseline from `docs/eta-mu-quality-ratchet-baseline-inventory.md`: extension release build emitted 210 CLJS infer warnings across `task_timing.cljs` and `lib/eta_mu/opencode.cljs`.
+- `pnpm --dir packages/eta-mu-extensions test`: passed; 72 tests, 195 assertions, 0 failures/errors, 0 warnings.
+- `pnpm --dir packages/eta-mu-extensions build`: passed with the warning ratchet wrapper; all pi and OpenCode extension targets emitted `0 warnings`.
+- `git diff --check`: passed.
+
+## Implementation notes
+
+- Replaced direct UI dot interop in `task_timing.cljs` with named `ui-set-status!` and `ui-notify!` helpers using typed JS function calls.
+- Added typed Zod/OpenCode adapter helpers in `lib/eta_mu/opencode.cljs` to remove schema-builder target inference warnings without changing plugin surface behavior.
+- Added `scripts/build-no-warnings.mjs` and routed the package `build` script through it so future release builds fail if shadow-cljs warnings return.
+- Left generated `dist/`, `.shadow-cljs/`, `target/`, and `node_modules/` artifacts untracked.

--- a/packages/eta-mu-extensions/lib/eta_mu/opencode.cljs
+++ b/packages/eta-mu-extensions/lib/eta_mu/opencode.cljs
@@ -9,49 +9,45 @@
 
 ;; ── Zod schema helpers ─────────────────────────────────────────────────────
 
-(defn- ->zod [z schema]
+(defn- describe-if [base description]
+  (if description
+    (.describe ^js base description)
+    base))
+
+(defn- ->zod [^js z schema]
   "Convert a JSON Schema map to a Zod schema object at runtime."
   (let [type* (aget schema "type")
         enum* (aget schema "enum")
-        desc* (aget schema "description")
-        min* (aget schema "min")
-        max* (aget schema "max")]
+        desc* (aget schema "description")]
     (cond
       (and enum* (pos? (alength enum*)))
-      (let [base (.apply (.-enum z) z enum*)]
-        (if desc* (.describe base desc*) base))
+      (describe-if (.apply ^js (aget z "enum") z enum*) desc*)
 
       (= type* "string")
-      (let [base (.string z)]
-        (if desc* (.describe base desc*) base))
+      (describe-if (.string z) desc*)
 
       (= type* "number")
-      (let [base (.number z)]
-        (if desc* (.describe base desc*) base))
+      (describe-if (.number z) desc*)
 
       (= type* "integer")
-      (let [base (.number z)]
-        (if desc* (.describe base desc*) base))
+      (describe-if (.number z) desc*)
 
       (= type* "boolean")
-      (let [base (.boolean z)]
-        (if desc* (.describe base desc*) base))
+      (describe-if (.boolean z) desc*)
 
       (= type* "array")
-      (let [base (.array z (.any z))]
-        (if desc* (.describe base desc*) base))
+      (describe-if (.array z (.any z)) desc*)
 
       :else
-      (let [base (.any z)]
-        (if desc* (.describe base desc*) base)))))
+      (describe-if (.any z) desc*))))
 
-(defn- build-args-schema [z params]
+(defn- build-args-schema [^js z params]
   "Build an OpenCode tool args shape from eta-mu parameter specs.
    @opencode-ai/plugin/tool expects a raw Zod shape object, not z.object(...)."
   (let [shape (js-obj)]
     (doseq [[k spec] params]
       (let [field (->zod z (clj->js (dissoc spec :optional)))]
-        (aset shape (name k) (if (:optional spec) (.optional field) field))))
+        (aset shape (name k) (if (:optional spec) (.optional ^js field) field))))
     shape))
 
 ;; ── Context adaptation ─────────────────────────────────────────────────────
@@ -97,8 +93,8 @@
   return values. step returns the next accumulator."
   [handlers initial step]
   (reduce (fn [p handler]
-            (.then p (fn [acc]
-                       (->promise (step acc handler)))))
+            (.then ^js p (fn [acc]
+                           (->promise (step acc handler)))))
           (js/Promise.resolve initial)
           handlers))
 
@@ -118,11 +114,17 @@
 (defn- set-output-system! [output system-prompt]
   (aset output "system" #js [system-prompt]))
 
+(defn- event-type [ev]
+  (aget (aget ev "event") "type"))
+
+(defn- event-payload [ev]
+  (aget ev "event"))
+
 ;; ── Plugin builders ────────────────────────────────────────────────────────
 
 (defn build-tool [tool-helper spec]
   "Create an OpenCode tool definition from an eta-mu tool spec."
-  (let [z (.-schema tool-helper)
+  (let [z (aget tool-helper "schema")
         params (:parameters spec)
         exec (:execute spec)]
     (tool-helper
@@ -136,11 +138,10 @@
   This preserves direct OpenCode SDK events while dedicated hook translators
   below handle pi lifecycle events with return-value propagation."
   (fn [ev]
-    (let [event-type (.. ev -event -type)
-          handlers (event-handlers events event-type)]
+    (let [handlers (event-handlers events (event-type ev))]
       (when (seq handlers)
         (doseq [handler handlers]
-          (handler (.. ev -event) #js {}))))))
+          (handler (event-payload ev) #js {}))))))
 
 (defn- build-system-transform-hook [input events]
   (let [turn-start-handlers (event-handlers events "turn_start")
@@ -165,7 +166,7 @@
                                      (fn [system-prompt handler]
                                        ;; Keep return-value propagation local to the handler while
                                        ;; allowing nil/no-op handlers.
-                                       (.then (->promise (handler (before-event system-prompt) pi-ctx))
+                                       (.then ^js (->promise (handler (before-event system-prompt) pi-ctx))
                                               (fn [result]
                                                 (or (when result
                                                       (aget result "systemPrompt"))
@@ -179,13 +180,13 @@
       (fn [_hook-input output]
         (let [ctx (hook-ctx input #js {})
               pi-ctx (adapt-ctx ctx)]
-          (.then (run-handlers handlers (aget output "messages")
-                               (fn [messages handler]
-                                 (.then (->promise (handler #js {:messages messages} pi-ctx))
-                                        (fn [result]
-                                          (or (when result
-                                                (aget result "messages"))
-                                              messages)))))
+          (.then ^js (run-handlers handlers (aget output "messages")
+                                   (fn [messages handler]
+                                     (.then ^js (->promise (handler #js {:messages messages} pi-ctx))
+                                            (fn [result]
+                                              (or (when result
+                                                    (aget result "messages"))
+                                                  messages)))))
                  (fn [messages]
                    (aset output "messages" messages))))))))
 

--- a/packages/eta-mu-extensions/package.json
+++ b/packages/eta-mu-extensions/package.json
@@ -9,7 +9,7 @@
     "manifest.edn"
   ],
   "scripts": {
-    "build": "node scripts/build.mjs release",
+    "build": "node scripts/build-no-warnings.mjs release",
     "watch": "node scripts/build.mjs watch",
     "clean": "node scripts/build.mjs clean",
     "test": "shadow-cljs compile node-test && node target/test.cjs",

--- a/packages/eta-mu-extensions/scripts/build-no-warnings.mjs
+++ b/packages/eta-mu-extensions/scripts/build-no-warnings.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const args = process.argv.slice(2);
+const child = spawn(process.execPath, ["scripts/build.mjs", ...args], {
+  cwd: new URL("..", import.meta.url),
+  env: process.env,
+  stdio: ["inherit", "pipe", "pipe"],
+});
+
+let output = "";
+const capture = (chunk, stream) => {
+  const text = chunk.toString();
+  output += text;
+  stream.write(text);
+};
+
+child.stdout.on("data", (chunk) => capture(chunk, process.stdout));
+child.stderr.on("data", (chunk) => capture(chunk, process.stderr));
+
+child.on("close", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  if (code !== 0) {
+    process.exit(code ?? 1);
+    return;
+  }
+
+  const normalized = output.replace(/\u001b\[[0-9;]*m/g, "");
+  if (/------ WARNING|:infer-warning|WARNING #/.test(normalized)) {
+    console.error("eta-mu-extensions build warning ratchet failed: build emitted warnings.");
+    process.exit(1);
+    return;
+  }
+
+  process.exit(0);
+});

--- a/packages/eta-mu-extensions/src/eta_mu/extensions/task_timing.cljs
+++ b/packages/eta-mu-extensions/src/eta_mu/extensions/task_timing.cljs
@@ -13,7 +13,7 @@
 (def STATUS-KEY "task-timing")
 
 (defn get-state []
-  (let [g (.-globalThis js/globalThis)]
+  (let [g js/globalThis]
     (if (aget g GLOBAL-KEY)
       (aget g GLOBAL-KEY)
       (let [fresh #js {:enabled true
@@ -25,9 +25,23 @@
         fresh))))
 
 (defn clear-interval-safe [state]
-  (when (.-interval state)
-    (js/clearInterval (.-interval state))
+  (when-let [interval (aget state "interval")]
+    (js/clearInterval interval)
     (aset state "interval" nil)))
+
+(defn- ui-handle [ctx]
+  (when (and ctx (aget ctx "hasUI"))
+    (aget ctx "ui")))
+
+(defn- ui-set-status! [ctx value]
+  (when-let [ui (ui-handle ctx)]
+    (when-let [set-status (aget ui "setStatus")]
+      (.call ^js set-status ui STATUS-KEY value))))
+
+(defn- ui-notify! [ctx message level]
+  (when-let [ui (ui-handle ctx)]
+    (when-let [notify (aget ui "notify")]
+      (.call ^js notify ui message level))))
 
 (defn fmt-ms [ms]
   (let [ms (if (and (number? ms) (>= ms 0)) ms 0)]
@@ -68,19 +82,16 @@
 
 (defn refresh-ui [state]
   (when (and (aget state "enabled")
-             (aget state "running")
-             (.-hasUI (aget state "ctx")))
-    (let [ctx (aget state "ctx")
-          now (js/performance.now)]
-      (.setStatus (.-ui ctx) STATUS-KEY (render-status state now)))))
+             (aget state "running"))
+    (when-let [ctx (aget state "ctx")]
+      (ui-set-status! ctx (render-status state (js/performance.now))))))
 
 (defn stop-and-finalize-ui [state]
-  (when (.-hasUI (aget state "ctx"))
-    (let [ctx (aget state "ctx")]
-      (if (not (aget state "enabled"))
-        (.setStatus (.-ui ctx) STATUS-KEY js/undefined)
-        (when (aget state "running")
-          (.setStatus (.-ui ctx) STATUS-KEY (render-status state (js/performance.now))))))))
+  (when-let [ctx (aget state "ctx")]
+    (if (not (aget state "enabled"))
+      (ui-set-status! ctx js/undefined)
+      (when (aget state "running")
+        (ui-set-status! ctx (render-status state (js/performance.now)))))))
 
 (defn start-ticker [state]
   (clear-interval-safe state)
@@ -106,10 +117,10 @@
                  (if (not (aget state "enabled"))
                    (do
                      (clear-interval-safe state)
-                     (.setStatus (.-ui ctx) STATUS-KEY js/undefined)
-                     (.notify (.-ui ctx) "Task timing: disabled" "info"))
+                     (ui-set-status! ctx js/undefined)
+                     (ui-notify! ctx "Task timing: disabled" "info"))
                    (do
-                     (.notify (.-ui ctx) "Task timing: enabled" "info")
+                     (ui-notify! ctx "Task timing: enabled" "info")
                      (when (aget state "running")
                        (aset state "ctx" ctx)
                        (start-ticker state)
@@ -126,10 +137,9 @@
                  (aset state "toolSegmentStartMs" nil)
                  (aset state "toolWaitTotalMs" 0)
                  (if (not (aget state "enabled"))
-                   (when (.-hasUI ctx)
-                     (.setStatus (.-ui ctx) STATUS-KEY js/undefined))
-                   (when (.-hasUI ctx)
-                     (.setStatus (.-ui ctx) STATUS-KEY (render-status state (js/performance.now)))
+                   (ui-set-status! ctx js/undefined)
+                   (do
+                     (ui-set-status! ctx (render-status state (js/performance.now)))
                      (start-ticker state))))))
 
   (em/on "tool_execution_start"
@@ -178,5 +188,4 @@
                  (aset state "toolActiveCount" 0)
                  (aset state "toolSegmentStartMs" nil)
                  (aset state "toolWaitTotalMs" 0)
-                 (when (.-hasUI ctx)
-                   (.setStatus (.-ui ctx) STATUS-KEY js/undefined))))))
+                 (ui-set-status! ctx js/undefined)))))


### PR DESCRIPTION
## Summary
- remove the 210 extension release-build CLJS infer warnings by adding typed UI and OpenCode/Zod adapter helpers
- route the eta-mu-extensions build script through a warning-ratchet wrapper that fails if shadow-cljs warnings return
- mark the extension warning cleanup Kanban task ready for review with verification evidence

## Verification
- pnpm install --frozen-lockfile
- pnpm --dir packages/eta-mu-extensions test
- pnpm --dir packages/eta-mu-extensions build
- python frontmatter smoke for the updated task
- git diff --check

## Notes
- `dist/`, `.shadow-cljs/`, `target/`, and `node_modules/` artifacts were generated locally but left untracked.
- Public extension manifest/output names are unchanged.