### PR TITLE
feat(runtime): Phase 3 — Boundary Adapters

### DIFF
--- a/docs/cljs-runtime-rewrite-boundary-adapter-plan.md
+++ b/docs/cljs-runtime-rewrite-boundary-adapter-plan.md
@@ -1,0 +1,294 @@
+# Eta-mu CLJS Runtime Rewrite — Boundary Adapter Plan
+
+Date: 2026-05-29
+Parent epic: `kanban/epics/eta-mu-cljs-runtime-rewrite.md`
+Kanban task: `kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md`
+Depends on: `docs/cljs-runtime-rewrite-shadow-spine-plan.md`
+Related: `docs/cljs-runtime-rewrite-runtime-core-plan.md`
+
+## Purpose
+
+Define how eta-mu will isolate raw JavaScript, Node, browser, provider SDK, OpenCode/pi host, and filesystem/process effects while rewriting the runtime in ClojureScript.
+
+The goal is not to ban interop. The goal is to make every interop boundary named, testable, and invisible to `domain.*`, `shape.*`, and `law.*` code.
+
+## Boundary law
+
+Raw host objects and JS interop may be born only in:
+
+- `eta_mu.runtime.extern.*`
+- test doubles under `test/cljs/**` where explicitly allowed
+
+Tiny JS/CLJS facades must call named `extern.*` adapters for API compatibility conversion instead of owning raw interop directly.
+
+Disallowed in ordinary runtime namespaces:
+
+- `js/JSON`, `js/Promise`, `js/Array.from`, `js/Buffer`, `js/process`, `js/window`, `js/document`
+- `js->clj`, `clj->js`, `#js`, `aget`, `aset`
+- SDK-native objects from providers, OpenCode, pi, Fastify, WebSocket, terminal, or browser APIs
+- namespace segments named `utils`
+
+## Adapter API rule
+
+Adapters must expose CLJS-first public functions:
+
+```clojure
+;; Good: data in, data out
+(fetch-json {:url "https://example.test"
+             :method :post
+             :headers {"authorization" "Bearer ..."}
+             :json {:query "x"}})
+;; => Promise resolving to {:status 200 :headers {...} :body {...}}
+
+;; Bad outside extern: raw RequestInit / Response / SDK object leakage
+```
+
+If a raw object must survive across layers, it is an opaque handle. Only the owning adapter may inspect it.
+
+## Initial adapter inventory
+
+| Boundary | Current source hotspots | Target namespace | Public data contract |
+|---|---|---|---|
+| Node filesystem | `coding-agent/src/core/session-manager.ts`, `resource-loader.ts`, `auth-storage.ts`, `output-contract-gate/src/artifacts.ts`, extension receipt tools | `eta_mu.runtime.extern.fs` | paths and strings/bytes; result maps with `:ok`, `:path`, `:content`, `:error`. |
+| Node path/url | many CLI/session/provider files | `eta_mu.runtime.extern.path` | string paths/URLs only. |
+| Process/env | `coding-agent/src/cli.ts`, config/model/auth files, extension tools | `eta_mu.runtime.extern.process` | `env`, `cwd`, `exit`, `argv` as CLJS data. |
+| Child process/bash | `coding-agent/src/core/bash-executor.ts`, `utils/child-process.ts`, `core/exec.ts` | `eta_mu.runtime.extern.process_exec` | command, args, cwd, env, timeout -> stdout/stderr/exit/truncation map. |
+| Git | `coding-agent/src/utils/git.ts`, package-manager flows | `eta_mu.runtime.extern.git` | repo path + git operation maps; no shell strings in domain. |
+| HTTP/fetch | `ai/src/providers/**`, `extensions/websearch_open_hax.cljs`, Proxx calls | `eta_mu.runtime.extern.http` | request map with `:json`/`:body`; response map with decoded body. |
+| Provider SDKs | `ai/src/providers/**` | `eta_mu.runtime.extern.provider.*` | provider-specific adapter maps; native request/response stays inside adapter. |
+| Proxx provider | custom provider routing and Knoxx dependency | `eta_mu.runtime.extern.provider.proxx` | OpenAI-compatible/proxx request and stream maps. |
+| OpenCode/pi host | `eta-mu-extensions/src/eta_mu/extensions/**`, `coding-agent/src/core/extensions/**` | `eta_mu.runtime.extern.opencode`, `eta_mu.runtime.extern.pi_host` | context, UI, tool registration, event APIs through opaque handles + CLJS maps. |
+| Markdown parser | `output-contract-gate/src/markdown.ts`, `eta_mu/contracts/core.cljs` MarkdownIt tokens | `eta_mu.runtime.extern.markdown` | markdown string -> CLJS AST/section maps. |
+| EDN parser | `output-contract-gate/src/edn.ts`, contract runtime | `eta_mu.runtime.extern.edn` or `shape.edn` depending parser choice | EDN string -> CLJS data/forms; parse errors as maps. |
+| Browser DOM/history/storage | `opencode-reactant/src/opencode/ui/**`, `web-ui/src/**` | `eta_mu.runtime.extern.browser.*` | browser state and event handles; UI state consumes maps. |
+| WebSocket/XMLHttpRequest | `opencode-reactant/src/opencode/ui/core.cljs`, `github.cljs`, `files.cljs` | `eta_mu.runtime.extern.browser.ws`, `eta_mu.runtime.extern.browser.http` | event maps and response maps. |
+| Terminal/TUI | `tui/src/**` | `eta_mu.runtime.extern.terminal` | terminal capabilities and render commands as data. |
+| Image/audio conversion | `coding-agent/src/utils/image-*.ts`, clipboard/image/audio utilities | `eta_mu.runtime.extern.media.*` | content parts and file/byte handles; codecs inside adapter. |
+| Package manager/npm | `coding-agent/src/core/package-manager.ts`, package command tests | `eta_mu.runtime.extern.package_manager` | package op maps; command execution delegated to process adapter. |
+
+## Existing CLJS hotspot handling
+
+### `packages/eta-mu-extensions`
+
+Existing CLJS already uses host interop heavily. Treat it as a working behavior donor, not as the final architecture.
+
+Immediate targets:
+
+- `websearch_open_hax.cljs` -> split into `extern.http`, `extern.fs`, and `infra.tools.websearch`.
+- `opencode_global_instructions.cljs` -> split into `extern.fs`, `extern.process`, `extern.opencode`, `law.contract_runtime`, and `shape.opmf`.
+- `contracts/core.cljs` MarkdownIt token access -> move parser/token handling behind `extern.markdown`.
+- receipt/session tools -> keep EDN/log file operations in `extern.fs` and repo discovery in `infra.receipts.repo`.
+
+### `packages/opencode-reactant`
+
+Existing browser CLJS should inform browser adapter design:
+
+- `WebSocket` and reconnect timers -> `extern.browser.ws`
+- `XMLHttpRequest`/JSON parsing -> `extern.browser.http`
+- `localStorage` -> `extern.browser.storage`
+- `history`/`window.location` -> `extern.browser.history`
+- console/debug logging -> `extern.browser.console` or an injected logger
+
+Do not let browser globals appear in reusable runtime core namespaces.
+
+## Boundary scanner plan
+
+Add a first scanner under the first CLJS runtime home, likely:
+
+```text
+packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
+```
+
+Inputs:
+
+- `src/cljs/**/*.cljs`
+- optional `--allow-test-interop` for `test/cljs/**`
+
+Allowed file patterns:
+
+- `src/cljs/**/extern/**/*.cljs`
+
+Allowlist comments are not implemented; the current scanner enforces an extern-only raw-interop boundary.
+
+Disallowed tokens:
+
+```text
+js/
+js->clj
+clj->js
+#js
+aget
+aset
+js/Promise
+js/JSON
+js/Array.from
+js/Buffer
+js/process
+js/window
+js/document
+```
+
+Disallowed namespace names:
+
+```text
+.utils
+/utils/
+```
+
+Output:
+
+```text
+boundary violation: src/cljs/eta_mu/runtime/domain/state.cljs:12 uses js/Date outside extern/facade
+boundary violation: src/cljs/eta_mu/runtime/shape/utils.cljs uses forbidden namespace segment utils
+```
+
+Exit non-zero on any violation.
+
+## Adapter test pattern
+
+Every adapter gets at least one conversion test.
+
+Examples:
+
+### HTTP adapter
+
+- Given CLJS request map with `:json`, adapter builds native request internally.
+- Given fake response, adapter returns `{:status 200 :body {...}}`.
+- Non-JSON response returns structured error map, not native exception leakage.
+
+### FS adapter
+
+- `read-text` returns string content for an existing file.
+- missing file returns/throws a normalized error with path and code.
+- `write-text!` creates parent directories only when requested.
+
+### OpenCode host adapter
+
+- fake host context with JS methods can receive CLJS tool result maps.
+- adapter translates host UI notify/status calls without exposing raw context in infra tools.
+
+### Provider adapter
+
+- CLJS message maps encode to provider payload.
+- provider response decodes to CLJS assistant/tool/content part maps.
+- streaming event shape is normalized before leaving adapter.
+
+## Implementation order
+
+### Step 1 — Core package boundary scanner
+
+Build scanner in `packages/eta-mu-runtime` as part of the shadow spine. It should be intentionally strict because the first runtime core has no real reason to use raw JS outside facade.
+
+### Step 2 — Minimal externs for runtime facade
+
+Only add what the runtime-core facade needs:
+
+- maybe `extern.time` if default timestamps must be generated
+- maybe `extern.js` for camelCase JS object conversion if not handled in facade
+
+Prefer passing `now` into pure functions to avoid an early time adapter.
+
+### Step 3 — Output-contract adapter split
+
+When porting `output-contract-gate`, add:
+
+- `extern.fs`
+- `extern.markdown`
+- `extern.edn` if parser is JS-backed
+- `infra.output_contract.artifacts`
+- `law.output_contract`
+- `shape.markdown`
+
+### Step 4 — Extension host adapters
+
+Before migrating custom tools, add:
+
+- `extern.opencode`
+- `extern.pi_host`
+- `extern.http`
+- `extern.process`
+- `extern.fs`
+
+Then port one extension/tool path at a time.
+
+### Step 5 — Provider adapters
+
+Only after message/content-part schemas are stable:
+
+- `extern.provider.openai`
+- `extern.provider.anthropic`
+- `extern.provider.google`
+- `extern.provider.bedrock`
+- `extern.provider.proxx`
+
+Do not migrate all providers in one slice.
+
+## Acceptable raw interop examples
+
+```clojure
+(ns eta-mu.runtime.extern.http)
+
+(defn fetch-json [request]
+  ;; raw js/fetch and clj->js allowed here
+  ...)
+```
+
+```clojure
+(ns eta-mu.runtime.facade)
+
+(defn ^:export createEtaMuState [js-options]
+  ;; only compatibility conversion; no domain logic here
+  ...)
+```
+
+## Unacceptable raw interop examples
+
+```clojure
+(ns eta-mu.runtime.domain.state)
+
+(defn create-breath-episode [id]
+  {:opened-at (.toISOString (js/Date.))}) ;; not allowed: hidden clock in domain
+```
+
+```clojure
+(ns eta-mu.runtime.shape.utils) ;; not allowed: utils namespace
+```
+
+## Verification commands
+
+For the first package:
+
+```bash
+pnpm --dir packages/eta-mu-runtime cljs:boundary
+pnpm --dir packages/eta-mu-runtime cljs:verify
+```
+
+For later extension/tool slices:
+
+```bash
+pnpm -C packages/eta-mu-extensions test
+pnpm -C packages/eta-mu-extensions build
+```
+
+For coding-agent runtime slices:
+
+```bash
+pnpm --filter @open-hax/eta-mu-cli test
+```
+
+## Acceptance checklist
+
+- [x] Boundary scanner exists and is wired into CLJS verification.
+- [x] Raw interop in new runtime CLJS appears only in `extern.*` namespaces.
+- [x] Each added adapter has at least one conversion/regression test.
+- [x] Adapter public APIs use CLJS maps/vectors/scalars or opaque handles.
+- [x] Domain/law/shape namespaces do not import provider SDKs, Node modules, browser globals, or OpenCode/pi host objects.
+- [x] No new `utils` namespace is introduced.
+
+## Implementation note
+
+The boundary-adapter PR moved facade JS conversion and timestamp defaults through `eta-mu.runtime.extern.js` and `eta-mu.runtime.extern.time`, added JSON/HTTP/process adapters, and added `eta-mu.runtime.infra.boundary` inventory data. The scanner now treats `extern.*` as the only raw-interop allow zone; facade code must call named adapters.
+
+## Recommended next planning handoff
+
+Use this plan during the next surface-parity implementation to broaden adapter coverage only where a migrated runtime path actually touches the world. Keep the scanner strict and local to `packages/eta-mu-runtime` until additional CLJS packages join the rewrite.

