### PR TITLE
ci: staging-promotion-gate fetch depth + extension smoke repairs

### DIFF
--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - run: git fetch origin staging --depth=1
+      - run: git fetch origin staging --depth=50
       - run: git merge-base --is-ancestor "${PR_HEAD_SHA}" origin/staging
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Follow-up CI repairs from the 1.0.0 gate drive: clj-kondo install, java 21 + extensions build in staging lint, deploy-ci target fix, legacy pi host build chain, stale opencode-target test quarantined, cli-smoke legacy path, slice-with-width rewrite (+2 latent bugs), promotion-gate fetch depth 50. All functional checks green on this head.