### PR TITLE
docs: process workspace and compiler notes

### DIFF
--- a/docs/notes/INDEX.md
+++ b/docs/notes/INDEX.md
@@ -12,6 +12,8 @@ This index classifies each note by topic and marks it as either:
   direction is current).
 - **historical** — brainstorming, transcripts, or one-off context that records
   how the thinking got here. Useful for lineage, not authoritative.
+- **decision candidate** — a bounded unresolved boundary that requires explicit
+  cross-repository review before it can govern implementation.
 
 Distilled, more durable write-ups live in [`../design/`](../design/). Notes
 that have been promoted there are marked below.
@@ -40,7 +42,7 @@ and the `.eta-mu/` ledger/state layout.
 | Note | Status | Summary |
 |------|--------|---------|
 | [dev/eta-mu-agents-md-improvement-plan.md](dev/eta-mu-agents-md-improvement-plan.md) | design intent | Acceptance criteria for improving `AGENTS.md`/`PROCESS.md`: FSM blocks invalid board moves across all surfaces (file edit, CLI, MCP, hooks); per-package `AGENTS.md`; sol/knoxx coexistence; `extern` boundary rule. |
-| [dev/katamorph-resources-fsm-contracts.md](dev/katamorph-resources-fsm-contracts.md) | design intent | `.eta-mu/` holds three kinds of things: resources, ledgers, state (projections). Kanban FSM as pure katamorph resources; drivers-as-resources (`:module`/`:driver`) as the bootstrap that makes katamorph a runtime. |
+| [dev/katamorph-resources-fsm-contracts.md](dev/katamorph-resources-fsm-contracts.md) | design intent | `.eta-mu/` holds three kinds of things: resources, ledgers, state (projections). Kanban FSM as pure katamorph resources; drivers-as-resources (`:module`/`:driver`) as the bootstrap that makes katamorph a runtime. Metadata conflict repaired 2026-07-26; source prose retained. |
 | [dev/eta-mu-kanban-agent-cli-draft.md](dev/eta-mu-kanban-agent-cli-draft.md) | design intent | Sketch of the (unimplemented) `eta-mu kanban agent` CLI: session registration, ledger-backed event/state EDN files, orchestrator self-assignment to tasks. |
 | [dev/eta-mu-orchestrator-prompt-draft.md](dev/eta-mu-orchestrator-prompt-draft.md) | historical | Stub system prompt for the "Eta Mu" orchestrator persona (mostly empty outline). |
 
@@ -50,8 +52,9 @@ Higher-level framing of how the workspace itself is composed.
 
 | Note | Status | Summary |
 |------|--------|---------|
-| [design/eta-mu-worlds-projections-ledger-design.md](design/eta-mu-worlds-projections-ledger-design.md) | historical | "Worlds & projections" framing for managing many repos/submodules — a manifest-defined working set. Perplexity transcript; vocabulary exploration, not a committed design. |
-| [design/eta-mu-init-experience-vision.md](design/eta-mu-init-experience-vision.md) | design intent | Vision script for `eta-mu init`: what the tool should *feel* like (event ledger, sentinel, fork tax, receipt river, session mycology, retrospective agent). Aspirational product narrative. |
+| [design/workspace-resources-ledgers-projections-synthesis.md](design/workspace-resources-ledgers-projections-synthesis.md) | design intent | Bounded current synthesis of workspace resources, append-only ledgers, rebuildable projections, worlds/task views, FSM interpretation, and responsible `eta-mu init` behavior. |
+| [design/eta-mu-worlds-projections-ledger-design.md](design/eta-mu-worlds-projections-ledger-design.md) | historical | "Worlds & projections" framing for managing many repos/submodules — a manifest-defined working set. Perplexity transcript; vocabulary exploration, not a committed design. Retained as source; its duplicate migration metadata still needs a non-destructive historical repair. |
+| [design/eta-mu-init-experience-vision.md](design/eta-mu-init-experience-vision.md) | design intent | Vision script for `eta-mu init`: what the tool should *feel* like (event ledger, sentinel, fork tax, receipt river, session mycology, retrospective agent). Metadata conflict repaired 2026-07-26; aspirational product narrative. |
 
 ## Tooling
 
@@ -81,8 +84,14 @@ declared capabilities, policies, and observations into OpenCode and other agent
 harnesses. Broken down from the large `clojurescript runtimes_compilers.md`
 Perplexity conversation export.
 
+The accepted constellation architecture assigns portable harness compilation to
+Muse. The reconciliation note below is the current bounded decision input; the
+older Keryx notes remain source material and do not independently authorize a
+second universal compiler.
+
 | Note | Status | Summary |
 |------|--------|---------|
