### PR TITLE
feat: sync kanban cards to GitHub issues

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -763,6 +763,7 @@ export async function main(args: string[], options?: MainOptions) {
  * Supports:
  *   eta-mu kanban serve [--tasks-dir <path>] [--port <port>] [--config <path>]
  *   eta-mu kanban board snapshot [--tasks-dir <path>] [--out <path>] [--config <path>]
+ *   eta-mu kanban sync github [--tasks-dir <path>] [--repo <owner/repo>] [--dry-run] [--config <path>]
  *   eta-mu kanban list [--tasks-dir <path>] [--config <path>]
  *   eta-mu kanban find <uuid> [--tasks-dir <path>] [--config <path>]
  *   eta-mu kanban search <query> [--tasks-dir <path>] [--config <path>]
@@ -1012,6 +1013,7 @@ function printKanbanHelp(): void {
 	console.log(`  serve                          Start the kanban web UI`);
 	console.log(`  board snapshot                 Generate board snapshot JSON`);
 	console.log(`  sync trello                    Sync tasks to Trello`);
+	console.log(`  sync github                    Sync tasks to GitHub issues`);
 	console.log(`  list                           List all tasks`);
 	console.log(`  find <uuid>                    Find task by UUID`);
 	console.log(`  search <query>                 Search tasks by title/content`);

--- a/packages/kanban/src/cli.ts
+++ b/packages/kanban/src/cli.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { buildBoardSnapshot, writeBoardSnapshot } from "./board.js";
 import { loadConfig, loadEnvironment, resolveConfigPathValue, resolveConfiguredProjects } from "./config.js";
 import { startKanbanServer } from "./server.js";
+import { GitHubClient, inferGitHubRepo, syncTasksToGitHub } from "./github-sync.js";
 import { syncTasksToTrello } from "./sync.js";
 import { loadTasks } from "./tasks.js";
 import { TrelloClient } from "./trello-client.js";
@@ -23,6 +24,7 @@ const showHelp = (): void => {
 USAGE
   openhax-kanban board snapshot [--tasks-dir <path>] [--out <path>] [--config <path>]
   openhax-kanban sync trello [--tasks-dir <path>] [--board-url <url>] [--board-id <id>] [--dry-run] [--archive-missing] [--config <path>]
+  openhax-kanban sync github [--tasks-dir <path>] [--repo <owner/repo>] [--dry-run] [--write-delay-ms <ms>] [--max-writes <n>] [--no-close-done] [--no-close-rejected] [--no-manage-labels] [--config <path>]
   openhax-kanban serve [--tasks-dir <path>] [--host <host>] [--port <port>] [--config <path>]
 
 MULTI-PROJECT CONFIG
@@ -43,6 +45,12 @@ FLAGS
   --board-id <id>         Trello board short id or id
   --dry-run               Print sync plan without mutating Trello
   --archive-missing       Archive Trello cards with known UUIDs that are missing locally
+  --repo <owner/repo>      GitHub repository target for sync github
+  --no-close-done         Keep done tasks open during GitHub sync
+  --no-close-rejected     Keep rejected tasks open during GitHub sync
+  --no-manage-labels      Do not create missing GitHub labels
+  --write-delay-ms <ms>   Delay between GitHub writes to avoid secondary rate limits
+  --max-writes <n>        Stop after applying this many GitHub write operations
   --host <host>           Host to bind the local web UI (default: 127.0.0.1)
   --port <port>           Port to bind the local web UI (default: 8787)
   --help                  Show this help
@@ -130,6 +138,32 @@ const printSyncPlan = (result: Awaited<ReturnType<typeof syncTasksToTrello>>, dr
   });
 };
 
+const printGitHubSyncPlan = (result: Awaited<ReturnType<typeof syncTasksToGitHub>>, dryRun: boolean): void => {
+  console.log(`${dryRun ? "Dry-run" : "Live"} GitHub issue sync for ${result.repo}`);
+  console.log(`Operations: ${result.plan.operations.length}`);
+  console.log(`- Create labels: ${result.plan.summary.createLabels}`);
+  console.log(`- Create issues: ${result.plan.summary.createIssues}`);
+  console.log(`- Update issues: ${result.plan.summary.updateIssues}`);
+  console.log(`- Skip done/rejected tasks without existing issues: ${result.plan.summary.skippedClosedTasks}`);
+  if (!dryRun) {
+    console.log(`- Applied operations: ${result.appliedOperations.length}`);
+  }
+
+  result.plan.operations.forEach((operation) => {
+    switch (operation.type) {
+      case "createLabel":
+        console.log(`  + label ${operation.label.name}`);
+        break;
+      case "createIssue":
+        console.log(`  + issue ${operation.task.title}`);
+        break;
+      case "updateIssue":
+        console.log(`  ~ issue #${operation.issueNumber} ${operation.task.title} -> ${operation.state}`);
+        break;
+    }
+  });
+};
+
 const main = async (): Promise<void> => {
   loadEnvironment();
 
@@ -194,6 +228,39 @@ const main = async (): Promise<void> => {
     });
 
     printSyncPlan(result, dryRun);
+    return;
+  }
+
+  if (parsedCli.command === "sync" && parsedCli.subcommand === "github") {
+    const tasks = await loadTasks(tasksDir);
+    const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+    if (!token) {
+      throw new Error("Missing GITHUB_TOKEN or GH_TOKEN.");
+    }
+
+    const repo =
+      readStringFlag(parsedCli.flags, "repo") ??
+      loadedConfig.config.github?.repo ??
+      inferGitHubRepo(tasksDir);
+
+    if (!repo) {
+      throw new Error("Missing GitHub repo target. Pass --repo, set github.repo in config, or run inside a GitHub-backed repository.");
+    }
+
+    const dryRun = parsedCli.flags["dry-run"] === true;
+    const client = new GitHubClient({ token });
+    const result = await syncTasksToGitHub(client, tasks, {
+      repo,
+      dryRun,
+      cwd: process.cwd(),
+      closeDone: parsedCli.flags["no-close-done"] === true ? false : loadedConfig.config.github?.closeDone,
+      closeRejected: parsedCli.flags["no-close-rejected"] === true ? false : loadedConfig.config.github?.closeRejected,
+      manageLabels: parsedCli.flags["no-manage-labels"] === true ? false : loadedConfig.config.github?.manageLabels,
+      writeDelayMs: readNumberFlag(parsedCli.flags, "write-delay-ms"),
+      maxWrites: readNumberFlag(parsedCli.flags, "max-writes")
+    });
+
+    printGitHubSyncPlan(result, dryRun);
     return;
   }
 