--- a/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
+++ b/kanban/tasks/eta-mu-cljs-rewrite-boundary-adapters.md
@@ -1,7 +1,7 @@
 ---
 uuid: "eta-mu-cljs-rewrite-boundary-adapters"
 title: "Eta-mu CLJS Rewrite — Boundary Adapters"
-status: todo
+status: review
 priority: P0
 labels: ["tasks", "cljs", "rewrite", "extern", "13sp"]
 created_at: "2026-05-29T21:18:48Z"
@@ -30,22 +30,30 @@ Create the named `extern.*` and `infra.*` boundary layers needed for CLJS runtim
 
 ## Work items
 
-- [ ] Define one named `extern.*` namespace per real boundary.
-- [ ] Keep adapter public APIs CLJS-first: maps, vectors, scalars, or opaque handles.
-- [ ] Move `js->clj`, `clj->js`, `#js`, `aget`, `aset`, `Promise.all`, Node globals, and SDK-native object access into extern adapters only.
-- [ ] Add conversion tests for each adapter that is used by migrated runtime code.
-- [ ] Add a boundary inventory/check script similar to Knoxx's `boundary:check` pattern.
+- [x] Define one named `extern.*` namespace per real boundary.
+- [x] Keep adapter public APIs CLJS-first: maps, vectors, scalars, or opaque handles.
+- [x] Move `js->clj`, `clj->js`, `#js`, `aget`, `aset`, `Promise.all`, Node globals, and SDK-native object access into extern adapters only.
+- [x] Add conversion tests for each adapter that is used by migrated runtime code.
+- [x] Add a boundary inventory/check script similar to Knoxx's `boundary:check` pattern.
 
 ## Acceptance criteria
 
