### PR TITLE
feat(runtime): Phase 2 — Runtime Core Contracts

### DIFF
--- a/docs/cljs-runtime-rewrite-runtime-core-plan.md
+++ b/docs/cljs-runtime-rewrite-runtime-core-plan.md
@@ -1,0 +1,227 @@
+# Eta-mu CLJS Runtime Rewrite — Runtime Core Port Plan
+
+Date: 2026-05-29
+Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+Kanban task: `kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md`
+Depends on: `docs/cljs-runtime-rewrite-shadow-spine-plan.md`
+Inventory: `docs/cljs-runtime-rewrite-architecture-inventory.md`
+
+## Purpose
+
+Define the first pure runtime domain to port after the CLJS spine exists. The goal is to move eta-mu's movement/state/envelope semantics into ClojureScript without dragging filesystem, provider SDK, terminal, browser, git, or OpenCode host effects into the first port.
+
+This is the rewrite's first real Knoxx-style domain/law/shape slice:
+
+- `domain.*`: decisions over already-normalized maps
+- `law.*`: schemas and guards
+- `shape.*`: compatibility transforms between JS public payloads and CLJS internal maps
+- `facade`: tiny JS-facing wrapper until public package cutover
+
+## Source slice
+
+Primary source package:
+
+- `packages/eta-mu-runtime/src/types.ts`
+- `packages/eta-mu-runtime/src/state.ts`
+- `packages/eta-mu-runtime/src/planner.ts`
+- `packages/eta-mu-runtime/src/envelope.ts`
+- `packages/eta-mu-runtime/src/index.ts`
+- `packages/eta-mu-runtime/tests/runtime.test.ts`
+
+Secondary follow-up source once the pure runtime slice passes:
+
+- `packages/coding-agent/src/core/messages.ts`
+- selected `packages/coding-agent/test/*message*.test.ts`
+- selected `packages/coding-agent/test/agent-session-*.test.ts` only where they assert pure data transformations rather than live agent I/O
+
+## Internal naming decision
+
+Use kebab-case keys inside CLJS and preserve camelCase at the JS facade boundary.
+
+Example:
+
+```clojure
+;; internal CLJS map
+{:social-friction 0.2
+ :deploy-risk 0.1
+ :user-intent-confidence 0.8}
+
+;; public JS payload remains compatible
+{"socialFriction" 0.2
+ "deployRisk" 0.1
+ "userIntentConfidence" 0.8}
+```
+
+Why:
+
+- CLJS domain/law code should be idiomatic and readable.
+- Existing TypeScript/JavaScript callers expect camelCase.
+- The `shape.*` layer makes the conversion visible and testable rather than scattered through domain code.
+
+## Target namespace map
+
+| Current TS source | Target CLJS namespace | Category | Notes |
+|---|---|---|---|
+| `types.ts` enum/string unions | `eta-mu.runtime.law.types` | law | Malli enums and shared scalar schemas. |
+| `types.ts` object schemas | `eta-mu.runtime.law.state`, `eta-mu.runtime.law.envelope`, `eta-mu.runtime.law.planning` | law | Split by meaning instead of one schema drawer. |
+| `state.ts` `DEFAULT_ETA_BELIEF` | `eta-mu.runtime.domain.state` | domain | Constant should use internal kebab keys. |
+| `state.ts` `createEtaBelief` | `eta-mu.runtime.domain.state/create-belief` | domain + law | Domain clamps; law validates final shape. |
+| `state.ts` `createBreathEpisode` | `eta-mu.runtime.domain.breath/create-episode` | domain | Time value is passed in; no hidden clock in pure domain. |
+| `state.ts` `createEtaMuState` | `eta-mu.runtime.domain.state/create-state` | domain | Current timestamp supplied by facade/infra if absent. |
+| `planner.ts` `selectPanelsFromContext` | `eta-mu.runtime.domain.planner/select-panels` | domain | Pure category rule over normalized context. |
+| `planner.ts` `rankCheapMuCandidates` | `eta-mu.runtime.domain.planner/rank-cheap-candidates` | domain | Deterministic candidate generation/ranking. |
+| `planner.ts` candidate helpers | `eta-mu.runtime.domain.candidate` | domain | ID, priority, and candidate construction. |
+| `envelope.ts` `recommendBreath` | `eta-mu.runtime.domain.breath/recommend` | domain | Breath decision over context and candidates. |
+| `envelope.ts` `createActionBatch` | `eta-mu.runtime.domain.envelope/create-action-batch` | domain | Builds batch, law validates output. |
+| TS/JS camelCase payloads | `eta-mu.runtime.shape.compat` | shape | JS in/out key conversion and defaulting. |
+| public ESM exports | `eta-mu.runtime.facade` | facade | Temporary JS-facing API until package cutover. |
+
+## Malli schema plan
+
+Minimum schema set:
+
+```clojure
+(def UnitInterval [:and number? [:>= 0] [:<= 1]])
+(def PanelName [:enum :field :movement :truth :trajectory :breath :memory :cost])
+(def CostClass [:enum :cheap :medium :expensive])
+(def Reversibility [:enum :easy :moderate :hard])
+(def MuCandidateKind [:enum :comment :summary :label :issue :patch-plan :patch
+                      :reroute :defer :request-evidence
+                      :request-human-attention :noop])
+```
+
+Then compose:
+
+- `EtaBelief`
+- `MuCandidate`
+- `BreathEpisode`
+- `EtaMuState`
+- `EtaMuPlanningContext`
+- `BreathRecommendation`
+- `EtaMuActionBatch`
+
+Validation rule:
+
+- Domain functions validate final outputs in tests and at facade boundaries.
+- Domain-internal helper functions should not parse JS payloads.
+- `shape.compat` owns camelCase/kebab-case and defaults.
+
+## Function parity contract
+
+The initial CLJS facade should expose functions equivalent to the current package surface:
+
+| Current public export | First CLJS facade export | Compatibility expectation |
+|---|---|---|
+| `createEtaBelief` | `createEtaBelief` | Clamps unit interval values and returns camelCase JS-compatible object. |
+| `createBreathEpisode` | `createBreathEpisode` | Preserves `openedAt`, `lastActivityAt`, `activityScalar`, `pendingCommit`. |
+| `createEtaMuState` | `createEtaMuState` | Default panels remain `field`, `movement`; episode default remains `episode:bootstrap`. |
+| `selectPanelsFromContext` | `selectPanelsFromContext` | Same panel ordering as current TS tests. |
+| `rankCheapMuCandidates` | `rankCheapMuCandidates` | Same candidate kinds and ranking. |
+| `recommendBreath` | `recommendBreath` | Same quiet-window and pending-commit behavior. |
+| `createActionBatch` | `createActionBatch` | Emits `kind: eta-mu-action-batch.v1`. |
+
+Public Typescript types stay generated/hand-authored during transition. Do not remove `.d.ts` compatibility until the cutover task.
+
+## Initial test parity
+
+Port the existing Vitest cases into CLJS test names:
+
+| Current test | CLJS test |
+|---|---|
+| `createEtaBelief clamps values into the unit interval` | `create-belief-clamps-unit-interval-test` |
+| `selectPanelsFromContext surfaces truth, trajectory, and breath under active pressure` | `select-panels-pressure-test` |
+| `rankCheapMuCandidates asks for evidence before stronger movement when ambiguity is high` | `rank-cheap-candidates-ambiguity-test` |
+| `createActionBatch emits a noop batch when no cheap movement is justified` | `create-action-batch-noop-test` |
+
+Add two new rewrite-specific tests:
+
+- `js-compat-roundtrip-test`: camelCase JS payload -> CLJS kebab map -> camelCase JS-compatible output.
+- `malformed-context-rejected-test`: a non-unit belief scalar or missing required planning context field fails with a structured error.
+
+## Coding-agent message core follow-up
+
+After `eta-mu-runtime` pure parity passes, extend the runtime core to cover message/content/session shapes used by `packages/coding-agent/src/core/messages.ts`.
+
+Target data:
+
+- Bash execution messages
+- Custom extension messages
+- Branch summary messages
+- Compaction summary messages
+- User/assistant/tool result passthrough messages
+- LLM-compatible message conversion
+- Text/image/audio/attachment content parts
+
+Target namespaces:
+
+```text
+eta_mu.runtime.law.message
+eta_mu.runtime.law.content_part
+eta_mu.runtime.shape.message
+eta_mu.runtime.domain.message
+eta_mu.runtime.domain.compaction_summary
+```
+
+Keep out of scope for this task:
+
+- `AgentSession` class lifecycle
+- filesystem session persistence
+- model/provider execution
+- extension runner host APIs
+- bash execution
+- TUI/web rendering
+
+Those belong to boundary-adapter and surface-parity tasks.
+
+## Execution sequence
+
+1. Implement the CLJS spine from `docs/cljs-runtime-rewrite-shadow-spine-plan.md`.
+2. Add Malli schemas and shape compat for eta-mu-runtime data.
+3. Port state/breath/planner/envelope pure functions.
+4. Add CLJS tests mirroring existing Vitest coverage.
+5. Add Node ESM smoke for JS import and camelCase public outputs.
+6. Run existing TS tests and typecheck.
+7. Only then consider JS wrapper changes or additional message/session shapes.
+
+## Verification commands
+
+```bash
+cd orgs/open-hax/eta-mu
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime cljs:verify
+```
+
+When the coding-agent message follow-up starts:
+
+```bash
+cd orgs/open-hax/eta-mu
+pnpm --filter @open-hax/eta-mu-cli test -- messages
+pnpm --filter @open-hax/eta-mu-cli test
+```
+
+If a filtered Vitest invocation is unsupported, run the full package test and record runtime.
+
+## Acceptance checklist
+
+- [x] Current eta-mu-runtime public functions have CLJS equivalents behind the facade.
+- [x] Existing TS tests still pass.
+- [x] CLJS tests cover parity and malformed data rejection.
+- [x] JS import smoke sees callable CLJS facade functions.
+- [x] Internal CLJS maps use kebab-case; public JS outputs preserve camelCase.
+- [x] No raw JS interop appears in `domain.*`, `law.*`, or `shape.*`.
+- [x] No TypeScript deletion happens in this task.
+
+## Implementation note
+
+The runtime-core PR extends the first `packages/eta-mu-runtime` CLJS spine with pure data contracts for content parts, agent messages, model descriptors, tool descriptors, and session context maps. The new facade exports are additive and do not change package `main`, `types`, or public TypeScript exports.
+
+## Risks
+
+- Date/time defaults can make parity tests flaky. Prefer passing `now` into pure functions and only default in facade wrappers.
+- Zod and Malli can disagree on error shape. During parity, assert behavior and returned data first; stabilize error reporting in the law layer before public cutover.
+- Candidate IDs include repo/trigger/kind/index string construction. Keep exact string format until a major compatibility change is approved.
+
+## Recommended next planning handoff
+
+Once the shadow spine is implemented, use this plan to port only `packages/eta-mu-runtime` pure semantics first. Do not start `AgentSession` or provider logic until this pure core is verified.

