### PR TITLE
fix(extensions): make the extension release build pass clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,41 @@
+
+## Clojure House Rules (eta-mu-sol constitution)
+
+# Architecture Paradigm: Categories vs. Contracts
+When modeling domains, you must strictly differentiate between the grammar of motion and the enforcement of that motion.
+- Categories: Describe the space of lawful possible transformations. They dictate "what kind of move this is" and define the state space, transition vocabulary, and general laws of composition for the runtime or a subsystem.
+- Contracts: Decide whether a particular runtime entity, event, or transition is admissible under current obligations. They dictate "whether you are allowed to count it as a valid move right now" by defining guards, admissibility checks, evidence requirements, delivery expectations, and side-effect constraints.
+
+
+### Zero Warnings
+`clj-kondo`, type checks, and tests must all pass with zero warnings. Warnings
+are failed contracts, not noise.
+
+### Namespace Architecture
+| Layer         | Pattern            | Rule                             |
+|---------------|--------------------|----------------------------------|
+| `domain.*`    | Business logic     | No I/O. Pure functions only.     |
+| `infra.*`     | Transport/DB/Queue | No domain policy.                |
+| `shape.*`     | Data morphisms     | Pure, domain-agnostic.           |
+| `law.*`       | Contracts/Malli    | No I/O. Validators only.         |
+### Modern ClojureScript
+Always use `^:async` metadata (ClojureScript ≥ 1.12.145). Never use
+`core.async` channels or Promise chains in new code.
+
+```clojure
+(defn ^:async fetch-data [url]
+  (await (js/fetch url)))
+
+(deftest ^:async fetch-test
+  (is (some? (await (fetch-data "https://example.com")))))
+```
+
+### Idioms
+- `when-let` over nested `let` + `if`
+- `->` / `->>` over nested `let` forms
+- No `utils` namespaces
+- No broad `:refer :all`
+- Custom macros registered in `.clj-kondo/config.edn` on day one
 ## Testing Gate
 - A task is not done while any relevant automated test suite is failing.
 - For coding-agent changes, run `pnpm --filter @open-hax/eta-mu-cli test` and resolve all failures before reporting completion.

--- a/packages/extensions/lib/eta_mu/opencode.cljs
+++ b/packages/extensions/lib/eta_mu/opencode.cljs
@@ -50,7 +50,7 @@
 
 (defn- build-args-schema
   "Build an OpenCode tool args shape from eta-mu parameter specs.
-   @opencode-ai/plugin/tool expects a raw Zod shape object, not z.object(...)."
+   The opencode-ai/plugin tool expects a raw Zod shape object, not z.object(...)."
   [^js z params]
   (let [shape (js-obj)]
     (doseq [[k spec] params]

--- a/packages/extensions/src/eta_mu/extensions/apply_patch.cljs
+++ b/packages/extensions/src/eta_mu/extensions/apply_patch.cljs
@@ -275,7 +275,8 @@
                               :text (str "Success. Updated the following files:\n" summary)}]
            :details #js {:root root :changes changes}})))
 
-(def apply-patch nil)
+
+(declare apply-patch)
 
 (em/defextension apply-patch
   :name "apply-patch"

--- a/packages/extensions/src/eta_mu/extensions/bootstrap.cljs
+++ b/packages/extensions/src/eta_mu/extensions/bootstrap.cljs
@@ -2,7 +2,8 @@
   "Bootstrap extension - verifies the CLJS compile/load path works."
   (:require-macros [eta-mu.core :as em]))
 
-(def bootstrap nil)
+
+(declare bootstrap)
 
 (em/defextension bootstrap
   :name "bootstrap"

--- a/packages/extensions/src/eta_mu/extensions/chronos.cljs
+++ b/packages/extensions/src/eta_mu/extensions/chronos.cljs
@@ -128,7 +128,8 @@
                              (js/Array.from projects)))]
         (make-result (str/join "\n" lines) #js {:projects projects})))))
 
-(def chronos nil)
+
+(declare chronos)
 
 (em/defextension chronos
   :name "chronos"

--- a/packages/extensions/src/eta_mu/extensions/contract_runtime.cljs
+++ b/packages/extensions/src/eta_mu/extensions/contract_runtime.cljs
@@ -441,7 +441,8 @@
             ["recent audit:"]
             (map summarize-row (take 12 audit))))))))
 