-- [ ] Boundary inventory runs and reports no disallowed raw JS interop outside `extern.*`/facade namespaces.
-- [ ] Each migrated effectful runtime path has an adapter-level test.
-- [ ] Infra orchestration namespaces remain data-in/data-out and do not own domain policy.
+- [x] Boundary inventory runs and reports no disallowed raw JS interop outside `extern.*` namespaces.
+- [x] Each migrated effectful runtime path has an adapter-level test.
+- [x] Infra orchestration namespaces remain data-in/data-out and do not own domain policy.
 
 ## Verification
 
 ```bash
 pnpm --dir packages/eta-mu-runtime cljs:boundary
 pnpm --dir packages/eta-mu-runtime cljs:verify
+pnpm --dir packages/eta-mu-runtime test
+pnpm --dir packages/eta-mu-runtime typecheck
+pnpm --dir packages/eta-mu-runtime build
+pnpm test
 pnpm -C packages/eta-mu-extensions test
 ```
+
+## Notes
+
+Implemented the first runtime boundary adapter slice in `packages/eta-mu-runtime` with named `extern.*` adapters for JS value conversion, time/timestamps, JSON, HTTP request encoding, and process snapshots. Added `infra.boundary` inventory data for implemented and planned boundaries, moved facade JS conversion/time defaults through extern adapters, and tightened the boundary scanner so raw interop is allowed only under `extern.*`.