--- a/kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-runtime-core.md
@@ -1,7 +1,7 @@
 ---
 uuid: "eta-mu-cljs-rewrite-runtime-core"
 title: "Eta-mu CLJS Rewrite — Runtime Core Port"
-status: todo
+status: review
 priority: P0
 labels: ["tasks", "cljs", "rewrite", "runtime", "13sp"]
 created_at: "2026-05-29T21:18:48Z"
@@ -31,23 +31,32 @@ Port the pure eta-mu runtime core into CLJS before migrating effectful command p
 
 ## Work items
 
-- [ ] Define Malli schemas in `law.*` for public runtime data crossing package boundaries.
-- [ ] Implement pure `domain.*` decisions with no Node, provider SDK, FS, git, process, or HTTP access.
-- [ ] Implement `shape.*` transforms for existing TS/JS DTO compatibility.
-- [ ] Add regression tests against representative current eta-mu/Pi message and tool payloads.
-- [ ] Keep text/image/audio content-part extensibility explicit.
+- [x] Define Malli schemas in `law.*` for public runtime data crossing package boundaries.
+- [x] Implement pure `domain.*` decisions with no Node, provider SDK, FS, git, process, or HTTP access.
+- [x] Implement `shape.*` transforms for existing TS/JS DTO compatibility.
+- [x] Add regression tests against representative current eta-mu/Pi message and tool payloads.
+- [x] Keep text/image/audio content-part extensibility explicit.
 
 ## Acceptance criteria
 
-- [ ] Pure runtime core tests pass under the CLJS test target.
-- [ ] Current JS callers can round-trip representative runtime payloads through the CLJS facade.
-- [ ] Boundary schemas reject at least one malformed payload per major data type.
-- [ ] No raw JS interop appears outside allowed facade/extern namespaces.
+- [x] Pure runtime core tests pass under the CLJS test target.
+- [x] Current JS callers can round-trip representative runtime payloads through the CLJS facade.
+- [x] Boundary schemas reject at least one malformed payload per major data type.
+- [x] No raw JS interop appears outside allowed facade/extern namespaces.
 
 ## Verification
 
 ```bash
 pnpm --dir packages/eta-mu-runtime cljs:verify
 pnpm --dir packages/eta-mu-runtime test
-pnpm --filter @open-hax/eta-mu-cli test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime build
+pnpm test
+pnpm -C packages/eta-mu-extensions build
 ```
+
+## Notes
+
+Implemented in `packages/eta-mu-runtime` with CLJS `law.*`, `domain.*`, and `shape.*` namespaces for content parts, agent messages, model descriptors, tool descriptors, and session context data. The JS facade now exposes runtime-core constructors/converters while keeping package `main`/`types` pointed at the existing TypeScript build.
+
+`pnpm --filter @open-hax/eta-mu-cli test` was also attempted after building local package dependencies. It is still blocked by pre-existing clipboard OSC52 environment assertions in `packages/coding-agent/test/clipboard.test.ts` (2 failures), while 108 CLI test files passed and 7 were skipped.