-(def contract-runtime nil)
+
+(declare contract-runtime)
 
 (em/defextension contract-runtime
   :name "contract-runtime"

--- a/packages/extensions/src/eta_mu/extensions/contract_runtime_v2.cljs
+++ b/packages/extensions/src/eta_mu/extensions/contract_runtime_v2.cljs
@@ -355,7 +355,8 @@
 
 ;; ── Extension ────────────────────────────────────────────
 
-(def contract-runtime-v2 nil)
+
+(declare contract-runtime-v2)
 
 (em/defextension contract-runtime-v2
   :name "contract-runtime-v2"

--- a/packages/extensions/src/eta_mu/extensions/custom_providers.cljs
+++ b/packages/extensions/src/eta_mu/extensions/custom_providers.cljs
@@ -219,7 +219,8 @@
     ;;                         :context-window 262144 :max-tokens 262144))})
     ))
 
-(def custom-providers nil)
+
+(declare custom-providers)
 
 (em/defextension custom-providers
   :name "custom-providers"

--- a/packages/extensions/src/eta_mu/extensions/graph_memory.cljs
+++ b/packages/extensions/src/eta_mu/extensions/graph_memory.cljs
@@ -502,7 +502,8 @@
 ;; Tool Implementations
 ;; =============================================================================
 
-(def graph-memory nil)
+
+(declare graph-memory)
 
 (em/defextension graph-memory
   :name "graph-memory"

--- a/packages/extensions/src/eta_mu/extensions/image_render.cljs
+++ b/packages/extensions/src/eta_mu/extensions/image_render.cljs
@@ -132,7 +132,45 @@
              :origin "file"
              :file-path resolved}))))
 
-(def image-render nil)
+
+;; The async body lives in a top-level `^:async` defn rather than inline in the
+;; `em/tool` :execute fn: syntax-quote strips the `^:async` metadata when a fn
+;; form is spliced through the em/tool/defextension macros, so an inline
+;; `(fn ^:async [...] (await ...))` fails to compile ("await can only be used in
+;; async contexts"). A top-level defn is read directly, so its async marking is
+;; honored.
+(defn ^:async render-image!
+  [source max-bytes mime-override signal cwd on-update]
+  (let [payload (await (cond
+                         (.startsWith source "data:")
+                         (load-from-data-url source max-bytes mime-override)
+                         (or (.startsWith source "http://") (.startsWith source "https://"))
+                         (load-from-url source max-bytes mime-override signal)
+                         :else
+                         (load-from-file source max-bytes mime-override cwd)))]
+    (when on-update
+      (on-update #js {:content #js [#js {:type "text" :text "Loading image..."}]}))
+    (let [opened (when (is-alacritty?)
+                   (let [fp (if (and (= (aget payload "origin") "file")
+                                     (aget payload "file-path"))
+                              (aget payload "file-path")
+                              (await (write-temp-image (js/Buffer.from (aget payload "data") "base64")
+                                                       (aget payload "mimeType"))))]
+                     (when fp
+                       (open-in-viewer fp))))]
+      #js {:content #js [#js {:type "text"
+                              :text (str "Rendered image from " (aget payload "source-label")
+                                         " (" (aget payload "mimeType") ", " (format-bytes (aget payload "bytes")) ")."
+                                         (when opened
+                                           (str " Opened externally via " (aget opened "viewer") ": " (aget opened "file-path"))))}
+                         #js {:type "image"
+                              :data (aget payload "data")
+                              :mimeType (aget payload "mimeType")}]
+           :details #js {:source (aget payload "source-label")
+                         :mimeType (aget payload "mimeType")
+                         :bytes (aget payload "bytes")}})))
+
+(declare image-render)
 
 (em/defextension image-render
   :name "image-render"
@@ -144,36 +182,10 @@
     :parameters {:source {:type "string" :description "Local file path, http(s) URL, or data: URL to render."}
                  :mimeType {:type "string" :description "Optional MIME type override." :optional true}
                  :maxBytes {:type "integer" :description "Maximum bytes to load" :minimum 1 :optional true}}
-    :execute (fn ^:async [_tool-call-id params signal on-update ctx]
-               (let [source (.trim (aget params "source"))
-                     max-bytes (or (aget params "maxBytes") DEFAULT-MAX-BYTES)
-                     mime-override (aget params "mimeType")
-                     cwd (aget ctx "cwd")
-                     payload (await (cond
-                                      (.startsWith source "data:")
-                                      (load-from-data-url source max-bytes mime-override)
-                                      (or (.startsWith source "http://") (.startsWith source "https://"))
-                                      (load-from-url source max-bytes mime-override signal)
-                                      :else
-                                      (load-from-file source max-bytes mime-override cwd)))]
-                 (when on-update
-                   (on-update #js {:content #js [#js {:type "text" :text "Loading image..."}]}))
-                 (let [opened (when (is-alacritty?)
-                                (let [fp (if (and (= (aget payload "origin") "file")
-                                                  (aget payload "file-path"))
-                                           (aget payload "file-path")
-                                           (await (write-temp-image (js/Buffer.from (aget payload "data") "base64")
-                                                                    (aget payload "mimeType"))))]
-                                  (when fp
-                                    (open-in-viewer fp))))]
-                   #js {:content #js [#js {:type "text"
-                                           :text (str "Rendered image from " (aget payload "source-label")
-                                                      " (" (aget payload "mimeType") ", " (format-bytes (aget payload "bytes")) ")."
-                                                      (when opened
-                                                        (str " Opened externally via " (aget opened "viewer") ": " (aget opened "file-path"))))}
-                                          #js {:type "image"
-                                               :data (aget payload "data")
-                                               :mimeType (aget payload "mimeType")}]
-                        :details #js {:source (aget payload "source-label")
-                                      :mimeType (aget payload "mimeType")
-                                      :bytes (aget payload "bytes")}})))))
+    :execute (fn [_tool-call-id params signal on-update ctx]
+               (render-image! (.trim (aget params "source"))
+                              (or (aget params "maxBytes") DEFAULT-MAX-BYTES)
+                              (aget params "mimeType")
+                              signal
+                              (aget ctx "cwd")
+                              on-update))))