--- a/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
+++ b/packages/eta-mu-runtime/scripts/check-cljs-boundaries.mjs
@@ -22,7 +22,7 @@ const disallowedTokens = [
 
 function isAllowedInteropFile(filePath) {
   const normalized = filePath.split(path.sep).join("/");
-  return normalized.includes("/extern/") || normalized.endsWith("/facade.cljs");
+  return normalized.includes("/extern/");
 }
 
 function hasForbiddenUtilsSegment(filePath) {
@@ -47,15 +47,18 @@ async function walk(dir) {
 const violations = [];
 const files = await walk(sourceRoot);
 
+let externCount = 0;
+
 for (const file of files) {
   const relative = path.relative(root, file);
 
-  if (isAllowedInteropFile(file)) {
-    continue;
-  }
-
   if (hasForbiddenUtilsSegment(file)) {
     violations.push(`${relative}: forbidden utils namespace/path segment`);
+  }
+
+  if (isAllowedInteropFile(file)) {
+    externCount += 1;
+    continue;
   }
 
   const text = await readFile(file, "utf8");
@@ -65,7 +68,7 @@ for (const file of files) {
       // Intentional first-pass scanner: this flags mentions in comments/docstrings too.
       // Prefer occasional false positives over silently allowing raw interop to leak.
       if (line.includes(token)) {
-        violations.push(`${relative}:${index + 1}: raw interop token outside extern/facade: ${token}`);
+        violations.push(`${relative}:${index + 1}: raw interop token outside extern: ${token}`);
       }
     }
   });
@@ -76,4 +79,4 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
-console.log(JSON.stringify({ ok: true, checked: files.length }));
+console.log(JSON.stringify({ ok: true, checked: files.length, extern: externCount }));

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/http.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/http.cljs
@@ -1,0 +1,34 @@
+(ns eta-mu.runtime.extern.http
+  (:require [clojure.string :as str]
+            [eta-mu.runtime.extern.js :as extern-js]
+            [eta-mu.runtime.extern.json :as json]
+            [eta-mu.runtime.law.boundary :as boundary-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(defn- method-name
+  [method]
+  (-> (or method :get) name str/upper-case))
+
+(defn request->fetch-init
+  "Convert a CLJS HTTP request map into an opaque JS fetch init object.
+   The raw object must not leave extern/infra code except as an opaque handle."
+  [request]
+  (let [request (law/validate! boundary-law/http-request-schema request "http request")
+        headers (merge (when (:json request)
+                         {"content-type" "application/json"})
+                       (:headers request))
+        body (cond
+               (contains? request :json) (json/stringify (:json request))
+               (contains? request :body) (:body request)
+               :else nil)
+        init (cond-> {:method (method-name (:method request))
+                      :headers headers}
+               body (assoc :body body)
+               (:signal request) (assoc :signal (:signal request)))]
+    (extern-js/clj->value init)))
+
+(defn response-map
+  [status headers body]
+  {:status status
+   :headers headers
+   :body body})

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/js.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/js.cljs
@@ -1,0 +1,37 @@
+(ns eta-mu.runtime.extern.js)
+
+(defn value->clj
+  "Decode a JavaScript value into keywordized CLJS data at a named boundary."
+  [value]
+  (js->clj value :keywordize-keys true))
+
+(defn object->clj
+  "Decode a possibly nil JavaScript object into a keywordized CLJS map."
+  [value]
+  (js->clj (or value #js {}) :keywordize-keys true))
+
+(defn array->clj-vector
+  "Decode a possibly nil JavaScript array into a CLJS vector."
+  [value]
+  (vec (js->clj (or value #js []) :keywordize-keys true)))
+
+(defn clj->value
+  "Encode CLJS data as a JavaScript value at a named boundary."
+  [value]
+  (clj->js value))
+
+(defn success
+  [boundary value]
+  {:ok true
+   :boundary boundary
+   :value value})
+
+(defn error
+  ([boundary message]
+   (error boundary message nil nil))
+  ([boundary message code cause]
+   (cond-> {:ok false
+            :boundary boundary
+            :message message}
+     code (assoc :code code)
+     cause (assoc :cause cause))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/json.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/json.cljs
@@ -1,0 +1,13 @@
+(ns eta-mu.runtime.extern.json
+  (:require [eta-mu.runtime.extern.js :as extern-js]))
+
+(defn stringify
+  [value]
+  (js/JSON.stringify (extern-js/clj->value value)))
+
+(defn parse
+  [text]
+  (try
+    (extern-js/success :json (extern-js/value->clj (js/JSON.parse text)))
+    (catch js/Error error
+      (extern-js/error :json "Invalid JSON" (.-name error) (.-message error)))))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/process.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/process.cljs
@@ -1,0 +1,39 @@
+(ns eta-mu.runtime.extern.process
+  (:require [eta-mu.runtime.extern.js :as extern-js]
+            [eta-mu.runtime.law.boundary :as boundary-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(defn- process-handle
+  []
+  (.-process js/globalThis))
+
+(defn argv
+  []
+  (if-let [process (process-handle)]
+    (extern-js/array->clj-vector (.-argv process))
+    []))
+
+(defn cwd
+  []
+  (if-let [process (process-handle)]
+    (if-let [cwd-fn (.-cwd process)]
+      (cwd-fn)
+      ".")
+    "."))
+
+(defn env
+  []
+  (if-let [process (process-handle)]
+    (->> (js/Object.entries (or (.-env process) #js {}))
+         array-seq
+         (map (fn [entry] [(aget entry 0) (aget entry 1)]))
+         (into {}))
+    {}))
+
+(defn snapshot
+  []
+  (law/validate! boundary-law/process-snapshot-schema
+                 {:argv (argv)
+                  :cwd (cwd)
+                  :env (env)}
+                 "process snapshot"))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/time.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/extern/time.cljs
@@ -1,0 +1,29 @@
+(ns eta-mu.runtime.extern.time)
+
+(defn finite-number!
+  [value label]
+  (if (and (number? value) (js/Number.isFinite value))
+    value
+    (throw (ex-info (str "Invalid eta-mu runtime " label)
+                    {:label label
+                     :value value}))))
+
+(defn now-ms
+  []
+  (finite-number! (.getTime (js/Date.)) "timestamp"))
+
+(defn now-iso
+  []
+  (.toISOString (js/Date.)))
+
+(defn timestamp-ms
+  [value]
+  (cond
+    (number? value)
+    (finite-number! value "timestamp")
+
+    (string? value)
+    (finite-number! (.getTime (js/Date. value)) "timestamp")
+
+    :else
+    (now-ms)))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/facade.cljs
@@ -7,6 +7,8 @@
             [eta-mu.runtime.domain.session :as session]
             [eta-mu.runtime.domain.state :as state]
             [eta-mu.runtime.domain.tool :as tool]
+            [eta-mu.runtime.extern.js :as host]
+            [eta-mu.runtime.extern.time :as extern-time]
             [eta-mu.runtime.shape.compat :as compat]
             [eta-mu.runtime.shape.message :as message-shape]
             [eta-mu.runtime.shape.model :as model-shape]
@@ -15,39 +17,23 @@
 
 (defn- now-iso
   []
-  (.toISOString (js/Date.)))
+  (extern-time/now-iso))
 
 (defn- js-value
   [value]
-  (js->clj value :keywordize-keys true))
+  (host/value->clj value))
 
 (defn- js-map
   [value]
-  (js->clj (or value #js {}) :keywordize-keys true))
-
-(defn- finite-number!
-  [value label]
-  (if (and (number? value) (js/Number.isFinite value))
-    value
-    (throw (ex-info (str "Invalid eta-mu runtime " label)
-                    {:label label
-                     :value value}))))
+  (host/object->clj value))
 
 (defn- timestamp-ms
   [value]
-  (cond
-    (number? value)
-    (finite-number! value "timestamp")
-
-    (string? value)
-    (finite-number! (.getTime (js/Date. value)) "timestamp")
-
-    :else
-    (finite-number! (.getTime (js/Date.)) "timestamp")))
+  (extern-time/timestamp-ms value))
 
 (defn- ->js
   [value]
-  (clj->js value))
+  (host/clj->value value))
 
 (defn create-eta-belief
   "JS facade for createEtaBelief."
@@ -112,7 +98,7 @@
   ([context actions]
    (let [context (-> context js-map compat/planning-context-from-external)
          actions (when actions
-                   (mapv compat/candidate-from-external (js->clj actions :keywordize-keys true)))]
+                   (mapv compat/candidate-from-external (host/value->clj actions)))]
      (-> context
          (breath/recommend actions)
          compat/breath-recommendation->external

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/infra/boundary.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/infra/boundary.cljs
@@ -1,0 +1,45 @@
+(ns eta-mu.runtime.infra.boundary
+  (:require [eta-mu.runtime.law.boundary :as boundary-law]
+            [eta-mu.runtime.law.core :as law]))
+
+(def implemented-boundaries
+  [{:boundary :js
+    :namespace "eta-mu.runtime.extern.js"
+    :contract "JS value <-> CLJS data conversion"}
+   {:boundary :time
+    :namespace "eta-mu.runtime.extern.time"
+    :contract "timestamps and ISO clock values"}
+   {:boundary :json
+    :namespace "eta-mu.runtime.extern.json"
+    :contract "JSON string <-> CLJS data conversion"}
+   {:boundary :http
+    :namespace "eta-mu.runtime.extern.http"
+    :contract "HTTP request map <-> opaque fetch init"}
+   {:boundary :process
+    :namespace "eta-mu.runtime.extern.process"
+    :contract "argv/cwd/env snapshots as CLJS data"}])
+
+(def planned-boundaries
+  [{:boundary :fs
+    :namespace "eta-mu.runtime.extern.fs"}
+   {:boundary :path
+    :namespace "eta-mu.runtime.extern.path"}
+   {:boundary :process-exec
+    :namespace "eta-mu.runtime.extern.process-exec"}
+   {:boundary :git
+    :namespace "eta-mu.runtime.extern.git"}
+   {:boundary :opencode
+    :namespace "eta-mu.runtime.extern.opencode"}
+   {:boundary :pi-host
+    :namespace "eta-mu.runtime.extern.pi-host"}
+   {:boundary :provider-proxx
+    :namespace "eta-mu.runtime.extern.provider-proxx"}])
+
+(defn boundary-inventory
+  []
+  {:implemented implemented-boundaries
+   :planned planned-boundaries})
+
+(defn validate-result
+  [result]
+  (law/validate! boundary-law/normalized-result-schema result "boundary result"))

--- a/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/boundary.cljs
+++ b/packages/eta-mu-runtime/src/cljs/eta_mu/runtime/law/boundary.cljs
@@ -1,0 +1,52 @@
+(ns eta-mu.runtime.law.boundary)
+
+(def boundary-name-schema
+  ;; `proxx` is the project/provider name, not a typo for proxy.
+  [:enum
+   :js
+   :time
+   :json
+   :http
+   :process
+   :fs
+   :path
+   :process-exec
+   :git
+   :opencode
+   :pi-host
+   :provider-proxx])
+
+(def normalized-error-schema
+  [:map
+   [:ok [:= false]]
+   [:boundary boundary-name-schema]
+   [:message [:string {:min 1}]]
+   [:code {:optional true} [:string {:min 1}]]
+   [:cause {:optional true} any?]])
+
+(def normalized-success-schema
+  [:map
+   [:ok [:= true]]
+   [:boundary boundary-name-schema]
+   [:value any?]])
+
+(def normalized-result-schema
+  [:or normalized-success-schema normalized-error-schema])
+
+(def http-method-schema
+  [:enum :get :post :put :patch :delete :head :options])
+
+(def http-request-schema
+  [:map
+   [:url [:string {:min 1}]]
+   [:method {:optional true} http-method-schema]
+   [:headers {:optional true} map?]
+   [:body {:optional true} any?]
+   [:json {:optional true} any?]
+   [:signal {:optional true} any?]])
+
+(def process-snapshot-schema
+  [:map
+   [:argv [:vector string?]]
+   [:cwd [:string {:min 1}]]
+   [:env map?]])

--- a/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/extern/core_test.cljs
+++ b/packages/eta-mu-runtime/test/cljs/eta_mu/runtime/extern/core_test.cljs
@@ -1,0 +1,58 @@
+(ns eta-mu.runtime.extern.core-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.runtime.extern.http :as http]
+            [eta-mu.runtime.extern.js :as extern-js]
+            [eta-mu.runtime.extern.json :as json]
+            [eta-mu.runtime.extern.process :as process]
+            [eta-mu.runtime.extern.time :as time]
+            [eta-mu.runtime.infra.boundary :as boundary]))
+
+(deftest js-boundary-roundtrip-test
+  (testing "JS extern converts values at a named boundary"
+    (let [value (extern-js/value->clj #js {:alpha 1 :nested #js {:beta true}})
+          encoded (extern-js/clj->value {:items [1 2]})]
+      (is (= {:alpha 1 :nested {:beta true}} value))
+      (is (= [1 2] (extern-js/value->clj (.-items encoded)))))))
+
+(deftest time-boundary-test
+  (testing "time extern validates timestamps before domain code receives them"
+    (is (= 1780099200000 (time/timestamp-ms "2026-05-30T00:00:00.000Z")))
+    (is (number? (time/now-ms)))
+    (is (thrown? js/Error (time/timestamp-ms "not-a-date")))))
+
+(deftest json-boundary-test
+  (testing "json extern returns normalized parse results"
+    (let [encoded (json/stringify {:ok true :items [1 2]})
+          parsed (json/parse encoded)
+          invalid (json/parse "{not json")]
+      (is (:ok parsed))
+      (is (= {:ok true :items [1 2]} (:value parsed)))
+      (is (false? (:ok invalid)))
+      (is (= :json (:boundary invalid))))))
+
+(deftest http-boundary-test
+  (testing "http extern builds an opaque fetch init from a CLJS request map"
+    (let [init (http/request->fetch-init {:url "https://example.test/api"
+                                          :method :post
+                                          :headers {"authorization" "Bearer token"}
+                                          :json {:query "eta"}})
+          decoded (extern-js/value->clj init)]
+      (is (= "POST" (:method decoded)))
+      (is (= "application/json" (get-in decoded [:headers :content-type])))
+      (is (= "Bearer token" (get-in decoded [:headers :authorization])))
+      (is (= {:query "eta"} (:value (json/parse (:body decoded))))))))
+
+(deftest process-boundary-test
+  (testing "process extern exposes argv/cwd/env as validated CLJS data"
+    (let [snapshot (process/snapshot)]
+      (is (vector? (:argv snapshot)))
+      (is (string? (:cwd snapshot)))
+      (is (map? (:env snapshot))))))
+
+(deftest boundary-inventory-test
+  (testing "infra boundary inventory separates implemented from planned adapters"
+    (let [{:keys [implemented planned]} (boundary/boundary-inventory)]
+      (is (some #(= :js (:boundary %)) implemented))
+      (is (some #(= :http (:boundary %)) implemented))
+      (is (some #(= :git (:boundary %)) planned))
+      (is (boundary/validate-result (extern-js/success :json {:a 1}))))))


### PR DESCRIPTION
## Phase 3: Boundary Adapters

**Epic:** eta-mu-cljs-runtime-rewrite
**Task:** eta-mu-cljs-rewrite-boundary-adapters
**Points:** 13

### What this delivers
- 5 `extern.*` namespaces: `js`, `time`, `json`, `http`, `process`
- `law/boundary.cljs` — Malli schemas for boundary names, normalized results, HTTP requests, process snapshots
- `infra/boundary.cljs` — `boundary-inventory` and `validate-result` functions
- Boundary scanner (`check-cljs-boundaries.mjs`) rejects raw interop outside `extern.*`
- 7 planned boundaries cataloged (fs, path, process-exec, git, opencode, pi-host, provider-proxx)

### Verification
```bash
pnpm --dir packages/eta-mu-runtime cljs:boundary
node scripts/check-cljs-boundaries.mjs
```

### Acceptance criteria
- [x] Boundary inventory runs and reports no disallowed raw JS interop outside extern.* namespaces
- [x] Each migrated effectful runtime path has an adapter-level test
- [x] Infra orchestration namespaces remain data-in/data-out