--- a/packages/kanban/src/github-sync.ts
+++ b/packages/kanban/src/github-sync.ts
@@ -1,0 +1,456 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import type { KanbanTask } from "./types.js";
+
+export interface GitHubAuthConfig {
+  token: string;
+  baseUrl?: string;
+}
+
+export interface GitHubLabelState {
+  name: string;
+  color?: string;
+  description?: string | null;
+}
+
+export interface GitHubIssueState {
+  number: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  labels: GitHubLabelState[];
+  htmlUrl?: string;
+}
+
+export interface GitHubRepoState {
+  labels: GitHubLabelState[];
+  issues: GitHubIssueState[];
+}
+
+export interface GitHubSyncOptions {
+  repo: string;
+  dryRun?: boolean;
+  closeDone?: boolean;
+  closeRejected?: boolean;
+  manageLabels?: boolean;
+  cwd?: string;
+  writeDelayMs?: number;
+  maxWrites?: number;
+}
+
+export type GitHubSyncOperation =
+  | {
+      type: "createLabel";
+      label: GitHubLabelState;
+    }
+  | {
+      type: "createIssue";
+      task: KanbanTask;
+      title: string;
+      body: string;
+      labels: string[];
+    }
+  | {
+      type: "updateIssue";
+      issueNumber: number;
+      task: KanbanTask;
+      title: string;
+      body: string;
+      labels: string[];
+      state: "open" | "closed";
+      stateReason?: "completed" | "not_planned";
+    };
+
+export interface GitHubSyncPlan {
+  operations: GitHubSyncOperation[];
+  summary: {
+    createLabels: number;
+    createIssues: number;
+    updateIssues: number;
+    skippedClosedTasks: number;
+  };
+}
+
+export interface GitHubSyncResult {
+  repo: string;
+  plan: GitHubSyncPlan;
+  appliedOperations: GitHubSyncOperation[];
+}
+
+const uuidMarkerPrefix = "openhax-kanban-sync";
+const uuidMarkerPattern = /<!--\s*openhax-kanban-sync\s+uuid="([^"]+)"\s*-->/u;
+
+const defaultLabelColors: Record<string, string> = {
+  kanban: "5319e7",
+  "priority:P0": "000000",
+  "priority:P1": "d93f0b",
+  "priority:P2": "fbca04",
+  "priority:P3": "0e8a16"
+};
+
+const statusColor = "cfd3d7";
+const defaultTaskLabelColor = "ededed";
+
+const normalizeGitHubLabelName = (label: string): string =>
+  label
+    .trim()
+    .replace(/\s+/gu, "-")
+    .replace(/[^\p{L}\p{N}_.:/-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 50);
+
+const unique = <T>(items: T[]): T[] => Array.from(new Set(items));
+
+export const extractTaskUuidFromIssue = (issue: Pick<GitHubIssueState, "body">): string | undefined => {
+  const body = issue.body ?? "";
+  const markerMatch = body.match(uuidMarkerPattern);
+  if (markerMatch?.[1]) {
+    return markerMatch[1];
+  }
+
+  const legacyMatch = body.match(/^Kanban UUID:\s*(.+)$/imu);
+  return legacyMatch?.[1]?.trim();
+};
+
+export const desiredIssueLabels = (task: KanbanTask): string[] =>
+  unique(
+    [
+      "kanban",
+      `status:${task.status}`,
+      task.priority ? `priority:${task.priority}` : undefined,
+      ...task.labels
+    ]
+      .filter((label): label is string => Boolean(label?.trim()))
+      .map(normalizeGitHubLabelName)
+      .filter((label) => label.length > 0)
+  );
+
+export const labelStateForName = (name: string): GitHubLabelState => ({
+  name,
+  color: defaultLabelColors[name] ?? (name.startsWith("status:") ? statusColor : defaultTaskLabelColor),
+  description: name === "kanban" ? "Synced from OpenHax markdown kanban." : undefined
+});
+
+const relativeSourcePath = (task: KanbanTask, cwd: string): string => {
+  const relative = path.relative(cwd, task.sourcePath);
+  return relative.startsWith("..") ? task.sourcePath : relative;
+};
+
+const truncateBody = (body: string): string => (body.length <= 58_000 ? body : `${body.slice(0, 57_900)}\n\n… truncated by kanban sync …\n`);
+
+export const buildIssueBody = (task: KanbanTask, options: { cwd?: string } = {}): string => {
+  const cwd = options.cwd ?? process.cwd();
+  const sourcePath = relativeSourcePath(task, cwd);
+  const header = [
+    `<!-- ${uuidMarkerPrefix} uuid="${task.uuid}" -->`,
+    "<!-- This section is managed by eta-mu kanban sync github. -->",
+    "",
+    "## Kanban metadata",
+    "",
+    `- UUID: \`${task.uuid}\``,
+    `- Status: \`${task.status}\``,
+    `- Priority: \`${task.priority}\``,
+    `- Source: \`${sourcePath}\``,
+    task.labels.length > 0 ? `- Labels: ${task.labels.map((label) => `\`${label}\``).join(", ")}` : "- Labels: none",
+    "",
+    "---",
+    ""
+  ].join("\n");
+
+  return truncateBody(`${header}${task.content.trim()}\n`);
+};
+
+const desiredIssueState = (
+  task: KanbanTask,
+  options: Pick<GitHubSyncOptions, "closeDone" | "closeRejected">
+): { state: "open" | "closed"; stateReason?: "completed" | "not_planned" } => {
+  if (task.status === "done" && options.closeDone !== false) {
+    return { state: "closed", stateReason: "completed" };
+  }
+
+  if (task.status === "rejected" && options.closeRejected !== false) {
+    return { state: "closed", stateReason: "not_planned" };
+  }
+
+  return { state: "open" };
+};
+
+const sameLabels = (current: string[], desired: string[]): boolean => {
+  const left = [...current].sort();
+  const right = [...desired].sort();
+  return left.length === right.length && left.every((label, index) => label === right[index]);
+};
+
+export const planGitHubIssueSync = (
+  tasks: KanbanTask[],
+  state: GitHubRepoState,
+  options: GitHubSyncOptions
+): GitHubSyncPlan => {
+  const operations: GitHubSyncOperation[] = [];
+  const existingLabels = new Set(state.labels.map((label) => label.name.toLowerCase()));
+  const issuesByUuid = new Map<string, GitHubIssueState>();
+  let skippedClosedTasks = 0;
+
+  for (const issue of state.issues) {
+    const uuid = extractTaskUuidFromIssue(issue);
+    if (uuid) {
+      issuesByUuid.set(uuid, issue);
+    }
+  }
+
+  const desiredLabels = unique(tasks.flatMap(desiredIssueLabels));
+  if (options.manageLabels !== false) {
+    for (const labelName of desiredLabels) {
+      if (!existingLabels.has(labelName.toLowerCase())) {
+        operations.push({ type: "createLabel", label: labelStateForName(labelName) });
+      }
+    }
+  }
+
+  for (const task of tasks) {
+    const issue = issuesByUuid.get(task.uuid);
+    const labels = desiredIssueLabels(task);
+    const title = task.title;
+    const body = buildIssueBody(task, { cwd: options.cwd });
+    const desiredState = desiredIssueState(task, options);
+
+    if (!issue) {
+      if (desiredState.state === "closed") {
+        skippedClosedTasks += 1;
+        continue;
+      }
+
+      operations.push({ type: "createIssue", task, title, body, labels });
+      continue;
+    }
+
+    const currentLabels = issue.labels.map((label) => label.name);
+    if (
+      issue.title !== title ||
+      (issue.body ?? "") !== body ||
+      issue.state !== desiredState.state ||
+      !sameLabels(currentLabels, labels)
+    ) {
+      operations.push({
+        type: "updateIssue",
+        issueNumber: issue.number,
+        task,
+        title,
+        body,
+        labels,
+        state: desiredState.state,
+        stateReason: desiredState.stateReason
+      });
+    }
+  }
+
+  return {
+    operations,
+    summary: {
+      createLabels: operations.filter((operation) => operation.type === "createLabel").length,
+      createIssues: operations.filter((operation) => operation.type === "createIssue").length,
+      updateIssues: operations.filter((operation) => operation.type === "updateIssue").length,
+      skippedClosedTasks
+    }
+  };
+};
+
+const parseLinkHeader = (linkHeader: string | null): string | undefined => {
+  if (!linkHeader) return undefined;
+  const next = linkHeader
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => part.endsWith('rel="next"'));
+  const match = next?.match(/^<([^>]+)>/u);
+  return match?.[1];
+};
+
+export class GitHubClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+
+  constructor(config: GitHubAuthConfig) {
+    this.token = config.token;
+    this.baseUrl = config.baseUrl ?? "https://api.github.com";
+  }
+
+  private async request<T>(endpointOrUrl: string, init: RequestInit = {}): Promise<T> {
+    const url = endpointOrUrl.startsWith("http") ? endpointOrUrl : `${this.baseUrl}${endpointOrUrl}`;
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${this.token}`,
+        "x-github-api-version": "2022-11-28",
+        ...(init.headers ?? {})
+      }
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`GitHub API ${response.status} ${response.statusText}: ${body}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private async paginate<T>(endpoint: string): Promise<T[]> {
+    const items: T[] = [];
+    let nextUrl: string | undefined = `${this.baseUrl}${endpoint}`;
+
+    while (nextUrl) {
+      const response = await fetch(nextUrl, {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${this.token}`,
+          "x-github-api-version": "2022-11-28"
+        }
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`GitHub API ${response.status} ${response.statusText}: ${body}`);
+      }
+
+      items.push(...((await response.json()) as T[]));
+      nextUrl = parseLinkHeader(response.headers.get("link"));
+    }
+
+    return items;
+  }
+
+  async getLabels(repo: string): Promise<GitHubLabelState[]> {
+    return this.paginate<GitHubLabelState>(`/repos/${repo}/labels?per_page=100`);
+  }
+
+  async getIssues(repo: string): Promise<GitHubIssueState[]> {
+    const issues = await this.paginate<{
+      number: number;
+      title: string;
+      body: string | null;
+      state: "open" | "closed";
+      labels: GitHubLabelState[];
+      html_url: string;
+      pull_request?: unknown;
+    }>(`/repos/${repo}/issues?state=all&per_page=100`);
+
+    return issues
+      .filter((issue) => !issue.pull_request)
+      .map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        body: issue.body,
+        state: issue.state,
+        labels: issue.labels,
+        htmlUrl: issue.html_url
+      }));
+  }
+
+  async createLabel(repo: string, label: GitHubLabelState): Promise<void> {
+    try {
+      await this.request(`/repos/${repo}/labels`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(label)
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes("already_exists") && !message.includes("Validation Failed")) {
+        throw error;
+      }
+    }
+  }
+
+  async createIssue(repo: string, input: { title: string; body: string; labels: string[] }): Promise<void> {
+    await this.request(`/repos/${repo}/issues`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input)
+    });
+  }
+
+  async updateIssue(
+    repo: string,
+    issueNumber: number,
+    input: { title: string; body: string; labels: string[]; state: "open" | "closed"; state_reason?: string }
+  ): Promise<void> {
+    await this.request(`/repos/${repo}/issues/${issueNumber}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input)
+    });
+  }
+}
+
+export const inferGitHubRepo = (cwd: string): string | undefined => {
+  try {
+    const remoteUrl = execFileSync("git", ["-C", cwd, "remote", "get-url", "origin"], { encoding: "utf8" }).trim();
+    const match =
+      remoteUrl.match(/^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/u) ??
+      remoteUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?\/?$/u);
+    return match?.[1]?.replace(/\.git$/u, "");
+  } catch {
+    return undefined;
+  }
+};
+
+const sleep = (milliseconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export const syncTasksToGitHub = async (
+  client: GitHubClient,
+  tasks: KanbanTask[],
+  options: GitHubSyncOptions
+): Promise<GitHubSyncResult> => {
+  const repoState: GitHubRepoState = {
+    labels: await client.getLabels(options.repo),
+    issues: await client.getIssues(options.repo)
+  };
+  const plan = planGitHubIssueSync(tasks, repoState, options);
+  const appliedOperations: GitHubSyncOperation[] = [];
+  const maxWrites = options.maxWrites ?? Number.POSITIVE_INFINITY;
+  const writeDelayMs = options.writeDelayMs ?? 0;
+
+  if (!options.dryRun) {
+    for (const operation of plan.operations) {
+      if (appliedOperations.length >= maxWrites) {
+        break;
+      }
+
+      switch (operation.type) {
+        case "createLabel":
+          await client.createLabel(options.repo, operation.label);
+          appliedOperations.push(operation);
+          break;
+        case "createIssue":
+          await client.createIssue(options.repo, {
+            title: operation.title,
+            body: operation.body,
+            labels: operation.labels
+          });
+          appliedOperations.push(operation);
+          break;
+        case "updateIssue":
+          await client.updateIssue(options.repo, operation.issueNumber, {
+            title: operation.title,
+            body: operation.body,
+            labels: operation.labels,
+            state: operation.state,
+            state_reason: operation.stateReason
+          });
+          appliedOperations.push(operation);
+          break;
+      }
+
+      if (writeDelayMs > 0 && appliedOperations.length < maxWrites) {
+        await sleep(writeDelayMs);
+      }
+    }
+  }
+
+  return { repo: options.repo, plan, appliedOperations };
+};

--- a/packages/kanban/src/index.ts
+++ b/packages/kanban/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./board.js";
 export * from "./config.js";
 export * from "./sync.js";
+export * from "./github-sync.js";
 export * from "./tasks.js";
 export * from "./task-writeback.js";
 export * from "./server.js";

--- a/packages/kanban/src/types.ts
+++ b/packages/kanban/src/types.ts
@@ -68,6 +68,12 @@ export interface KanbanConfigFile {
     archiveMissing?: boolean;
     listMapping?: Record<string, string>;
   };
+  github?: {
+    repo?: string;
+    closeDone?: boolean;
+    closeRejected?: boolean;
+    manageLabels?: boolean;
+  };
 }
 
 export interface LoadedKanbanConfig {

--- a/packages/kanban/tests/github-sync.test.ts
+++ b/packages/kanban/tests/github-sync.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildIssueBody,
+  desiredIssueLabels,
+  extractTaskUuidFromIssue,
+  planGitHubIssueSync
+} from "../src/github-sync.js";
+import type { GitHubRepoState, KanbanTask } from "../src/index.js";
+
+const sampleTask: KanbanTask = {
+  uuid: "task-123",
+  title: "Sync Kanban to GitHub",
+  slug: "sync-kanban-to-github",
+  status: "in_progress",
+  priority: "P1",
+  labels: ["kanban sync", "github"],
+  createdAt: "2026-05-31T00:00:00.000Z",
+  content: "Create or update GitHub issues from markdown cards.",
+  sourcePath: "/workspace/kanban/sync-kanban.md"
+};
+
+describe("GitHub issue sync", () => {
+  it("embeds and reads a stable task UUID marker", () => {
+    const body = buildIssueBody(sampleTask, { cwd: "/workspace" });
+
+    expect(body).toContain('<!-- openhax-kanban-sync uuid="task-123" -->');
+    expect(body).toContain("`kanban/sync-kanban.md`");
+    expect(extractTaskUuidFromIssue({ body })).toBe("task-123");
+  });
+
+  it("normalizes labels from status, priority, and frontmatter labels", () => {
+    expect(desiredIssueLabels(sampleTask)).toEqual([
+      "kanban",
+      "status:in_progress",
+      "priority:P1",
+      "kanban-sync",
+      "github"
+    ]);
+  });
+
+  it("creates labels and issues for open tasks", () => {
+    const state: GitHubRepoState = { labels: [], issues: [] };
+    const plan = planGitHubIssueSync([sampleTask], state, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace"
+    });
+
+    expect(plan.summary.createLabels).toBe(5);
+    expect(plan.summary.createIssues).toBe(1);
+    expect(plan.summary.updateIssues).toBe(0);
+    expect(plan.operations.some((operation) => operation.type === "createIssue")).toBe(true);
+  });
+
+  it("updates existing issues by UUID and closes done tasks", () => {
+    const doneTask = { ...sampleTask, status: "done" };
+    const body = buildIssueBody(sampleTask, { cwd: "/workspace" });
+    const state: GitHubRepoState = {
+      labels: desiredIssueLabels(doneTask).map((name) => ({ name })),
+      issues: [
+        {
+          number: 42,
+          title: "Old title",
+          body,
+          state: "open",
+          labels: [{ name: "kanban" }]
+        }
+      ]
+    };
+    const plan = planGitHubIssueSync([doneTask], state, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace"
+    });
+
+    expect(plan.summary.createIssues).toBe(0);
+    expect(plan.summary.updateIssues).toBe(1);
+    expect(plan.operations).toContainEqual(
+      expect.objectContaining({
+        type: "updateIssue",
+        issueNumber: 42,
+        state: "closed",
+        stateReason: "completed"
+      })
+    );
+  });
+
+  it("does not create new closed issues for already-done local tasks", () => {
+    const doneTask = { ...sampleTask, status: "done" };
+    const state: GitHubRepoState = { labels: [], issues: [] };
+    const plan = planGitHubIssueSync([doneTask], state, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace"
+    });
+
+    expect(plan.summary.createIssues).toBe(0);
+    expect(plan.summary.skippedClosedTasks).toBe(1);
+  });
+});


### PR DESCRIPTION
Adds `eta-mu kanban sync github` / `openhax-kanban sync github` to create/update GitHub issues from markdown kanban tasks with status, priority, and task labels. Includes UUID markers for idempotency, skips creating already-done/rejected tasks, and adds throttling flags for GitHub secondary rate limits.\n\nLocal verification:\n- pnpm --filter @open-hax/kanban-legacy test\n- pnpm --filter @open-hax/kanban-legacy build\n- git diff --check on touched files\n\nNote: full @open-hax/eta-mu-cli build is currently blocked by an existing module-resolution issue for @open-hax/eta-mu-runtime/cljs in this checkout.