--- a/packages/extensions/src/eta_mu/extensions/lisp_decomp_nudge.cljs
+++ b/packages/extensions/src/eta_mu/extensions/lisp_decomp_nudge.cljs
@@ -100,7 +100,8 @@
   (.call (aget pi "on") pi "agent_end"
          (fn [_event ctx] (handle-agent-end pi ctx))))
 
-(def lisp-decomp-nudge nil)
+
+(declare lisp-decomp-nudge)
 
 (em/defextension lisp-decomp-nudge
   :name "lisp-decomp-nudge"

--- a/packages/extensions/src/eta_mu/extensions/opencode_global_instructions.cljs
+++ b/packages/extensions/src/eta_mu/extensions/opencode_global_instructions.cljs
@@ -719,7 +719,8 @@
 
 ;; ── Extension registration ─────────────────────────────────
 
-(def opencode-global-instructions nil)
+
+(declare opencode-global-instructions)
 
 (em/defextension opencode-global-instructions
   :name "opencode-global-instructions"

--- a/packages/extensions/src/eta_mu/extensions/opmf_contract_gate.cljs
+++ b/packages/extensions/src/eta_mu/extensions/opmf_contract_gate.cljs
@@ -1165,7 +1165,8 @@
   (.call (aget pi "on") pi "agent_idle" (fn [event ctx] (handle-agent-idle pi ctx event)))
   (.call (aget pi "on") pi "session_shutdown" (fn [_event ctx] (handle-session-shutdown ctx))))
 
-(def opmf-contract-gate nil)
+
+(declare opmf-contract-gate)
 
 (em/defextension opmf-contract-gate
   :name "opmf-contract-gate"

--- a/packages/extensions/src/eta_mu/extensions/receipt_river.cljs
+++ b/packages/extensions/src/eta_mu/extensions/receipt_river.cljs
@@ -506,7 +506,8 @@
                           :record (clj->js record)
                           :line line})))))
 
-(def receipt-river nil)
+
+(declare receipt-river)
 
 (em/defextension receipt-river
   :name "receipt-river"

--- a/packages/extensions/src/eta_mu/extensions/session_mycology.cljs
+++ b/packages/extensions/src/eta_mu/extensions/session_mycology.cljs
@@ -576,7 +576,8 @@
                                   :spore spore
                                    :promotion promotion})))))))))
 
-(def session-mycology nil)
+
+(declare session-mycology)
 
 (em/defextension session-mycology
   :name "session-mycology"

--- a/packages/extensions/src/eta_mu/extensions/task_timing.cljs
+++ b/packages/extensions/src/eta_mu/extensions/task_timing.cljs
@@ -105,7 +105,8 @@
              (- now-ms (aget state "toolSegmentStartMs"))))
     (aset state "toolSegmentStartMs" nil)))
 