+| [design/muse-keryx-runtime-compiler-reconciliation.md](design/muse-keryx-runtime-compiler-reconciliation.md) | decision candidate | Classifies Keryx material as Muse requirements/target adapter input, eta-mu-native implementation, or historical naming; requires actual-code inventory and cross-repository acceptance. |
 | [dev/opencode-plugins-cljs.md](dev/opencode-plugins-cljs.md) | design intent | How to write OpenCode plugins and tools almost entirely in ClojureScript, with thin JS shims only where the loader contract demands it. |
 | [dev/agent-dsl-macros-composition.md](dev/agent-dsl-macros-composition.md) | design intent | `deftool`, `defhook`, `defplugin` macros and a Hiccup-style vector DSL for composing agent capabilities without one huge file. |
 | [dev/opencode-edn-config.md](dev/opencode-edn-config.md) | design intent | `opencode.edn` as a project-side authoring layer that composes domain fragments and generates OpenCode JSON/plugin artifacts. |
@@ -132,3 +141,7 @@ agent orchestrato.md` Perplexity conversation export.
     `design/`, `dev/`, and `other/`.
 - Empty category directories (`empty/`, `infrastructure/`) are reserved for
   future notes; no files were placed there in this pass.
+- On 2026-07-26, two short note frontmatter conflicts were repaired without
+  rewriting source prose; two bounded synthesis notes were added. The long
+  worlds/projections transcript remains historical source and is not mass
+  normalized.

--- a/docs/notes/design/eta-mu-init-experience-vision.md
+++ b/docs/notes/design/eta-mu-init-experience-vision.md
@@ -1,12 +1,7 @@
 ---
 original_name: "2026.06.14.12.19.50.md"
-<<<<<<<< HEAD:docs/notes/design/eta-mu-init-experience-vision.md
 title: "Eta-Mu Init Experience Vision"
-summary: "Describes the desired first-run eta-mu init experience scanning a project and initializing ledgers, kanban, and agent integrations."
-========
-title: "Eta Mu Init Vision Script"
-summary: "Vision script for the `eta-mu init` experience: ledger, sentinel, fork tax, receipt river, session mycology, retrospective agent."
->>>>>>>> origin/device/yoga:docs/notes/design/eta-mu-init-vision-script.md
+summary: "Vision script for the `eta-mu init` experience: ledger, sentinel, fork tax, receipt river, session mycology, retrospective agent, and harness integration."
 category: "design"
 created: "2026-06-14"
 ---
@@ -42,7 +37,6 @@ The file sentinel records file changes to an immuatable ledger file``
 
 The ledger is regularly analyzed by statistical analysis
 All substantial related changes are automaticly commited with inteligent commit messages
-
 The event ledger is version controled separately from your code
 
 A kanban/ folder was created, and is being populated by a sol agent.

--- a/docs/notes/design/muse-keryx-runtime-compiler-reconciliation.md
+++ b/docs/notes/design/muse-keryx-runtime-compiler-reconciliation.md
@@ -1,0 +1,117 @@
+---
+original_name: null
+title: "Muse and Keryx Runtime-Compiler Reconciliation"
+summary: "Classifies eta-mu's Keryx note cluster as source material for Muse and eta-mu-native implementations rather than a second universal harness compiler."
+category: "design"
+created: "2026-07-26"
+status: "decision candidate"
+sources:
+  - "docs/notes/INDEX.md#keryx-opencode-interpreter-and-declaration-assembly"
+  - "docs/notes/design/keryx-package-proposal.md"
+  - "docs/notes/design/opencode-first-agent-runtime.md"
+  - "docs/notes/design/keryx-role-extern-boundary.md"
+  - "docs/architecture/contract-dialect-and-data-authority.md"
+external_sources:
+  - "octave-commons/muse"
+---
+
+# Muse and Keryx Runtime-Compiler Reconciliation
+
+## Observation
+
+The eta-mu notes index groups thirteen Keryx artifacts covering:
+
+- declaration assembly;
+- tools, hooks, and plugins;
+- capability interpretation;
+- OpenCode EDN configuration;
+- TypeScript declaration emission;
+- host/CLJS boundary discipline;
+- a runtime IR with OpenCode as the first target;
+- package and namespace naming.
+
+The accepted cross-repository architecture now assigns substantially the same
+portable responsibility to Muse: consume Katamorph resources, link capability
+implementations and exposures, and compile harness-native artifacts for
+OpenCode, Claude, Codex, eta-mu-native, MCP, and later targets.
+
+## Problem
+
+Without an explicit disposition, the notes can be read as authority to build a
+second universal compiler inside eta-mu. That would recreate the duplication the
+architecture record is trying to remove:
+
+```text
+Katamorph resources
+   -> Keryx compiler in eta-mu
+   -> Muse compiler in its own repo
+   -> host-specific artifacts
+```
+
+The duplication is conceptual even where the current code differs.
+
+## Proposed classification
+
+Keryx should not be treated as a second top-level system. Classify each note or
+implementation under one of four roles:
+
+### 1. Muse language/compiler requirement
+
+Portable declaration assembly, profile selection, capability linking, loss
+diagnostics, target generation, and tools/hooks/plugins belong in Muse or in a
+shared contract consumed by Muse.
+
+### 2. Muse OpenCode target implementation
+
+OpenCode-specific decoding, encoding, plugin packaging, configuration layout,
+and target tests may become a Muse OpenCode adapter/package. The Keryx name may
+remain as the adapter's internal role vocabulary if it remains useful.
+
+### 3. eta-mu-native interpreter implementation
+
+Sol/Rheos/native eta-mu runtime code that executes the same Katamorph semantics
+without compiling to an external harness belongs in eta-mu. It should conform to
+the same capability and exposure laws rather than sharing arbitrary Keryx
+internals.
+
+### 4. Historical naming or exploratory material
+
+Naming exercises, abandoned package boundaries, and prompt/PR instructions
+remain historical notes. They can inform lineage without governing current
+implementation.
+
+## Boundary rule
+
+```text
+Katamorph owns semantic resources.
+Muse owns portable target compilation and host compatibility.
+eta-mu owns native runtime implementations and conformance fixtures.
+A target adapter may live in Muse even when eta-mu supplies executable handlers.
+```
+
+No repository should infer ownership merely because a prototype was first built
+there.
+
+## Migration questions
+
+- Which Keryx code currently exists, and which notes describe only intended
+  implementation?
+- Can the existing OpenCode pipeline be moved or adapted into Muse without
+  changing its observable target artifacts?
+- Which schemas duplicate Muse's current DSL versus Katamorph's resource
+  registry?
+- Should `Keryx` remain the name of Muse's OpenCode adapter, an eta-mu-native
+  role, or only historical vocabulary?
+- What round-trip and loss-reporting fixtures prove that the migration preserves
+  declared behavior?
+
+## Acceptance path
+
+This note is a `decision candidate`, not the decision itself. Resolve it through
+an explicit cross-repository design/ADR or accepted migration plan after
+inventorying actual Keryx and Muse code. Until then:
+
+- do not add a new universal compiler surface under Keryx;
+- preserve the notes and prototypes;
+- route new portable target-compilation work toward Muse;
+- mark host-specific or native-runtime work by its actual implementation role.

--- a/docs/notes/design/workspace-resources-ledgers-projections-synthesis.md
+++ b/docs/notes/design/workspace-resources-ledgers-projections-synthesis.md
@@ -1,0 +1,137 @@
+---
+original_name: null
+title: "Workspace Resources, Ledgers, and Projections — Synthesis"
+summary: "Distills recurring eta-mu notes into a bounded workspace model: declared resources, append-only ledgers, rebuildable projections, and task-shaped repository views."
+category: "design"
+created: "2026-07-26"
+sources:
+  - "docs/notes/dev/katamorph-resources-fsm-contracts.md"
+  - "docs/notes/design/eta-mu-worlds-projections-ledger-design.md"
+  - "docs/notes/design/eta-mu-init-experience-vision.md"
+  - "docs/architecture/contract-dialect-and-data-authority.md"
+status: "design intent"
+---
+
+# Workspace Resources, Ledgers, and Projections — Synthesis
+
+## Purpose
+
+This note extracts the smallest stable model recurring across the source notes.
+It does not replace the original transcripts or vision script. The long
+`eta-mu-worlds-projections-ledger-design.md` file remains historical source
+material, including its unresolved metadata conflict markers; this note is the
+bounded working representation to use for current reasoning.
+
+## Stable model
+
+A `.ημ/` operating context contains three logically distinct classes of data:
+
+```text
+resources
+  declarative identities, contracts, policies, manifests, capabilities,
+  actors, modules, drivers, and workflow definitions
+
+ledgers
+  append-only records of operations, messages, transitions, receipts,
+  sessions, tool activity, observations, and decisions
+
+projections
+  rebuildable current views derived from one or more resources and ledgers:
+  board state, session context, search indices, graph views, status, and UI
+```
+
+The distinction is about authority and change semantics, not necessarily three
+physical directories or databases.
+
+## Worlds and projections
+
+The source transcript uses **world** for a reproducible multi-repository working
+set and **projection** for a task-shaped view of that set.
+
+A world may bind:
+
+- repositories and repository families;
+- exact paths and submodule edges;
+- pinned revisions or branch policies;
+- contract/resource roots;
+- available runtime services and actors.
+
+A workspace projection selects the subset needed for one task, session, actor,
+or product surface. It should not rewrite or duplicate the underlying world.
+
+This vocabulary is compatible with Epiphany's evidence projections but should
+not be conflated with them:
+
+- an eta-mu workspace projection selects operational context;
+- an Epiphany projection derives a search, graph, timeline, or context view from
+  canonical and durable evidence.
+
+A context packet may combine both: it is produced from an Epiphany projection
+for an actor operating inside an eta-mu workspace projection.
+
+## Runtime interpretation
+
+Resources become operational only through interpreters and implementations.
+The old note proposes drivers/modules as resources so Katamorph can describe
+runtime dependencies. The current architecture narrows the ownership:
+
+- Katamorph defines portable resource and capability semantics;
+- implementing packages own executable handlers and drivers;
+- Muse compiles implementations/exposures into harness-native forms;
+- Sol and Rheos interpret native agent and workflow resources;
+- event-ledger owns the common append boundary;
+- Epiphany observes sources and builds evidence-governed projections.
+
+A resource declaration must not imply that Katamorph itself dynamically loads
+arbitrary dependencies. Runtime/module loading requires an explicit
+implementation and authority boundary.
+
+## FSM implication
+
+A workflow FSM is primarily resource data plus ledger interpretation:
+
+```text
+transition request event
+  -> validate actor/grant/policy/current state
+  -> evaluate transition contract
+  -> append accepted or rejected transition event
+  -> rebuild current board/work projection
+  -> trigger declared reactions
+```
+
+The projected state is not the authoritative transition history. Direct file
+edits or UI actions are adapters that submit transition requests; they do not
+bypass the same laws.
+
+## Product implication
+
+The `eta-mu init` vision is best understood as composition discovery and
+proposal, not silent autonomous mutation. A responsible initialization flow
+should:
+
+1. observe Git/package/runtime/workflow facts;
+2. propose resource manifests and integrations;
+3. preserve exact source evidence;
+4. identify which changes require operator acceptance;
+5. initialize ledgers and projections only through explicit, reversible steps;
+6. report unsupported or lossy harness integrations.
+
+The desired experience remains useful, but automatic commits, submodule edits,
+workflow rewrites, or skill promotion require policy and acceptance boundaries.
+
+## Open decisions
+
+- The canonical workspace/world manifest contract and its owner.
+- Whether `world` remains product vocabulary or becomes a formal Katamorph
+  resource kind.
+- The boundary between a Katamorph module declaration and a Muse/runtime
+  implementation resource.
+- How workspace projections reference Epiphany context-query profiles.
+- Which initialization proposals may be accepted as a batch and which require
+  separate review.
+
+## Disposition
+
+`design intent`. This note should inform workspace manifest, product-composition,
+FSM, and initialization designs. The original notes remain source records and
+should not be deleted or silently rewritten.

--- a/docs/notes/dev/katamorph-resources-fsm-contracts.md
+++ b/docs/notes/dev/katamorph-resources-fsm-contracts.md
@@ -1,14 +1,8 @@
 ---
 original_name: "2026.06.14.22.24.55.md"
-<<<<<<<< HEAD:docs/notes/dev/katamorph-resources-fsm-contracts.md
-title: "Katamorph Resources and FSM as Contracts"
-summary: "Proposes modeling katamorph resources, drivers, and the kanban finite-state machine as pure resources over event ledgers."
-category: "dev"
-========
 title: "Eta Mu Resources, Ledgers, and State"
 summary: "Sketches `.eta-mu/` as resources, ledgers, and state projections; kanban FSM as katamorph resources."
 category: "design"
->>>>>>>> origin/device/yoga:docs/notes/design/eta-mu-resources-ledgers-state.md
 created: "2026-06-14"
 ---
 


### PR DESCRIPTION
## Summary

Processes a bounded eta-mu `docs/notes/` batch derived from the Epiphany cross-repository synthesis.

This PR:

- removes unresolved frontmatter conflict markers from two short notes while preserving their source prose;
- adds a current synthesis of resources, ledgers, projections, worlds/task views, FSM interpretation, and responsible initialization;
- records the Keryx/Muse compiler-boundary collision as a decision candidate rather than silently authorizing a second universal compiler;
- updates the notes index with source status, current syntheses, and the cross-repository ownership boundary;
- leaves the long worlds/projections Perplexity transcript unchanged as historical source material.

## Source basis

- `docs/notes/dev/katamorph-resources-fsm-contracts.md`
- `docs/notes/design/eta-mu-worlds-projections-ledger-design.md`
- `docs/notes/design/eta-mu-init-experience-vision.md`
- `docs/notes/INDEX.md`
- `docs/architecture/contract-dialect-and-data-authority.md`
- `octave-commons/epiphany` inbox-synthesis process

## Validation

Documentation-only. Five files changed: two metadata repairs, two bounded synthesis notes, and the index. The branch is based on merged PR #145 at `28c0b18d7ec186c304a4a3782d68e32746731f69` and is not behind `main`.