--- a/packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
+++ b/packages/eta-mu-runtime/scripts/smoke-cljs-runtime.mjs
@@ -8,6 +8,18 @@ const expected = [
   "rankCheapMuCandidates",
   "recommendBreath",
   "createActionBatch",
+  "createTextContent",
+  "createImageContent",
+  "createAudioContent",
+  "createBashExecutionMessage",
+  "createCustomMessage",
+  "createBranchSummaryMessage",
+  "createCompactionSummaryMessage",
+  "convertToLlmMessages",
+  "createToolDescriptor",
+  "composeToolDescriptors",
+  "selectCompatibleModels",
+  "createSessionContext",
 ];
 
 for (const key of expected) {
@@ -33,4 +45,25 @@ if (batch.kind !== "eta-mu-action-batch.v1") {
   throw new Error(`createActionBatch smoke failed: ${JSON.stringify(batch)}`);
 }
 
-console.log(JSON.stringify({ ok: true, exports: expected, batchKind: batch.kind }));
+const bashMessage = mod.createBashExecutionMessage({
+  command: "echo hi",
+  output: "hi",
+  exitCode: 0,
+  cancelled: false,
+  truncated: false,
+  timestamp: "2026-05-30T00:00:00.000Z",
+});
+const llmMessages = mod.convertToLlmMessages([bashMessage]);
+if (llmMessages[0]?.role !== "user" || llmMessages[0]?.content?.[0]?.type !== "text") {
+  throw new Error(`convertToLlmMessages smoke failed: ${JSON.stringify(llmMessages)}`);
+}
+
+const tools = mod.composeToolDescriptors([
+  [mod.createToolDescriptor({ name: "read", description: "Read files", parameters: {} })],
+  [mod.createToolDescriptor({ name: "read", description: "Duplicate", parameters: {} })],
+]);
+if (tools.length !== 1 || tools[0].name !== "read") {
+  throw new Error(`composeToolDescriptors smoke failed: ${JSON.stringify(tools)}`);
+}
+
+console.log(JSON.stringify({ ok: true, exports: expected, batchKind: batch.kind, llmMessages: llmMessages.length }));

--- a/packages/eta-mu-runtime/shadow-cljs.edn
+++ b/packages/eta-mu-runtime/shadow-cljs.edn
@@ -12,7 +12,19 @@
                                 :selectPanelsFromContext eta-mu.runtime.facade/select-panels-from-context
                                 :rankCheapMuCandidates eta-mu.runtime.facade/rank-cheap-mu-candidates
                                 :recommendBreath eta-mu.runtime.facade/recommend-breath
-                                :createActionBatch eta-mu.runtime.facade/create-action-batch}}}
+                                :createActionBatch eta-mu.runtime.facade/create-action-batch
+                                :createTextContent eta-mu.runtime.facade/create-text-content
+                                :createImageContent eta-mu.runtime.facade/create-image-content
+                                :createAudioContent eta-mu.runtime.facade/create-audio-content
+                                :createBashExecutionMessage eta-mu.runtime.facade/create-bash-execution-message
+                                :createCustomMessage eta-mu.runtime.facade/create-custom-message
+                                :createBranchSummaryMessage eta-mu.runtime.facade/create-branch-summary-message
+                                :createCompactionSummaryMessage eta-mu.runtime.facade/create-compaction-summary-message
+                                :convertToLlmMessages eta-mu.runtime.facade/convert-to-llm-messages
+                                :createToolDescriptor eta-mu.runtime.facade/create-tool-descriptor
+                                :composeToolDescriptors eta-mu.runtime.facade/compose-tool-descriptors
+                                :selectCompatibleModels eta-mu.runtime.facade/select-compatible-models
+                                :createSessionContext eta-mu.runtime.facade/create-session-context}}}
    :compiler-options {:output-feature-set :es-next
                       :optimizations :simple
                       :source-map true}}

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/message.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/message.cljs
@@ -1,0 +1,151 @@
+(ns eta-mu.runtime.domain.message
+  (:require [clojure.string :as str]
+            [eta-mu.runtime.law.content-part :as content-law]
+            [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.message :as message-law]))
+
+(def compaction-summary-prefix
+  "The conversation history before this point was compacted into the following summary:\n\n<summary>\n")
+
+(def compaction-summary-suffix
+  "\n</summary>")
+
+(def branch-summary-prefix
+  "The following is a summary of a branch that this conversation came back from:\n\n<summary>\n")
+
+(def branch-summary-suffix "</summary>")
+
+(defn create-text-content
+  [text]
+  (law/validate! content-law/text-content-schema
+                 {:type :text :text (or text "")}
+                 "text content"))
+
+(defn create-image-content
+  [data mime-type]
+  (law/validate! content-law/image-content-schema
+                 {:type :image :data data :mime-type mime-type}
+                 "image content"))
+
+(defn create-audio-content
+  ([data mime-type]
+   (create-audio-content data mime-type nil))
+  ([data mime-type format]
+   (law/validate! content-law/audio-content-schema
+                  (cond-> {:type :audio :data data :mime-type mime-type}
+                    format (assoc :format format))
+                  "audio content")))
+
+(defn input-content-vector
+  [content]
+  (let [normalized (if (string? content)
+                     [(create-text-content content)]
+                     (vec content))]
+    (doseq [part normalized]
+      (law/validate! content-law/input-content-schema part "input content"))
+    normalized))
+
+(defn- safe-fence-text
+  [text]
+  (str/replace text "```" "`​``"))
+
+(defn bash-execution->text
+  [msg]
+  (let [text (str "Ran `" (:command msg) "`\n"
+                  (if (seq (:output msg))
+                    (str "```\n" (safe-fence-text (:output msg)) "\n```")
+                    "(no output)"))
+        text (cond
+               (:cancelled msg)
+               (str text "\n\n(command cancelled)")
+
+               (and (some? (:exit-code msg)) (not= 0 (:exit-code msg)))
+               (str text "\n\nCommand exited with code " (:exit-code msg))
+
+               :else text)]
+    (if (and (:truncated msg) (:full-output-path msg))
+      (str text "\n\n[Output truncated. Full output: " (:full-output-path msg) "]")
+      text)))
+
+(defn create-bash-execution-message
+  [message]
+  (law/validate! message-law/bash-execution-message-schema
+                 (merge {:role :bash-execution
+                         :output ""
+                         :exit-code nil
+                         :cancelled false
+                         :truncated false
+                         :exclude-from-context false}
+                        message)
+                 "bash execution message"))
+
+(defn create-custom-message
+  [custom-type content display details timestamp]
+  (law/validate! message-law/custom-message-schema
+                 (cond-> {:role :custom
+                          :custom-type custom-type
+                          :content content
+                          :display display
+                          :timestamp timestamp}
+                   (some? details) (assoc :details details))
+                 "custom message"))
+
+(defn create-branch-summary-message
+  [summary from-id timestamp]
+  (law/validate! message-law/branch-summary-message-schema
+                 {:role :branch-summary
+                  :summary summary
+                  :from-id from-id
+                  :timestamp timestamp}
+                 "branch summary message"))
+
+(defn create-compaction-summary-message
+  [summary tokens-before timestamp]
+  (law/validate! message-law/compaction-summary-message-schema
+                 {:role :compaction-summary
+                  :summary summary
+                  :tokens-before tokens-before
+                  :timestamp timestamp}
+                 "compaction summary message"))
+
+(defn- custom->llm
+  [message]
+  {:role :user
+   :content (input-content-vector (:content message))
+   :timestamp (:timestamp message)})
+
+(defn- summary->llm
+  [message prefix suffix]
+  {:role :user
+   :content [(create-text-content (str prefix (:summary message) suffix))]
+   :timestamp (:timestamp message)})
+
+(defn message->llm
+  [message]
+  (case (:role message)
+    :bash-execution
+    (when-not (:exclude-from-context message)
+      {:role :user
+       :content [(create-text-content (bash-execution->text message))]
+       :timestamp (:timestamp message)})
+
+    :custom
+    (custom->llm message)
+
+    :branch-summary
+    (summary->llm message branch-summary-prefix branch-summary-suffix)
+
+    :compaction-summary
+    (summary->llm message compaction-summary-prefix compaction-summary-suffix)
+
+    (:user :assistant :tool-result)
+    message
+
+    nil))
+
+(defn convert-to-llm
+  [messages]
+  (->> messages
+       (map #(law/validate! message-law/agent-message-schema % "agent message"))
+       (keep message->llm)
+       (mapv #(law/validate! message-law/llm-message-schema % "llm message"))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/model.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/model.cljs
@@ -1,0 +1,33 @@
+(ns eta-mu.runtime.domain.model
+  (:require [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.model :as model-law]))
+
+(defn supports-inputs?
+  [model required-inputs]
+  (let [supported (set (:input model))]
+    (every? supported required-inputs)))
+
+(defn- estimated-output-cost
+  [model]
+  (get-in model [:cost :output] ##Inf))
+
+(defn- estimated-input-cost
+  [model]
+  (get-in model [:cost :input] ##Inf))
+
+(defn select-compatible-models
+  [models requirements]
+  (let [requirements (law/validate! model-law/model-requirements-schema
+                                    (merge {:inputs [:text]
+                                            :reasoning-required false
+                                            :min-context-window 1}
+                                           requirements)
+                                    "model requirements")
+        required-inputs (set (:inputs requirements))]
+    (->> models
+         (map #(law/validate! model-law/model-candidate-schema % "model candidate"))
+         (filter #(supports-inputs? % required-inputs))
+         (filter #(or (not (:reasoning-required requirements)) (:reasoning %)))
+         (filter #(>= (:context-window %) (:min-context-window requirements)))
+         (sort-by (juxt estimated-output-cost estimated-input-cost :id))
+         vec)))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/session.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/session.cljs
@@ -1,0 +1,20 @@
+(ns eta-mu.runtime.domain.session
+  (:require [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.message :as message-law]
+            [eta-mu.runtime.law.session :as session-law]))
+
+(defn create-session-context
+  [options]
+  (law/validate! session-law/session-context-schema
+                 (merge {:messages []
+                         :active-tool-names []
+                         :metadata {}}
+                        options)
+                 "session context"))
+
+(defn append-message
+  [session message]
+  (let [message (law/validate! message-law/agent-message-schema message "agent message")]
+    (law/validate! session-law/session-context-schema
+                   (update session :messages conj message)
+                   "session context")))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/tool.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/domain/tool.cljs
@@ -1,0 +1,23 @@
+(ns eta-mu.runtime.domain.tool
+  (:require [eta-mu.runtime.law.core :as law]
+            [eta-mu.runtime.law.tool :as tool-law]))
+
+(defn create-tool-descriptor
+  [descriptor]
+  (law/validate! tool-law/tool-descriptor-schema
+                 (merge {:enabled true
+                         :parameters {}}
+                        descriptor)
+                 "tool descriptor"))
+
+(defn compose-tool-descriptors
+  [descriptor-groups]
+  (let [descriptors (map create-tool-descriptor (mapcat identity descriptor-groups))]
+    (->> descriptors
+         (reduce (fn [acc descriptor]
+                   (if (contains? (:seen acc) (:name descriptor))
+                     acc
+                     {:seen (conj (:seen acc) (:name descriptor))
+                      :items (conj (:items acc) descriptor)}))
+                 {:seen #{} :items []})
+         :items)))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
@@ -1,17 +1,49 @@
 (ns eta-mu.runtime.facade
   (:require [eta-mu.runtime.domain.breath :as breath]
             [eta-mu.runtime.domain.envelope :as envelope]
+            [eta-mu.runtime.domain.message :as message]
+            [eta-mu.runtime.domain.model :as model]
             [eta-mu.runtime.domain.planner :as planner]
+            [eta-mu.runtime.domain.session :as session]
             [eta-mu.runtime.domain.state :as state]
-            [eta-mu.runtime.shape.compat :as compat]))
+            [eta-mu.runtime.domain.tool :as tool]
+            [eta-mu.runtime.shape.compat :as compat]
+            [eta-mu.runtime.shape.message :as message-shape]
+            [eta-mu.runtime.shape.model :as model-shape]
+            [eta-mu.runtime.shape.session :as session-shape]
+            [eta-mu.runtime.shape.tool :as tool-shape]))
 
 (defn- now-iso
   []
   (.toISOString (js/Date.)))
 
+(defn- js-value
+  [value]
+  (js->clj value :keywordize-keys true))
+
 (defn- js-map
   [value]
   (js->clj (or value #js {}) :keywordize-keys true))
+
+(defn- finite-number!
+  [value label]
+  (if (and (number? value) (js/Number.isFinite value))
+    value
+    (throw (ex-info (str "Invalid eta-mu runtime " label)
+                    {:label label
+                     :value value}))))
+
+(defn- timestamp-ms
+  [value]
+  (cond
+    (number? value)
+    (finite-number! value "timestamp")
+
+    (string? value)
+    (finite-number! (.getTime (js/Date. value)) "timestamp")
+
+    :else
+    (finite-number! (.getTime (js/Date.)) "timestamp")))
 
 (defn- ->js
   [value]
@@ -95,3 +127,117 @@
       envelope/create-action-batch
       compat/action-batch->external
       ->js))
+
+(defn create-text-content
+  "JS facade for createTextContent."
+  [text]
+  (-> text
+      message/create-text-content
+      message-shape/content->external
+      ->js))
+
+(defn create-image-content
+  "JS facade for createImageContent."
+  [data mime-type]
+  (-> (message/create-image-content data mime-type)
+      message-shape/content->external
+      ->js))
+
+(defn create-audio-content
+  "JS facade for createAudioContent."
+  ([data mime-type]
+   (create-audio-content data mime-type nil))
+  ([data mime-type format]
+   (-> (message/create-audio-content data mime-type (some-> format keyword))
+       message-shape/content->external
+       ->js)))
+
+(defn create-bash-execution-message
+  "JS facade for createBashExecutionMessage."
+  [options]
+  (let [options (js-map options)
+        message (-> (assoc options :role "bashExecution")
+                    message-shape/message-from-external
+                    (assoc :timestamp (timestamp-ms (:timestamp options)))
+                    message/create-bash-execution-message)]
+    (-> message message-shape/message->external ->js)))
+
+(defn create-custom-message
+  "JS facade for createCustomMessage."
+  ([custom-type content display]
+   (create-custom-message custom-type content display nil nil))
+  ([custom-type content display details]
+   (create-custom-message custom-type content display details nil))
+  ([custom-type content display details timestamp]
+   (let [content (if (string? content)
+                   content
+                   (mapv message-shape/content-from-external (js-value content)))
+         details (some-> details js-value)]
+     (-> (message/create-custom-message custom-type content display details (timestamp-ms timestamp))
+         message-shape/message->external
+         ->js))))
+
+(defn create-branch-summary-message
+  "JS facade for createBranchSummaryMessage."
+  [summary from-id timestamp]
+  (-> (message/create-branch-summary-message summary from-id (timestamp-ms timestamp))
+      message-shape/message->external
+      ->js))
+
+(defn create-compaction-summary-message
+  "JS facade for createCompactionSummaryMessage."
+  [summary tokens-before timestamp]
+  (-> (message/create-compaction-summary-message summary tokens-before (timestamp-ms timestamp))
+      message-shape/message->external
+      ->js))
+
+(defn convert-to-llm-messages
+  "JS facade for convertToLlmMessages."
+  [messages]
+  (->> (js-value messages)
+       (mapv message-shape/message-from-external)
+       message/convert-to-llm
+       (mapv message-shape/message->external)
+       ->js))
+
+(defn create-tool-descriptor
+  "JS facade for createToolDescriptor."
+  [descriptor]
+  (-> descriptor
+      js-map
+      tool-shape/descriptor-from-external
+      tool/create-tool-descriptor
+      tool-shape/descriptor->external
+      ->js))
+
+(defn compose-tool-descriptors
+  "JS facade for composeToolDescriptors."
+  [descriptor-groups]
+  (let [groups (->> (js-value descriptor-groups)
+                    (mapv #(mapv tool-shape/descriptor-from-external %)))]
+    (->> groups
+         tool/compose-tool-descriptors
+         (mapv tool-shape/descriptor->external)
+         ->js)))
+
+(defn select-compatible-models
+  "JS facade for selectCompatibleModels."
+  [models requirements]
+  (let [models (mapv model-shape/model-from-external (js-value models))
+        requirements (model-shape/requirements-from-external (js-map requirements))]
+    (->> (model/select-compatible-models models requirements)
+         (mapv model-shape/model->external)
+         ->js)))
+
+(defn create-session-context
+  "JS facade for createSessionContext."
+  [context]
+  (let [context (js-map context)
+        now (timestamp-ms (:updatedAt context))]
+    (-> context
+        (update :createdAt #(or % now))
+        (update :updatedAt #(or % now))
+        session-shape/context-from-external
+        session/create-session-context
+        session-shape/context->external
+        ->js)))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/content_part.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/content_part.cljs
@@ -1,0 +1,47 @@
+(ns eta-mu.runtime.law.content-part)
+
+(def audio-format-schema
+  [:enum :wav :mp3 :flac :ogg :webm :m4a :aac])
+
+(def input-modality-schema
+  [:enum :text :image :audio])
+
+(def text-content-schema
+  [:map
+   [:type [:= :text]]
+   [:text string?]
+   [:text-signature {:optional true} [:string {:min 1}]]])
+
+(def image-content-schema
+  [:map
+   [:type [:= :image]]
+   [:data [:string {:min 1}]]
+   [:mime-type [:string {:min 1}]]])
+
+(def audio-content-schema
+  [:map
+   [:type [:= :audio]]
+   [:data [:string {:min 1}]]
+   [:mime-type [:string {:min 1}]]
+   [:format {:optional true} audio-format-schema]])
+
+(def input-content-schema
+  [:or text-content-schema image-content-schema audio-content-schema])
+
+(def thinking-content-schema
+  [:map
+   [:type [:= :thinking]]
+   [:thinking string?]
+   [:thinking-signature {:optional true} [:string {:min 1}]]
+   [:redacted {:optional true} boolean?]])
+
+(def tool-call-content-schema
+  [:map
+   [:type [:= :tool-call]]
+   [:id [:string {:min 1}]]
+   [:name [:string {:min 1}]]
+   [:arguments map?]
+   [:thought-signature {:optional true} [:string {:min 1}]]])
+
+(def assistant-content-schema
+  [:or text-content-schema thinking-content-schema tool-call-content-schema])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/message.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/message.cljs
@@ -1,0 +1,103 @@
+(ns eta-mu.runtime.law.message
+  (:require [eta-mu.runtime.law.content-part :as content]))
+
+(def timestamp-schema [:int {:min 0}])
+
+(def role-schema
+  [:enum :user :assistant :tool-result :bash-execution :custom :branch-summary :compaction-summary])
+
+(def usage-cost-schema
+  [:map
+   [:input [:and number? [:>= 0]]]
+   [:output [:and number? [:>= 0]]]
+   [:cache-read [:and number? [:>= 0]]]
+   [:cache-write [:and number? [:>= 0]]]
+   [:total [:and number? [:>= 0]]]])
+
+(def usage-schema
+  [:map
+   [:input [:int {:min 0}]]
+   [:output [:int {:min 0}]]
+   [:cache-read [:int {:min 0}]]
+   [:cache-write [:int {:min 0}]]
+   [:total-tokens [:int {:min 0}]]
+   [:cost usage-cost-schema]])
+
+(def stop-reason-schema
+  [:enum :stop :length :tool-use :error :aborted])
+
+(def user-message-schema
+  [:map
+   [:role [:= :user]]
+   [:content [:or string? [:vector {:min 1} content/input-content-schema]]]
+   [:timestamp timestamp-schema]])
+
+(def assistant-message-schema
+  [:map
+   [:role [:= :assistant]]
+   [:content [:vector content/assistant-content-schema]]
+   [:api [:string {:min 1}]]
+   [:provider [:string {:min 1}]]
+   [:model [:string {:min 1}]]
+   [:response-id {:optional true} [:string {:min 1}]]
+   [:usage usage-schema]
+   [:stop-reason stop-reason-schema]
+   [:error-message {:optional true} [:string {:min 1}]]
+   [:timestamp timestamp-schema]])
+
+(def tool-result-message-schema
+  [:map
+   [:role [:= :tool-result]]
+   [:tool-call-id [:string {:min 1}]]
+   [:tool-name [:string {:min 1}]]
+   [:content [:vector content/input-content-schema]]
+   [:details {:optional true} any?]
+   [:is-error boolean?]
+   [:timestamp timestamp-schema]])
+
+(def bash-execution-message-schema
+  [:map
+   [:role [:= :bash-execution]]
+   [:command [:string {:min 1}]]
+   [:output string?]
+   [:exit-code {:optional true} [:maybe int?]]
+   [:cancelled boolean?]
+   [:truncated boolean?]
+   [:full-output-path {:optional true} [:string {:min 1}]]
+   [:timestamp timestamp-schema]
+   [:exclude-from-context {:optional true} boolean?]])
+
+(def custom-message-schema
+  [:map
+   [:role [:= :custom]]
+   [:custom-type [:string {:min 1}]]
+   [:content [:or string? [:vector {:min 1} content/input-content-schema]]]
+   [:display boolean?]
+   [:details {:optional true} any?]
+   [:timestamp timestamp-schema]])
+
+(def branch-summary-message-schema
+  [:map
+   [:role [:= :branch-summary]]
+   [:summary [:string {:min 1}]]
+   [:from-id [:string {:min 1}]]
+   [:timestamp timestamp-schema]])
+
+(def compaction-summary-message-schema
+  [:map
+   [:role [:= :compaction-summary]]
+   [:summary [:string {:min 1}]]
+   [:tokens-before [:int {:min 0}]]
+   [:timestamp timestamp-schema]])
+
+(def agent-message-schema
+  [:or user-message-schema
+   assistant-message-schema
+   tool-result-message-schema
+   bash-execution-message-schema
+   custom-message-schema
+   branch-summary-message-schema
+   compaction-summary-message-schema])
+
+(def llm-message-schema
+  [:or user-message-schema assistant-message-schema tool-result-message-schema])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/model.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/model.cljs
@@ -1,0 +1,36 @@
+(ns eta-mu.runtime.law.model
+  (:require [eta-mu.runtime.law.content-part :as content]))
+
+(def thinking-level-schema
+  [:enum :minimal :low :medium :high :xhigh])
+
+(def provider-schema [:string {:min 1}])
+(def api-schema [:string {:min 1}])
+
+(def model-cost-schema
+  [:map
+   [:input [:and number? [:>= 0]]]
+   [:output [:and number? [:>= 0]]]
+   [:cache-read [:and number? [:>= 0]]]
+   [:cache-write [:and number? [:>= 0]]]])
+
+(def model-candidate-schema
+  [:map
+   [:id [:string {:min 1}]]
+   [:name [:string {:min 1}]]
+   [:api api-schema]
+   [:provider provider-schema]
+   [:base-url [:string {:min 1}]]
+   [:reasoning boolean?]
+   [:input [:vector content/input-modality-schema]]
+   [:cost model-cost-schema]
+   [:context-window [:int {:min 1}]]
+   [:max-tokens [:int {:min 1}]]
+   [:headers {:optional true} map?]
+   [:compat {:optional true} any?]])
+
+(def model-requirements-schema
+  [:map
+   [:inputs {:optional true} [:vector content/input-modality-schema]]
+   [:reasoning-required {:optional true} boolean?]
+   [:min-context-window {:optional true} [:int {:min 1}]]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/session.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/session.cljs
@@ -1,0 +1,12 @@
+(ns eta-mu.runtime.law.session
+  (:require [eta-mu.runtime.law.message :as message]))
+
+(def session-context-schema
+  [:map
+   [:session-id [:string {:min 1}]]
+   [:cwd [:string {:min 1}]]
+   [:messages [:vector message/agent-message-schema]]
+   [:active-tool-names [:vector [:string {:min 1}]]]
+   [:metadata map?]
+   [:created-at message/timestamp-schema]
+   [:updated-at message/timestamp-schema]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/tool.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/tool.cljs
@@ -1,0 +1,9 @@
+(ns eta-mu.runtime.law.tool)
+
+(def tool-descriptor-schema
+  [:map
+   [:name [:string {:min 1}]]
+   [:description [:string {:min 1}]]
+   [:parameters map?]
+   [:enabled boolean?]
+   [:metadata {:optional true} any?]])

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/message.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/message.cljs
@@ -1,0 +1,308 @@
+(ns eta-mu.runtime.shape.message)
+
+(def role->internal
+  {:user :user
+   "user" :user
+   :assistant :assistant
+   "assistant" :assistant
+   :toolResult :tool-result
+   :tool-result :tool-result
+   "toolResult" :tool-result
+   "tool-result" :tool-result
+   :bashExecution :bash-execution
+   :bash-execution :bash-execution
+   "bashExecution" :bash-execution
+   "bash-execution" :bash-execution
+   :custom :custom
+   "custom" :custom
+   :branchSummary :branch-summary
+   :branch-summary :branch-summary
+   "branchSummary" :branch-summary
+   "branch-summary" :branch-summary
+   :compactionSummary :compaction-summary
+   :compaction-summary :compaction-summary
+   "compactionSummary" :compaction-summary
+   "compaction-summary" :compaction-summary})
+
+(def role->external
+  {:user :user
+   :assistant :assistant
+   :tool-result :toolResult
+   :bash-execution :bashExecution
+   :custom :custom
+   :branch-summary :branchSummary
+   :compaction-summary :compactionSummary})
+
+(def content-type->internal
+  {:text :text
+   "text" :text
+   :image :image
+   "image" :image
+   :audio :audio
+   "audio" :audio
+   :thinking :thinking
+   "thinking" :thinking
+   :toolCall :tool-call
+   :tool-call :tool-call
+   "toolCall" :tool-call
+   "tool-call" :tool-call})
+
+(def content-type->external
+  {:text :text
+   :image :image
+   :audio :audio
+   :thinking :thinking
+   :tool-call :toolCall})
+
+(defn- maybe-keyword
+  [value]
+  (cond
+    (keyword? value) value
+    (string? value) (keyword value)
+    :else value))
+
+(defn- first-present
+  [m keys]
+  (when-let [key (first (filter #(contains? m %) keys))]
+    (get m key)))
+
+(defn content-from-external
+  [content]
+  (let [content-type (get content-type->internal (:type content))]
+    (case content-type
+      :text
+      (cond-> {:type :text
+               :text (or (:text content) "")}
+        (:textSignature content) (assoc :text-signature (:textSignature content))
+        (:text-signature content) (assoc :text-signature (:text-signature content)))
+
+      :image
+      {:type :image
+       :data (:data content)
+       :mime-type (or (:mimeType content) (:mime-type content))}
+
+      :audio
+      (cond-> {:type :audio
+               :data (:data content)
+               :mime-type (or (:mimeType content) (:mime-type content))}
+        (:format content) (assoc :format (maybe-keyword (:format content))))
+
+      :thinking
+      (cond-> {:type :thinking
+               :thinking (or (:thinking content) "")}
+        (:thinkingSignature content) (assoc :thinking-signature (:thinkingSignature content))
+        (:thinking-signature content) (assoc :thinking-signature (:thinking-signature content))
+        (contains? content :redacted) (assoc :redacted (boolean (:redacted content))))
+
+      :tool-call
+      (cond-> {:type :tool-call
+               :id (:id content)
+               :name (:name content)
+               :arguments (or (:arguments content) {})}
+        (:thoughtSignature content) (assoc :thought-signature (:thoughtSignature content))
+        (:thought-signature content) (assoc :thought-signature (:thought-signature content)))
+
+      content)))
+
+(defn content->external
+  [content]
+  (case (:type content)
+    :text
+    (cond-> {:type :text
+             :text (:text content)}
+      (:text-signature content) (assoc :textSignature (:text-signature content)))
+
+    :image
+    {:type :image
+     :data (:data content)
+     :mimeType (:mime-type content)}
+
+    :audio
+    (cond-> {:type :audio
+             :data (:data content)
+             :mimeType (:mime-type content)}
+      (:format content) (assoc :format (name (:format content))))
+
+    :thinking
+    (cond-> {:type :thinking
+             :thinking (:thinking content)}
+      (:thinking-signature content) (assoc :thinkingSignature (:thinking-signature content))
+      (contains? content :redacted) (assoc :redacted (:redacted content)))
+
+    :tool-call
+    (cond-> {:type :toolCall
+             :id (:id content)
+             :name (:name content)
+             :arguments (:arguments content)}
+      (:thought-signature content) (assoc :thoughtSignature (:thought-signature content)))
+
+    content))
+
+(defn content-list-from-external
+  [content]
+  (if (string? content)
+    content
+    (mapv content-from-external content)))
+
+(defn content-list->external
+  [content]
+  (if (string? content)
+    content
+    (mapv content->external content)))
+
+(defn usage-from-external
+  [usage]
+  {:input (:input usage)
+   :output (:output usage)
+   :cache-read (or (:cacheRead usage) (:cache-read usage))
+   :cache-write (or (:cacheWrite usage) (:cache-write usage))
+   :total-tokens (or (:totalTokens usage) (:total-tokens usage))
+   :cost {:input (get-in usage [:cost :input])
+          :output (get-in usage [:cost :output])
+          :cache-read (or (get-in usage [:cost :cacheRead]) (get-in usage [:cost :cache-read]))
+          :cache-write (or (get-in usage [:cost :cacheWrite]) (get-in usage [:cost :cache-write]))
+          :total (get-in usage [:cost :total])}})
+
+(defn usage->external
+  [usage]
+  {:input (:input usage)
+   :output (:output usage)
+   :cacheRead (:cache-read usage)
+   :cacheWrite (:cache-write usage)
+   :totalTokens (:total-tokens usage)
+   :cost {:input (get-in usage [:cost :input])
+          :output (get-in usage [:cost :output])
+          :cacheRead (get-in usage [:cost :cache-read])
+          :cacheWrite (get-in usage [:cost :cache-write])
+          :total (get-in usage [:cost :total])}})
+
+(defn message-from-external
+  [message]
+  (let [role (get role->internal (:role message))]
+    (case role
+      :user
+      {:role :user
+       :content (content-list-from-external (:content message))
+       :timestamp (:timestamp message)}
+
+      :assistant
+      (cond-> {:role :assistant
+               :content (mapv content-from-external (:content message))
+               :api (:api message)
+               :provider (:provider message)
+               :model (:model message)
+               :usage (usage-from-external (:usage message))
+               :stop-reason (maybe-keyword (or (:stopReason message) (:stop-reason message)))
+               :timestamp (:timestamp message)}
+        (:responseId message) (assoc :response-id (:responseId message))
+        (:response-id message) (assoc :response-id (:response-id message))
+        (:errorMessage message) (assoc :error-message (:errorMessage message))
+        (:error-message message) (assoc :error-message (:error-message message)))
+
+      :tool-result
+      (cond-> {:role :tool-result
+               :tool-call-id (or (:toolCallId message) (:tool-call-id message))
+               :tool-name (or (:toolName message) (:tool-name message))
+               :content (mapv content-from-external (:content message))
+               :is-error (boolean (or (:isError message) (:is-error message)))
+               :timestamp (:timestamp message)}
+        (contains? message :details) (assoc :details (:details message)))
+
+      :bash-execution
+      (cond-> {:role :bash-execution
+               :command (:command message)
+               :output (or (:output message) "")
+               :exit-code (first-present message [:exitCode :exit-code])
+               :cancelled (if (contains? message :cancelled) (:cancelled message) false)
+               :truncated (if (contains? message :truncated) (:truncated message) false)
+               :timestamp (:timestamp message)}
+        (some? (first-present message [:fullOutputPath :full-output-path]))
+        (assoc :full-output-path (first-present message [:fullOutputPath :full-output-path]))
+        (contains? message :excludeFromContext)
+        (assoc :exclude-from-context (:excludeFromContext message))
+        (contains? message :exclude-from-context)
+        (assoc :exclude-from-context (:exclude-from-context message)))
+
+      :custom
+      (cond-> {:role :custom
+               :custom-type (or (:customType message) (:custom-type message))
+               :content (content-list-from-external (:content message))
+               :display (:display message)
+               :timestamp (:timestamp message)}
+        (contains? message :details) (assoc :details (:details message)))
+
+      :branch-summary
+      {:role :branch-summary
+       :summary (:summary message)
+       :from-id (or (:fromId message) (:from-id message))
+       :timestamp (:timestamp message)}
+
+      :compaction-summary
+      {:role :compaction-summary
+       :summary (:summary message)
+       :tokens-before (or (:tokensBefore message) (:tokens-before message))
+       :timestamp (:timestamp message)}
+
+      message)))
+
+(defn message->external
+  [message]
+  (case (:role message)
+    :user
+    {:role :user
+     :content (content-list->external (:content message))
+     :timestamp (:timestamp message)}
+
+    :assistant
+    (cond-> {:role :assistant
+             :content (mapv content->external (:content message))
+             :api (:api message)
+             :provider (:provider message)
+             :model (:model message)
+             :usage (usage->external (:usage message))
+             :stopReason (name (:stop-reason message))
+             :timestamp (:timestamp message)}
+      (:response-id message) (assoc :responseId (:response-id message))
+      (:error-message message) (assoc :errorMessage (:error-message message)))
+
+    :tool-result
+    (cond-> {:role :toolResult
+             :toolCallId (:tool-call-id message)
+             :toolName (:tool-name message)
+             :content (mapv content->external (:content message))
+             :isError (:is-error message)
+             :timestamp (:timestamp message)}
+      (contains? message :details) (assoc :details (:details message)))
+
+    :bash-execution
+    (cond-> {:role :bashExecution
+             :command (:command message)
+             :output (:output message)
+             :exitCode (:exit-code message)
+             :cancelled (:cancelled message)
+             :truncated (:truncated message)
+             :timestamp (:timestamp message)}
+      (:full-output-path message) (assoc :fullOutputPath (:full-output-path message))
+      (contains? message :exclude-from-context) (assoc :excludeFromContext (:exclude-from-context message)))
+
+    :custom
+    (cond-> {:role :custom
+             :customType (:custom-type message)
+             :content (content-list->external (:content message))
+             :display (:display message)
+             :timestamp (:timestamp message)}
+      (contains? message :details) (assoc :details (:details message)))
+
+    :branch-summary
+    {:role :branchSummary
+     :summary (:summary message)
+     :fromId (:from-id message)
+     :timestamp (:timestamp message)}
+
+    :compaction-summary
+    {:role :compactionSummary
+     :summary (:summary message)
+     :tokensBefore (:tokens-before message)
+     :timestamp (:timestamp message)}
+
+    message))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/model.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/model.cljs
@@ -1,0 +1,64 @@
+(ns eta-mu.runtime.shape.model)
+
+(defn- maybe-keyword
+  [value]
+  (cond
+    (keyword? value) value
+    (string? value) (keyword value)
+    :else value))
+
+(defn cost-from-external
+  [cost]
+  {:input (:input cost)
+   :output (:output cost)
+   :cache-read (or (:cacheRead cost) (:cache-read cost))
+   :cache-write (or (:cacheWrite cost) (:cache-write cost))})
+
+(defn cost->external
+  [cost]
+  {:input (:input cost)
+   :output (:output cost)
+   :cacheRead (:cache-read cost)
+   :cacheWrite (:cache-write cost)})
+
+(defn model-from-external
+  [model]
+  (cond-> {:id (:id model)
+           :name (:name model)
+           :api (:api model)
+           :provider (:provider model)
+           :base-url (or (:baseUrl model) (:base-url model))
+           :reasoning (:reasoning model)
+           :input (mapv maybe-keyword (:input model))
+           :cost (cost-from-external (:cost model))
+           :context-window (or (:contextWindow model) (:context-window model))
+           :max-tokens (or (:maxTokens model) (:max-tokens model))}
+    (:headers model) (assoc :headers (:headers model))
+    (:compat model) (assoc :compat (:compat model))))
+
+(defn model->external
+  [model]
+  (cond-> {:id (:id model)
+           :name (:name model)
+           :api (:api model)
+           :provider (:provider model)
+           :baseUrl (:base-url model)
+           :reasoning (:reasoning model)
+           :input (mapv name (:input model))
+           :cost (cost->external (:cost model))
+           :contextWindow (:context-window model)
+           :maxTokens (:max-tokens model)}
+    (:headers model) (assoc :headers (:headers model))
+    (:compat model) (assoc :compat (:compat model))))
+
+(defn requirements-from-external
+  [requirements]
+  (cond-> {}
+    (:inputs requirements) (assoc :inputs (mapv maybe-keyword (:inputs requirements)))
+    (contains? requirements :reasoningRequired)
+    (assoc :reasoning-required (:reasoningRequired requirements))
+    (contains? requirements :reasoning-required)
+    (assoc :reasoning-required (:reasoning-required requirements))
+    (or (:minContextWindow requirements) (:min-context-window requirements))
+    (assoc :min-context-window (or (:minContextWindow requirements)
+                                   (:min-context-window requirements)))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/session.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/session.cljs
@@ -1,0 +1,29 @@
+(ns eta-mu.runtime.shape.session
+  (:require [eta-mu.runtime.shape.message :as message-shape]))
+
+(defn- first-present
+  [m keys]
+  (when-let [key (first (filter #(contains? m %) keys))]
+    (get m key)))
+
+(defn context-from-external
+  [context]
+  (let [created-at (or (first-present context [:createdAt :created-at]) 0)
+        updated-at (or (first-present context [:updatedAt :updated-at]) created-at)]
+    {:session-id (or (:sessionId context) (:session-id context))
+     :cwd (:cwd context)
+     :messages (mapv message-shape/message-from-external (or (:messages context) []))
+     :active-tool-names (vec (or (:activeToolNames context) (:active-tool-names context) []))
+     :metadata (or (:metadata context) {})
+     :created-at created-at
+     :updated-at updated-at}))
+
+(defn context->external
+  [context]
+  {:sessionId (:session-id context)
+   :cwd (:cwd context)
+   :messages (mapv message-shape/message->external (:messages context))
+   :activeToolNames (vec (:active-tool-names context))
+   :metadata (:metadata context)
+   :createdAt (:created-at context)
+   :updatedAt (:updated-at context)})

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/tool.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/shape/tool.cljs
@@ -1,0 +1,19 @@
+(ns eta-mu.runtime.shape.tool)
+
+(defn descriptor-from-external
+  [descriptor]
+  (cond-> {:name (:name descriptor)
+           :description (:description descriptor)
+           :parameters (or (:parameters descriptor) {})
+           :enabled (if (contains? descriptor :enabled)
+                      (:enabled descriptor)
+                      true)}
+    (contains? descriptor :metadata) (assoc :metadata (:metadata descriptor))))
+
+(defn descriptor->external
+  [descriptor]
+  (cond-> {:name (:name descriptor)
+           :description (:description descriptor)
+           :parameters (:parameters descriptor)
+           :enabled (:enabled descriptor)}
+    (contains? descriptor :metadata) (assoc :metadata (:metadata descriptor))))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/core_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/core_test.cljs
@@ -1,0 +1,77 @@
+(ns eta-mu.runtime.domain.core-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.domain.message :as message]
+            [eta-mu.runtime.domain.model :as model]
+            [eta-mu.runtime.domain.session :as session]
+            [eta-mu.runtime.domain.tool :as tool]))
+
+(def timestamp 1780099200000)
+
+(def cheap-text-model
+  {:id "cheap-text"
+   :name "Cheap Text"
+   :api "openai-responses"
+   :provider "openai"
+   :base-url "https://api.openai.example/v1"
+   :reasoning false
+   :input [:text]
+   :cost {:input 0.1 :output 0.2 :cache-read 0 :cache-write 0}
+   :context-window 128000
+   :max-tokens 4096})
+
+(def reasoning-audio-model
+  {:id "reasoning-audio"
+   :name "Reasoning Audio"
+   :api "anthropic-messages"
+   :provider "anthropic"
+   :base-url "https://api.anthropic.example"
+   :reasoning true
+   :input [:text :image :audio]
+   :cost {:input 1.0 :output 2.0 :cache-read 0.1 :cache-write 0.2}
+   :context-window 200000
+   :max-tokens 8192})
+
+(deftest select-compatible-models-test
+  (testing "model selection is pure data filtering over provider/model descriptors"
+    (let [selected (model/select-compatible-models
+                    [reasoning-audio-model cheap-text-model]
+                    {:inputs [:text :audio]
+                     :reasoning-required true
+                     :min-context-window 160000})]
+      (is (= ["reasoning-audio"] (mapv :id selected))))))
+
+(deftest compose-tool-descriptors-test
+  (testing "tool composition concatenates descriptor groups and keeps first name owner"
+    (let [tools (tool/compose-tool-descriptors
+                 [[{:name "read" :description "Read files" :parameters {}}
+                   {:name "bash" :description "Run command" :parameters {}}]
+                  [{:name "read" :description "Duplicate" :parameters {}}
+                   {:name "write" :description "Write files" :parameters {} :enabled false}]])]
+      (is (= ["read" "bash" "write"] (mapv :name tools)))
+      (is (= "Read files" (:description (first tools))))
+      (is (false? (:enabled (last tools)))))))
+
+(deftest session-context-test
+  (testing "session context is pure data and validates message payloads"
+    (let [user-message {:role :user
+                        :content [(message/create-text-content "hello")]
+                        :timestamp timestamp}
+          ctx (session/create-session-context {:session-id "s1"
+                                               :cwd "/repo"
+                                               :messages [user-message]
+                                               :active-tool-names ["read" "bash"]
+                                               :metadata {:branch "main"}
+                                               :created-at timestamp
+                                               :updated-at timestamp})
+          next-message (message/create-custom-message "notice" "hi" true nil timestamp)
+          updated (session/append-message ctx next-message)]
+      (is (= "s1" (:session-id ctx)))
+      (is (= 2 (count (:messages updated))))
+      (is (thrown? js/Error
+                   (session/append-message ctx {:role :user
+                                                :content []
+                                                :timestamp timestamp})))
+      (is (thrown? js/Error
+                   (session/append-message ctx {:role :user
+                                                :content [(message/create-text-content "valid")]
+                                                :timestamp -1}))))))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/message_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/domain/message_test.cljs
@@ -1,0 +1,87 @@
+(ns eta-mu.runtime.domain.message-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.domain.message :as message]))
+
+(def timestamp 1780099200000)
+
+(deftest bash-execution-message-to-llm-test
+  (testing "bash executions become user text unless excluded"
+    (let [bash-message (message/create-bash-execution-message
+                        {:command "pnpm test"
+                         :output "failed"
+                         :exit-code 1
+                         :cancelled false
+                         :truncated true
+                         :full-output-path "/tmp/full.log"
+                         :timestamp timestamp})
+          [llm-message] (message/convert-to-llm [bash-message])]
+      (is (= :user (:role llm-message)))
+      (is (= :text (-> llm-message :content first :type)))
+      (is (re-find #"Ran `pnpm test`" (-> llm-message :content first :text)))
+      (is (re-find #"Command exited with code 1" (-> llm-message :content first :text)))
+      (is (re-find #"/tmp/full.log" (-> llm-message :content first :text))))
+    (let [excluded (message/create-bash-execution-message
+                    {:command "secret"
+                     :output "hidden"
+                     :cancelled false
+                     :truncated false
+                     :exclude-from-context true
+                     :timestamp timestamp})]
+      (is (= [] (message/convert-to-llm [excluded]))))))
+
+(deftest summary-message-to-llm-test
+  (testing "branch and compaction summaries preserve their compatibility wrappers"
+    (let [branch (message/create-branch-summary-message "branch facts" "abc" timestamp)
+          compaction (message/create-compaction-summary-message "old facts" 1200 timestamp)
+          [branch-llm compaction-llm] (message/convert-to-llm [branch compaction])]
+      (is (re-find #"came back from" (-> branch-llm :content first :text)))
+      (is (re-find #"branch facts" (-> branch-llm :content first :text)))
+      (is (re-find #"compacted" (-> compaction-llm :content first :text)))
+      (is (re-find #"old facts" (-> compaction-llm :content first :text))))))
+
+(deftest custom-message-content-parts-test
+  (testing "custom messages keep text/image/audio input parts explicit"
+    (let [custom (message/create-custom-message
+                  "extension.notice"
+                  [(message/create-text-content "hello")
+                   (message/create-image-content "aW1n" "image/png")
+                   (message/create-audio-content "YXVkaW8=" "audio/wav" :wav)]
+                  true
+                  {:source :test}
+                  timestamp)
+          [llm-message] (message/convert-to-llm [custom])]
+      (is (= [:text :image :audio] (mapv :type (:content llm-message))))
+      (is (= "audio/wav" (-> llm-message :content last :mime-type))))))
+
+(deftest llm-passthrough-message-test
+  (testing "already-compatible user, assistant, and tool-result messages pass through unchanged"
+    (let [usage {:input 1
+                 :output 2
+                 :cache-read 0
+                 :cache-write 0
+                 :total-tokens 3
+                 :cost {:input 0 :output 0 :cache-read 0 :cache-write 0 :total 0}}
+          user {:role :user
+                :content [(message/create-text-content "hello")]
+                :timestamp timestamp}
+          assistant {:role :assistant
+                     :content [(message/create-text-content "done")]
+                     :api "openai-responses"
+                     :provider "openai"
+                     :model "gpt-test"
+                     :usage usage
+                     :stop-reason :stop
+                     :timestamp timestamp}
+          tool-result {:role :tool-result
+                       :tool-call-id "tool-1"
+                       :tool-name "read"
+                       :content [(message/create-text-content "ok")]
+                       :is-error false
+                       :timestamp timestamp}]
+      (is (= [user assistant tool-result]
+             (message/convert-to-llm [user assistant tool-result]))))))
+
+(deftest malformed-content-rejected-test
+  (testing "major content types reject malformed payloads"
+    (is (thrown? js/Error (message/create-image-content "aW1n" nil)))
+    (is (thrown? js/Error (message/create-audio-content "YXVkaW8=" "audio/wav" :not-a-format)))))

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/facade_test.cljs
@@ -58,3 +58,102 @@
                                     :crust 0
                                     :bloomNeed 0.25
                                     :userIntentConfidence 0.5}})))))
+
+(deftest message-facade-roundtrip-test
+  (testing "facade round-trips representative message payloads to LLM-compatible messages"
+    (let [bash-message (facade/create-bash-execution-message
+                        #js {:command "echo hi"
+                             :output "hi"
+                             :exitCode 0
+                             :cancelled false
+                             :truncated false
+                             :timestamp "2026-05-30T00:00:00.000Z"})
+          custom-message (facade/create-custom-message
+                          "extension.notice"
+                          #js [(facade/create-text-content "look")
+                               (facade/create-image-content "aW1n" "image/png")
+                               (facade/create-audio-content "YXVkaW8=" "audio/wav" "wav")]
+                          true
+                          #js {:source "test"}
+                          "2026-05-30T00:00:01.000Z")
+          bash-roundtrip (->clj bash-message)
+          llm (->clj (facade/convert-to-llm-messages #js [bash-message custom-message]))]
+      (is (false? (:excludeFromContext bash-roundtrip)))
+      (is (= ["user" "user"] (mapv :role llm)))
+      (is (re-find #"Ran `echo hi`" (-> llm first :content first :text)))
+      (is (= ["text" "image" "audio"] (mapv :type (-> llm second :content)))))))
+
+(deftest runtime-core-facade-test
+  (testing "facade exposes pure tool/model/session runtime data contracts"
+    (let [tools (->clj (facade/compose-tool-descriptors
+                        #js [#js [(facade/create-tool-descriptor
+                                   #js {:name "read"
+                                        :description "Read files"
+                                        :parameters #js {}})]
+                             #js [(facade/create-tool-descriptor
+                                   #js {:name "read"
+                                        :description "Duplicate"
+                                        :parameters #js {}})
+                                  (facade/create-tool-descriptor
+                                   #js {:name "write"
+                                        :description "Write files"
+                                        :parameters #js {}
+                                        :enabled false})]]))
+          models (->clj (facade/select-compatible-models
+                         #js [#js {:id "cheap-text"
+                                   :name "Cheap Text"
+                                   :api "openai-responses"
+                                   :provider "openai"
+                                   :baseUrl "https://api.openai.example/v1"
+                                   :reasoning false
+                                   :input #js ["text"]
+                                   :cost #js {:input 0.1 :output 0.2 :cacheRead 0 :cacheWrite 0}
+                                   :contextWindow 128000
+                                   :maxTokens 4096}
+                              #js {:id "reasoning-audio"
+                                   :name "Reasoning Audio"
+                                   :api "anthropic-messages"
+                                   :provider "anthropic"
+                                   :baseUrl "https://api.anthropic.example"
+                                   :reasoning true
+                                   :input #js ["text" "image" "audio"]
+                                   :cost #js {:input 1 :output 2 :cacheRead 0.1 :cacheWrite 0.2}
+                                   :contextWindow 200000
+                                   :maxTokens 8192}]
+                         #js {:inputs #js ["text" "audio"]
+                              :reasoningRequired true
+                              :minContextWindow 160000}))
+          session (->clj (facade/create-session-context
+                          #js {:sessionId "s1"
+                               :cwd "/repo"
+                               :messages #js [#js {:role "user"
+                                                   :content #js [(facade/create-text-content "hello")]
+                                                   :timestamp 1780099200000}]
+                               :activeToolNames #js ["read" "write"]
+                               :metadata #js {:branch "main"}
+                               :createdAt 1780099200000
+                               :updatedAt 1780099200000}))]
+      (is (= ["read" "write"] (mapv :name tools)))
+      (is (false? (:enabled (first (filter #(= "write" (:name %)) tools)))))
+      (is (= "reasoning-audio" (-> models first :id)))
+      (is (= "s1" (:sessionId session)))
+      (is (= "text" (-> session :messages first :content first :type)))
+      (is (thrown? js/Error
+                   (facade/select-compatible-models
+                    #js [#js {:id "cheap-text"
+                              :name "Cheap Text"
+                              :api "openai-responses"
+                              :provider "openai"
+                              :baseUrl "https://api.openai.example/v1"
+                              :reasoning false
+                              :input #js ["text"]
+                              :cost #js {:input 0.1 :output 0.2 :cacheRead 0 :cacheWrite 0}
+                              :contextWindow 128000
+                              :maxTokens 4096}]
+                    #js {:inputs #js ["text"]
+                         :reasoningRequired "false"}))))))
+
+(deftest invalid-timestamp-rejected-test
+  (testing "facade rejects invalid timestamp inputs before domain validation"
+    (is (thrown? js/Error
+                 (facade/create-branch-summary-message "summary" "from" "not-a-date")))))


### PR DESCRIPTION
## Phase 2: Runtime Core Contracts

**Epic:** eta-mu-cljs-runtime-rewrite
**Task:** eta-mu-cljs-rewrite-runtime-core
**Points:** 13

### What this delivers
- 10 `domain.*` CLJS namespaces (breath, candidate, envelope, message, model, planner, session, state, surface, tool)
- 11 `law.*` CLJS namespaces (boundary, candidate, content_part, core, message, model, planning, session, state, surface, tool, types)
- 6 `shape.*` CLJS namespaces (compat, message, model, session, surface, tool)
- 7 CLJS test files covering domain core, message, planner, state, extern, facade, shape message
- `facade.cljs` (241 lines) wires all domain/shape/law namespaces into JS-facing functions
- TS compatibility wrappers in `state.ts`, `planner.ts`, `envelope.ts` that delegate to CLJS

### Verification
```bash
pnpm --dir packages/eta-mu-runtime cljs:test
pnpm --dir packages/eta-mu-runtime cljs:boundary
```

### Acceptance criteria
- [x] Pure runtime core tests pass under CLJS test target
- [x] JS callers can round-trip representative runtime payloads through CLJS facade
- [x] Boundary schemas reject at least one malformed payload per major data type
- [x] No raw JS interop appears outside allowed facade/extern namespaces