-(def task-timing nil)
+
+(declare task-timing)
 
 (em/defextension task-timing
   :name "task-timing"

--- a/packages/extensions/src/eta_mu/extensions/websearch_open_hax.cljs
+++ b/packages/extensions/src/eta_mu/extensions/websearch_open_hax.cljs
@@ -105,7 +105,52 @@
                            :truncated true
                            :outputPath output-path}}))))
 
-(def websearch-open-hax nil)
+
+;; The async body lives in a top-level `^:async` defn rather than inline in the
+;; `em/tool` :execute fn: syntax-quote strips the `^:async` metadata when a fn
+;; form is spliced through the em/tool/defextension macros, so an inline
+;; `(fn ^:async [...] (await ...))` fails to compile ("await can only be used in
+;; async contexts"). A top-level defn is read directly, so its async marking is
+;; honored.
+(defn ^:async run-websearch!
+  [params signal onUpdate]
+  (let [token (proxy-token)]
+    (if-not token
+      (js/Promise.reject (js/Error. "Missing auth token for Open Hax proxy. Set OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN (or PROXY_AUTH_TOKEN)."))
+      (let [endpoint (str (.replace (proxy-url) #"/+$" "") "/api/tools/websearch")
+            model (or (aget params "model")
+                      (aget js/process.env "OPEN_HAX_WEBSEARCH_MODEL")
+                      DEFAULT-MODEL)]
+        (when onUpdate
+          (onUpdate #js {:content #js [#js {:type "text" :text (str "Calling Open Hax websearch... (" endpoint ")")}]
+                         :details #js {:status "starting" :endpoint endpoint :model model}}))
+        (let [resp (await (js/fetch endpoint
+                                    #js {:method "POST"
+                                         :headers #js {"Authorization" (str "Bearer " token)
+                                                       "Content-Type" "application/json"}
+                                         :body (js/JSON.stringify #js {:query (aget params "query")
+                                                                       :numResults (aget params "numResults")
+                                                                       :searchContextSize (aget params "searchContextSize")
+                                                                       :allowedDomains (aget params "allowedDomains")
+                                                                       :model model})
+                                         :signal signal}))
+              raw (await (.text resp))
+              json (try
+                     (js/JSON.parse raw)
+                     (catch :default _ nil))]
+          (cond
+            (not json)
+            (js/Promise.reject
+              (js/Error. (str "Open Hax websearch returned non-JSON: " (subs raw 0 2000))))
+
+            (not (.-ok resp))
+            (js/Promise.reject
+              (js/Error. (str "Open Hax websearch error (" (.-status resp) " " (.-statusText resp) "): " (subs raw 0 2000))))
+
+            :else
+            (await (handle-success json endpoint model))))))))
+
+(declare websearch-open-hax)
 
 (em/defextension websearch-open-hax
   :name "websearch-open-hax"
@@ -119,39 +164,5 @@
                  :searchContextSize {:type "string" :enum ["low" "medium" "high"] :description "Search context size (default: medium)" :optional true}
                  :allowedDomains {:type "array" :items {:type "string"} :description "Optional allow-list of domains" :optional true}
                  :model {:type "string" :description "Model ID to use" :optional true}}
-    :execute (fn ^:async [_tcid params signal onUpdate _ctx]
-               (let [token (proxy-token)]
-                 (if-not token
-                   (js/Promise.reject (js/Error. "Missing auth token for Open Hax proxy. Set OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN (or PROXY_AUTH_TOKEN)."))
-                   (let [endpoint (str (.replace (proxy-url) #"/+$" "") "/api/tools/websearch")
-                         model (or (aget params "model")
-                                   (aget js/process.env "OPEN_HAX_WEBSEARCH_MODEL")
-                                   DEFAULT-MODEL)]
-                     (when onUpdate
-                       (onUpdate #js {:content #js [#js {:type "text" :text (str "Calling Open Hax websearch... (" endpoint ")")}]
-                                  :details #js {:status "starting" :endpoint endpoint :model model}}))
-                     (let [resp (await (js/fetch endpoint
-                                                 #js {:method "POST"
-                                                      :headers #js {"Authorization" (str "Bearer " token)
-                                                                    "Content-Type" "application/json"}
-                                                      :body (js/JSON.stringify #js {:query (aget params "query")
-                                                                                    :numResults (aget params "numResults")
-                                                                                    :searchContextSize (aget params "searchContextSize")
-                                                                                    :allowedDomains (aget params "allowedDomains")
-                                                                                    :model model})
-                                                      :signal signal}))
-                           raw (await (.text resp))
-                           json (try
-                                  (js/JSON.parse raw)
-                                  (catch :default _ nil))]
-                       (cond
-                         (not json)
-                         (js/Promise.reject
-                           (js/Error. (str "Open Hax websearch returned non-JSON: " (subs raw 0 2000))))
-
-                         (not (.-ok resp))
-                         (js/Promise.reject
-                           (js/Error. (str "Open Hax websearch error (" (.-status resp) " " (.-statusText resp) "): " (subs raw 0 2000))))
-
-                         :else
-                         (await (handle-success json endpoint model))))))))))
+    :execute (fn [_tcid params signal onUpdate _ctx]
+               (run-websearch! params signal onUpdate))))

--- a/packages/sol/ecosystem.config.cjs
+++ b/packages/sol/ecosystem.config.cjs
@@ -177,7 +177,10 @@ const apps = [
       PROXX_AUTH_TOKEN: envValue('PROXX_AUTH_TOKEN', envValue('PROXY_AUTH_TOKEN', '')),
       PROXX_DEFAULT_MODEL: envValue('PROXX_DEFAULT_MODEL', 'gemma4:31b'),
 
-      // Provider overrides (optional)
+      // Sol public base URL behind the Cloudflare tunnel.
+      SOL_PUBLIC_BASE_URL: envValue('SOL_PUBLIC_BASE_URL', 'https://sol-stealth.promethean.rest'),
+      // Knoxx callback/OAuth reachability through the tunnel.
+      KNOXX_BASE_URL: envValue('KNOXX_BASE_URL', 'https://knoxx-stealth.promethean.rest'),
       KNOXX_PROVIDER_BASE_URLS: envValue('KNOXX_PROVIDER_BASE_URLS', ''),
       KNOXX_PROVIDER_AUTH_TOKENS: envValue('KNOXX_PROVIDER_AUTH_TOKENS', ''),
       KNOXX_PROVIDER_AUTH_HEADERS: envValue('KNOXX_PROVIDER_AUTH_HEADERS', ''),

--- a/packages/sol/src/cljs/open_hax/sol/infra/config.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/config.cljs
@@ -44,9 +44,10 @@
    ;; Prefer Sol-scoped vars so a leaked ambient HOST/PORT (e.g. PORT=8000 from a
    ;; knoxx shell, which collides with knoxx-backend) can't re-point Sol. Default
    ;; port is 8001 — Sol's own port, not knoxx's 8000.
-   :host (env "SOL_HOST" (env "HOST" "0.0.0.0"))
-   :port (js/parseInt (env "SOL_PORT" (env "PORT" "8001")) 10)
-   :knoxx-base-url (env "KNOXX_BASE_URL" "http://localhost:8000")
+    :host (env "SOL_HOST" (env "HOST" "0.0.0.0"))
+    :port (js/parseInt (env "SOL_PORT" (env "PORT" "8001")) 10)
+    :public-base-url (env "SOL_PUBLIC_BASE_URL" "")
+    :knoxx-base-url (env "KNOXX_BASE_URL" "http://localhost:8000")
    :knoxx-api-key (env "KNOXX_API_KEY" "")
    :knoxx-default-role (env "KNOXX_DEFAULT_ROLE" "knowledge_worker")
    :knoxx-default-actor-id (env "KNOXX_DEFAULT_ACTOR_ID" "chat_primary")


### PR DESCRIPTION
With install/paths/source-tracking fixed, the extension build finally ran in CI and surfaced three latent issues that blocked `test` + CLJS jobs:

1. await in macro-wrapped tool execute fns — syntax-quote strips the `^:async` metadata when a fn is spliced through em/tool/defextension, so `(fn ^:async [...] (await ...))` compiled as non-async and failed ("await can only be used in async contexts"). Move the async bodies of image-render and websearch-open-hax into top-level `^:async` defns (read directly, so async is honored) and have :execute call them.

2. :redef-in-file warnings tripped the build's zero-warning ratchet — every extension had `(def NAME nil)` then `(em/defextension NAME ...)` which redefines it. Replace the forward-decls with `(declare NAME)`, which forward-declares for clj-kondo without a redefinable binding.

3. JSDoc parse warning — a docstring in lib/eta_mu/opencode.cljs started a line with `@opencode-ai/...`, which Closure parsed as an unknown JSDoc tag (also a ratchet warning). Reword it.

Verified locally: `pnpm build` exits 0 (0 warnings, 15 paths valid), `pnpm test` 72 tests/195 assertions 0 failures, clj-kondo 0 errors.