### PR TITLE
feat(sol): emit principal-bound run and turn episodes

### DIFF
--- a/.github/workflows/sol-ci.yml
+++ b/.github/workflows/sol-ci.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           persist-credentials: false
 
@@ -35,37 +35,54 @@ jobs:
           java-version: "21"
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.2
+        uses: DeLaGuardo/setup-clojure@ada62bb3282a01a296659d48378b812b8e097360
         with:
           cli: 1.12.5.1654
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: "10.14.0"
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "22"
           cache: pnpm
 
+      - name: Detect eta-mu app credentials
+        id: dependency-credentials
+        env:
+          ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
+          ETA_MU_APP_PRIVATE_KEY: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          if [[ -n "${ETA_MU_APP_ID}" && -n "${ETA_MU_APP_PRIVATE_KEY}" ]]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Create cross-repository read token
         id: dependency-token
-        uses: actions/create-github-app-token@v1
+        if: steps.dependency-credentials.outputs.available == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         with:
           app-id: ${{ secrets.ETA_MU_APP_ID }}
           private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
-          owner: open-hax
 
       - name: Configure private Git dependency reads
         env:
           DEPENDENCY_TOKEN: ${{ steps.dependency-token.outputs.token }}
         shell: bash
         run: |
+          if [[ "${{ steps.dependency-credentials.outputs.available }}" != "true" ]]; then
+            echo "ETA_MU_APP_ID / ETA_MU_APP_PRIVATE_KEY are unavailable"
+            exit 1
+          fi
           if [[ -z "${DEPENDENCY_TOKEN}" ]]; then
-            echo "Missing eta-mu GitHub App token for private dependency reads"
+            echo "The eta-mu GitHub App did not mint a dependency token"
             exit 1
           fi
           authorization="$(printf 'x-access-token:%s' "${DEPENDENCY_TOKEN}" | base64 -w0)"

--- a/.github/workflows/sol-ci.yml
+++ b/.github/workflows/sol-ci.yml
@@ -1,0 +1,100 @@
+name: Sol CI
+
+on:
+  pull_request:
+    paths:
+      - "packages/sol/**"
+      - "packages/turn-processor/**"
+      - "packages/eta-mu/**"
+      - ".github/workflows/sol-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/sol/**"
+      - "packages/turn-processor/**"
+      - "packages/eta-mu/**"
+      - ".github/workflows/sol-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.2
+        with:
+          cli: 1.12.5.1654
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.14.0"
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install workspace dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Install clj-kondo
+        run: |
+          curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
+          chmod +x install-clj-kondo
+          sudo ./install-clj-kondo
+
+      - name: Lint Sol
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --dir packages/sol lint 2>&1 | tee sol-lint.log
+
+      - name: Test Sol
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --dir packages/sol test 2>&1 | tee sol-test.log
+          grep -q "0 failures, 0 errors" sol-test.log
+          if grep -E "(^|[[:space:]])WARNING([:[:space:]]|$)" sol-test.log; then
+            echo "Sol test compilation emitted warnings"
+            exit 1
+          fi
+
+      - name: Build Sol server
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --dir packages/sol build 2>&1 | tee sol-build.log
+          if grep -E "(^|[[:space:]])WARNING([:[:space:]]|$)" sol-build.log; then
+            echo "Sol server compilation emitted warnings"
+            exit 1
+          fi
+
+      - name: Upload Sol validation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: sol-validation
+          path: |
+            sol-lint.log
+            sol-test.log
+            sol-build.log
+            packages/sol/.shadow-cljs/
+          if-no-files-found: ignore

--- a/.github/workflows/sol-ci.yml
+++ b/.github/workflows/sol-ci.yml
@@ -7,13 +7,19 @@ on:
       - "packages/turn-processor/**"
       - "packages/eta-mu/**"
       - ".github/workflows/sol-ci.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "packages/sol/**"
       - "packages/turn-processor/**"
       - "packages/eta-mu/**"
       - ".github/workflows/sol-ci.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 permissions:
   contents: read
@@ -34,10 +40,11 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Set up Clojure CLI
+      - name: Set up Clojure CLI and clj-kondo
         uses: DeLaGuardo/setup-clojure@ada62bb3282a01a296659d48378b812b8e097360
         with:
           cli: 1.12.5.1654
+          clj-kondo: 2025.10.23
 
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
@@ -50,6 +57,7 @@ jobs:
         with:
           node-version: "22"
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Detect eta-mu app credentials
         id: dependency-credentials
@@ -89,13 +97,7 @@ jobs:
           git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${authorization}"
 
       - name: Install workspace dependencies
-        run: pnpm install --no-frozen-lockfile
-
-      - name: Install clj-kondo
-        run: |
-          curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
-          chmod +x install-clj-kondo
-          sudo ./install-clj-kondo
+        run: pnpm install --frozen-lockfile
 
       - name: Lint Sol
         shell: bash

--- a/.github/workflows/sol-ci.yml
+++ b/.github/workflows/sol-ci.yml
@@ -51,6 +51,26 @@ jobs:
           node-version: "22"
           cache: pnpm
 
+      - name: Create cross-repository read token
+        id: dependency-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ETA_MU_APP_ID }}
+          private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          owner: open-hax
+
+      - name: Configure private Git dependency reads
+        env:
+          DEPENDENCY_TOKEN: ${{ steps.dependency-token.outputs.token }}
+        shell: bash
+        run: |
+          if [[ -z "${DEPENDENCY_TOKEN}" ]]; then
+            echo "Missing eta-mu GitHub App token for private dependency reads"
+            exit 1
+          fi
+          authorization="$(printf 'x-access-token:%s' "${DEPENDENCY_TOKEN}" | base64 -w0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${authorization}"
+
       - name: Install workspace dependencies
         run: pnpm install --no-frozen-lockfile
 
@@ -86,6 +106,10 @@ jobs:
             echo "Sol server compilation emitted warnings"
             exit 1
           fi
+
+      - name: Remove private Git authorization
+        if: always()
+        run: git config --global --unset-all http.https://github.com/.extraheader || true
 
       - name: Upload Sol validation evidence
         if: always()

--- a/.github/workflows/sol-ci.yml
+++ b/.github/workflows/sol-ci.yml
@@ -85,6 +85,10 @@ jobs:
         with:
           app-id: ${{ secrets.ETA_MU_APP_ID }}
           private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            katamorph
+            event-ledger
 
       - name: Configure private Git dependency reads
         env:

--- a/.github/workflows/sol-ci.yml
+++ b/.github/workflows/sol-ci.yml
@@ -59,6 +59,12 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Lint Sol source and tests
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --dir packages/sol lint 2>&1 | tee sol-lint.log
+
       - name: Detect eta-mu app credentials
         id: dependency-credentials
         env:
@@ -98,12 +104,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Lint Sol
-        shell: bash
-        run: |
-          set -o pipefail
-          pnpm --dir packages/sol lint 2>&1 | tee sol-lint.log
 
       - name: Test Sol
         shell: bash

--- a/packages/eta-mu/deps.edn
+++ b/packages/eta-mu/deps.edn
@@ -1,0 +1,1 @@
+{:paths ["src/cljs"]}

--- a/packages/sol/.clj-kondo/config.edn
+++ b/packages/sol/.clj-kondo/config.edn
@@ -1,2 +1,2 @@
 {:config-paths ["../../kondo-config/clj-kondo.exports/open-hax/kondo-config"]
- :hooks {:analyze-call {knoxx.backend.macros/defroute hooks.defroute/defroute}}}
+ :hooks {:analyze-call {open-hax.sol.macros/defroute hooks.defroute/defroute}}}

--- a/packages/sol/.clj-kondo/hooks/defroute.clj
+++ b/packages/sol/.clj-kondo/hooks/defroute.clj
@@ -15,39 +15,11 @@
 ;;       [guard-fn1 guard-fn2]
 ;;       body...)
 ;;
-;; The hook generates:
-;;
-;;   (defn fn-name [_app _runtime _config _deps]
-;;     (let [<only symbols referenced in body+guards> (fn [& _] nil) ...]
-;;       (^:async fn [ctx]            ; or [_ctx] when ctx is unused
-;;         [guards-if-any] body...)))
-;;
-;; The body is wrapped in an ^:async fn that mirrors the handler the
-;; runtime macro emits.  Modeling the async fn boundary means await and
-;; raw Promise chains inside route bodies are analyzed in the same
-;; structural context they actually run in.
-;;
-;; Using (fn [& _] nil) as the binding value avoids both
-;; "Unresolved symbol" errors (which occur when the right side
-;; references a symbol not yet in scope) and "Nil cannot be called"
-;; errors (which occur when clj-kondo tracks a nil-typed binding).
-;; A variadic fn is callable with any argument count, so all route-body
-;; call sites are valid.
-;;
-;; Only symbols that actually appear in the body are injected, so
-;; clj-kondo does not emit spurious unused-binding warnings for the
-;; many standard deps that a given route does not reference.
-;;
-;; request, reply, and await are injected via the let pool as variadic
-;; fns so clj-kondo does not flag them as unresolved inside route bodies.
-;; ctx is modeled as the wrapping ^:async fn parameter (the macro binds
-;; it from (aget request "ctx")), not via the let pool.
-;;
-;; In pre-handler mode children[5] is a vector of guard fn symbols;
-;; it is detected and skipped so it is not treated as a body form.
+;; The generated analysis node mirrors the macro's real async handler boundary.
+;; Fastify request/reply values are host objects, not functions; they are modeled
+;; as indexable arrays so `aget` paths type-check. `await` and injected
+;; capabilities remain variadic functions.
 
-;; Structural params (app, deps) are never in body text — generated as _-prefixed.
-;; runtime and config are sometimes in body text; they go in the filtered let pool.
 (def ^:private deps-syms
   '[runtime config
     route! json-response! error-response! ensure-permission!
@@ -55,10 +27,6 @@
     bearer-headers fetch-json request-query-string
     session-guard optional-session-guard])
 
-;; request, reply, and await live in the let pool (bound as variadic fns).
-;; ctx is modeled as the parameter of the ^:async handler fn that wraps the
-;; body — see new-node below — because the runtime macro binds it from
-;; (aget request "ctx") inside the emitted handler, not from deps.
 (def ^:private handler-syms
   '[request reply await])
 
@@ -68,11 +36,12 @@
     (api/vector-node [(api/token-node '&) (api/token-node '_)])
     (api/token-node nil)]))
 
+(defn- host-object-node []
+  ;; `aget` is the dominant operation in route bodies. An empty JS array gives
+  ;; clj-kondo an indexable host value without claiming a domain map shape.
+  (api/list-node [(api/token-node 'array)]))
+
 (defn- async-handler-node
-  "Wrap the route body forms in the ^:async handler fn that the runtime macro
-   emits.  When the body references ctx, it becomes the fn parameter (the macro
-   binds it from (aget request \"ctx\")); otherwise an ignored _ctx parameter is
-   used so clj-kondo does not flag an unused binding."
   [ctx-used? body-forms]
   (let [param (if ctx-used? 'ctx '_ctx)]
     (api/list-node
@@ -87,12 +56,12 @@
     (api/vector-node [])]))
 
 (defn- binding-value-node [sym]
-  (if (str/ends-with? (name sym) "*")
-    (atom-node)
-    (any-fn-node)))
+  (cond
+    (#{'request 'reply} sym) (host-object-node)
+    (str/ends-with? (name sym) "*") (atom-node)
+    :else (any-fn-node)))
 
 (defn- collect-body-syms
-  "Walk body nodes recursively, returning a set of all symbol sexprs found."
   [nodes]
   (reduce (fn [acc node]
             (if (api/token-node? node)
@@ -106,38 +75,27 @@
   (let [children          (:children node)
         fn-name           (nth children 1 nil)
         extra-vec         (nth children 2 nil)
-        ;; children: defroute fn-name extra-deps method path [guards?] body...
-        ;; Pre-handler mode: children[5] is a vector of guard fn symbols.
-        ;; Classic mode:     children[5] is the first body form.
         maybe-guards      (nth children 5 nil)
         pre-handler-mode? (and maybe-guards (api/vector-node? maybe-guards))
         body              (if pre-handler-mode?
-                            (drop 6 children)  ; skip guard vector
+                            (drop 6 children)
                             (drop 5 children))
         extra-syms        (when (api/vector-node? extra-vec)
                             (map api/sexpr (:children extra-vec)))
-        ;; In pre-handler mode, include the guard vector in the generated body so:
-        ;; (a) guard symbols are visible as references when filtering, and
-        ;; (b) clj-kondo sees them as referenced in the let body (no unused-binding).
         effective-body    (if pre-handler-mode?
                             (cons maybe-guards body)
                             body)
         body-syms         (collect-body-syms effective-body)
         ctx-used?         (contains? body-syms 'ctx)
-        ;; Only inject let bindings for symbols actually referenced in body+guards.
         needed-std-syms   (filter (fn [s] (contains? body-syms s))
                                   (concat deps-syms handler-syms))
-        ;; Extra-deps used as guards or in body are kept; genuinely unused ones are
-        ;; filtered so the real unused-dep warning surfaces.
         needed-extra-syms (filter (fn [s] (contains? body-syms s)) extra-syms)
         all-syms          (concat needed-std-syms needed-extra-syms)
         binding-vec       (api/vector-node
                            (mapcat (fn [sym]
-                                     [(api/token-node sym) (binding-value-node sym)])
+                                     [(api/token-node sym)
+                                      (binding-value-node sym)])
                                    all-syms))
-        ;; All four structural params use _ prefix: they're never referenced in body
-        ;; text (app/deps are macro-internal; runtime/config are injected via let
-        ;; when the body actually uses them).
         new-node          (api/list-node
                            [(api/token-node 'defn)
                             fn-name
@@ -146,9 +104,5 @@
                             (api/list-node
                              [(api/token-node 'let)
                               binding-vec
-                              ;; Model the actual ^:async handler context the
-                              ;; runtime macro emits, so await and Promise
-                              ;; chains in the body are analyzed inside an
-                              ;; async function rather than at let-body scope.
                               (async-handler-node ctx-used? effective-body)])])]
     {:node new-node}))

--- a/packages/sol/deps.edn
+++ b/packages/sol/deps.edn
@@ -1,8 +1,8 @@
 {;; Default classpath = the shadow-cljs build (shadow-cljs.edn uses :deps true).
- ;; katamorph + event-ledger are consumed from immutable git refs (the standalone
- ;; open-hax repos, currently katamorph v0.2.0 and event-ledger v0.3.0), NOT the
- ;; removed local packages/ copies — bump the :git/sha + :git/tag together to
- ;; adopt a new release.
+ ;; katamorph + event-ledger are consumed from immutable git refs in the
+ ;; standalone open-hax repos, never from removed local packages/ copies.
+ ;; Katamorph is tagged; event-ledger is pinned to the merged principal-binding
+ ;; revision until the next package tag is cut.
  ;; turn-processor + eta-mu are workspace siblings consumed as source paths:
  ;; the provider adapter wires their run-loop/stream-fn/tools into sol's
  ;; agent sessions.
@@ -18,8 +18,7 @@
   refactor-nrepl/refactor-nrepl {:mvn/version "3.9.1"}
   io.github.open-hax/katamorph    {:git/tag "v0.2.0"
                                    :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}
-  io.github.open-hax/event-ledger {:git/tag "v0.3.0"
-                                   :git/sha "f67c438d3c3b16ce9452a0c934f59101d1b95815"}}
+  io.github.open-hax/event-ledger {:git/sha "ada7374b7f4e1c3b0ab4e6bbe996f10f06e9b93a"}}
 
  :aliases
  ;; Clojure-first mutation harness (mutation/knoxx/…) — mutates CLJS source
@@ -40,4 +39,4 @@
                 io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts ["-m" "cognitect.test-runner"
-               "--namespace-regex" "^knoxx\\..*-test$"]}}}
+               "--namespace-regex" "^knoxx\..*-test$"]}}}

--- a/packages/sol/deps.edn
+++ b/packages/sol/deps.edn
@@ -18,7 +18,8 @@
   refactor-nrepl/refactor-nrepl {:mvn/version "3.9.1"}
   io.github.open-hax/katamorph    {:git/tag "v0.2.0"
                                    :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}
-  io.github.open-hax/event-ledger {:git/sha "ada7374b7f4e1c3b0ab4e6bbe996f10f06e9b93a"}}
+  io.github.open-hax/event-ledger {:git/url "https://github.com/open-hax/event-ledger.git"
+                                   :git/sha "ada7374b7f4e1c3b0ab4e6bbe996f10f06e9b93a"}}
 
  :aliases
  ;; Clojure-first mutation harness (mutation/knoxx/…) — mutates CLJS source
@@ -39,4 +40,4 @@
                 io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts ["-m" "cognitect.test-runner"
-               "--namespace-regex" "^knoxx\..*-test$"]}}}
+               "--namespace-regex" "^knoxx\\..*-test$"]}}}

--- a/packages/sol/deps.edn
+++ b/packages/sol/deps.edn
@@ -3,23 +3,23 @@
  ;; standalone open-hax repos, never from removed local packages/ copies.
  ;; Katamorph is tagged; event-ledger is pinned to the merged principal-binding
  ;; revision until the next package tag is cut.
- ;; turn-processor + eta-mu are workspace siblings consumed as source paths:
+ ;; turn-processor + eta-mu are workspace siblings consumed as local deps:
  ;; the provider adapter wires their run-loop/stream-fn/tools into sol's
- ;; agent sessions.
- :paths ["src/cljs" "test/cljs"
-         "../turn-processor/src/cljs"
-         "../eta-mu/src/cljs"]
+ ;; agent sessions without deprecated parent-directory :paths.
+ :paths ["src/cljs" "test/cljs"]
 
  :deps
- {thheller/shadow-cljs          {:mvn/version "3.4.11"}
-  metosin/malli                 {:mvn/version "0.16.4"}
-  funcool/promesa               {:mvn/version "11.0.678"}
-  cider/cider-nrepl             {:mvn/version "0.50.2"}
-  refactor-nrepl/refactor-nrepl {:mvn/version "3.9.1"}
+ {thheller/shadow-cljs            {:mvn/version "3.4.11"}
+  metosin/malli                   {:mvn/version "0.16.4"}
+  funcool/promesa                 {:mvn/version "11.0.678"}
+  cider/cider-nrepl               {:mvn/version "0.50.2"}
+  refactor-nrepl/refactor-nrepl   {:mvn/version "3.9.1"}
+  open-hax/turn-processor         {:local/root "../turn-processor"}
+  open-hax/eta-mu                 {:local/root "../eta-mu"}
   io.github.open-hax/katamorph    {:git/tag "v0.2.0"
-                                   :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}
+                                    :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}
   io.github.open-hax/event-ledger {:git/url "https://github.com/open-hax/event-ledger.git"
-                                   :git/sha "ada7374b7f4e1c3b0ab4e6bbe996f10f06e9b93a"}}
+                                    :git/sha "ada7374b7f4e1c3b0ab4e6bbe996f10f06e9b93a"}}
 
  :aliases
  ;; Clojure-first mutation harness (mutation/knoxx/…) — mutates CLJS source

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_ledger.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_ledger.cljs
@@ -1,0 +1,73 @@
+(ns open-hax.sol.infra.agent.episode-ledger
+  "Effect seam from one Sol turn episode to the standalone event-ledger.
+
+   Hosts may inject `:event-ledger-append!` or supply `:event-ledger-db`. Without
+   either, Sol still builds and validates the canonical envelopes while keeping
+   its existing local EDN/realtime projections fully compatible."
+  (:require [open-hax.event-ledger :as event-ledger]
+            [open-hax.sol.domain.time :as time]
+            [open-hax.sol.shape.episode-event :as episode-event]))
+
+(defn- default-id-fn
+  []
+  (str (random-uuid)))
+
+(defn configured-appender
+  "Resolve the canonical append capability from Sol config.
+
+   An injected one-argument function is preferred for tests/non-Mongo hosts.
+   A configured Mongo DB delegates directly to event-ledger/append-event."
+  [config]
+  (or (:event-ledger-append! config)
+      (when-let [db (:event-ledger-db config)]
+        (fn [envelope]
+          (event-ledger/append-event db envelope)))))
+
+(defn create-episode
+  "Create process-local sequencing state for one send-agent-turn! invocation."
+  [config {:keys [run-id session-id conversation-id agent-spec auth-context]}]
+  (let [id-fn (or (:event-ledger-id-fn config) default-id-fn)
+        turn-id (id-fn)
+        episode-id (id-fn)
+        base (episode-event/episode-context
+              {:run-id run-id
+               :session-id session-id
+               :turn-id turn-id
+               :episode-id episode-id
+               :conversation-id conversation-id
+               :node-id (:sol-node-id config)
+               :auth-context auth-context
+               :agent-spec agent-spec})]
+    {:context base
+     :id-fn id-fn
+     :append! (configured-appender config)
+     :root-id* (atom nil)
+     :parent-id* (atom nil)}))
+
+(defn configured?
+  [episode]
+  (some? (:append! episode)))
+
+(defn ^:async emit!
+  "Validate and optionally append the next canonical lifecycle event.
+
+   Causal state advances only after the configured appender accepts the event.
+   With no appender, validation itself is the acceptance boundary and the
+   existing Sol runtime remains operational."
+  [episode event-type payload]
+  (let [event-id ((:id-fn episode))
+        root-id (or @(:root-id* episode) event-id)
+        parent-id @(:parent-id* episode)
+        context (assoc (:context episode) :causal/root root-id)
+        envelope (episode-event/envelope context
+                                         event-id
+                                         (time/now-iso)
+                                         parent-id
+                                         event-type
+                                         payload)
+        result (if-let [append! (:append! episode)]
+                 (await (append! envelope))
+                 envelope)]
+    (compare-and-set! (:root-id* episode) nil root-id)
+    (reset! (:parent-id* episode) event-id)
+    result))

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -44,9 +44,11 @@
    With no configured appender the envelopes are still built and validated, so
    current local-only deployments remain compatible. With an appender, any
    canonical append failure is observable and prevents a false claim of
-   successful canonical persistence."
+   successful canonical persistence. `:turn-executor!` is an optional infra
+   injection used by conformance tests and alternate Sol hosts."
   [runtime config request]
   (let [request (normalized-request request)
+        execute! (or (:turn-executor! config) turn/send-agent-turn!)
         episode (episode-ledger/create-episode
                  config
                  {:run-id (:run-id request)
@@ -63,7 +65,7 @@
             "sol.turn.started"
             (lifecycle-payload request "running" nil)))
     (try
-      (let [result (await (turn/send-agent-turn! runtime config request))
+      (let [result (await (execute! runtime config request))
             completed (lifecycle-payload
                        request
                        "completed"

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -20,6 +20,11 @@
            :conversation-id conversation-id
            :run-id run-id)))
 
+(defn- error-message
+  [error]
+  (or (some-> error .-message str)
+      (str error)))
+
 (defn- lifecycle-payload
   [request status extra]
   (merge {:status status
@@ -30,7 +35,10 @@
 
 (defn- ^:async emit-failure-lifecycle!
   [episode request error]
-  (let [payload (lifecycle-payload request "failed" {:error (str error)})]
+  (let [payload (lifecycle-payload
+                 request
+                 "failed"
+                 {:error (error-message error)})]
     (try
       (await (episode-ledger/emit! episode "sol.turn.failed" payload))
       (await (episode-ledger/emit! episode "sol.run.failed" payload))
@@ -48,8 +56,8 @@
           (throw (ex-info "Sol turn and canonical episode emission failed"
                           {:run-id (:run-id request)
                            :session-id (:session-id request)
-                           :turn-error (str error)
-                           :ledger-error (str ledger-error)}
+                           :turn-error (error-message error)
+                           :ledger-error (error-message ledger-error)}
                           ledger-error))
           (throw error))))))
 
@@ -84,7 +92,8 @@
           completed (lifecycle-payload
                      request
                      "completed"
-                     {:model (:model result)})]
+                     (when-let [model (:model result)]
+                       {:model model}))]
       ;; Completion persistence is outside the execution-failure handler. If a
       ;; terminal append fails, propagate it directly; never append a later
       ;; `turn.failed` after `turn.completed` has already been accepted.

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -82,12 +82,12 @@
         (await (report! failure))
         (.error js/console
                 "[sol-event-ledger] canonical terminal persistence failed"
-                (clj->js failure)))
+                failure))
       (catch :default report-error
         (.error js/console
                 "[sol-event-ledger] persistence failure reporter failed"
-                (clj->js (assoc failure
-                                :report/error (error-message report-error))))))
+                (assoc failure
+                       :report/error (error-message report-error)))))
     failure))
 
 (defn- ^:async emit-completion-lifecycle!

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -38,6 +38,21 @@
       (catch :default ledger-error
         ledger-error))))
 
+(defn- ^:async execute-or-record-failure!
+  [execute! runtime config request episode]
+  (try
+    (await (execute! runtime config request))
+    (catch :default error
+      (let [ledger-error (await (emit-failure-lifecycle! episode request error))]
+        (if ledger-error
+          (throw (ex-info "Sol turn and canonical episode emission failed"
+                          {:run-id (:run-id request)
+                           :session-id (:session-id request)
+                           :turn-error (str error)
+                           :ledger-error (str ledger-error)}
+                          ledger-error))
+          (throw error))))))
+
 (defn ^:async send-agent-turn!
   "Execute one existing Sol turn while emitting a four-event canonical episode.
 
@@ -64,22 +79,15 @@
             episode
             "sol.turn.started"
             (lifecycle-payload request "running" nil)))
-    (try
-      (let [result (await (execute! runtime config request))
-            completed (lifecycle-payload
-                       request
-                       "completed"
-                       {:model (:model result)})]
-        (await (episode-ledger/emit! episode "sol.turn.completed" completed))
-        (await (episode-ledger/emit! episode "sol.run.completed" completed))
-        result)
-      (catch :default error
-        (let [ledger-error (await (emit-failure-lifecycle! episode request error))]
-          (if ledger-error
-            (throw (ex-info "Sol turn and canonical episode emission failed"
-                            {:run-id (:run-id request)
-                             :session-id (:session-id request)
-                             :turn-error (str error)
-                             :ledger-error (str ledger-error)}
-                            ledger-error))
-            (throw error)))))))
+    (let [result (await (execute-or-record-failure!
+                         execute! runtime config request episode))
+          completed (lifecycle-payload
+                     request
+                     "completed"
+                     {:model (:model result)})]
+      ;; Completion persistence is outside the execution-failure handler. If a
+      ;; terminal append fails, propagate it directly; never append a later
+      ;; `turn.failed` after `turn.completed` has already been accepted.
+      (await (episode-ledger/emit! episode "sol.turn.completed" completed))
+      (await (episode-ledger/emit! episode "sol.run.completed" completed))
+      result)))

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -61,14 +61,62 @@
                           ledger-error))
           (throw error))))))
 
+(defn- persistence-failure
+  [request event-type error]
+  {:failure/kind :canonical-persistence
+   :event/type event-type
+   :run/id (:run-id request)
+   :session/id (:session-id request)
+   :conversation/id (:conversation-id request)
+   :error/message (error-message error)})
+
+(defn- ^:async report-persistence-failure!
+  "Report a canonical terminal append failure without rewriting successful local
+   execution as a failed run. Hosts may inject `:event-ledger-report-error!`;
+   the default is a structured console error. Reporter failure is itself logged
+   but never replaces the already-produced turn result."
+  [config request event-type error]
+  (let [failure (persistence-failure request event-type error)]
+    (try
+      (if-let [report! (:event-ledger-report-error! config)]
+        (await (report! failure))
+        (.error js/console
+                "[sol-event-ledger] canonical terminal persistence failed"
+                (clj->js failure)))
+      (catch :default report-error
+        (.error js/console
+                "[sol-event-ledger] persistence failure reporter failed"
+                (clj->js (assoc failure
+                                :report/error (error-message report-error))))))
+    failure))
+
+(defn- ^:async emit-completion-lifecycle!
+  [config episode request completed]
+  (try
+    (await (episode-ledger/emit! episode "sol.turn.completed" completed))
+    (try
+      (await (episode-ledger/emit! episode "sol.run.completed" completed))
+      true
+      (catch :default error
+        (await (report-persistence-failure!
+                config request "sol.run.completed" error))
+        false))
+    (catch :default error
+      (await (report-persistence-failure!
+              config request "sol.turn.completed" error))
+      false)))
+
 (defn ^:async send-agent-turn!
   "Execute one existing Sol turn while emitting a four-event canonical episode.
 
    With no configured appender the envelopes are still built and validated, so
-   current local-only deployments remain compatible. With an appender, any
-   canonical append failure is observable and prevents a false claim of
-   successful canonical persistence. `:turn-executor!` is an optional infra
-   injection used by conformance tests and alternate Sol hosts."
+   current local-only deployments remain compatible. Canonical start failures
+   remain blocking because execution has not begun. Execution failures remain
+   failures and attempt canonical failure events. Once execution succeeds,
+   terminal canonical append failures are reported separately and the produced
+   result is returned so Sol's local EDN/realtime projections stay truthful.
+   `:turn-executor!` and `:event-ledger-report-error!` are optional infra
+   injections used by conformance tests and alternate Sol hosts."
   [runtime config request]
   (let [request (normalized-request request)
         execute! (or (:turn-executor! config) turn/send-agent-turn!)
@@ -94,9 +142,5 @@
                      "completed"
                      (when-let [model (:model result)]
                        {:model model}))]
-      ;; Completion persistence is outside the execution-failure handler. If a
-      ;; terminal append fails, propagate it directly; never append a later
-      ;; `turn.failed` after `turn.completed` has already been accepted.
-      (await (episode-ledger/emit! episode "sol.turn.completed" completed))
-      (await (episode-ledger/emit! episode "sol.run.completed" completed))
+      (await (emit-completion-lifecycle! config episode request completed))
       result)))

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -33,6 +33,41 @@
            {:model model})
          (or extra {})))
 
+(defn- ^:async emit-start-lifecycle!
+  [episode request]
+  (await (episode-ledger/emit!
+          episode
+          "sol.run.started"
+          (lifecycle-payload request "running" nil)))
+  (try
+    (await (episode-ledger/emit!
+            episode
+            "sol.turn.started"
+            (lifecycle-payload request "running" nil)))
+    nil
+    (catch :default turn-start-error
+      (let [payload (lifecycle-payload
+                     request
+                     "failed"
+                     {:error (error-message turn-start-error)})
+            run-failure-error
+            (try
+              (await (episode-ledger/emit!
+                      episode
+                      "sol.run.failed"
+                      payload))
+              nil
+              (catch :default error
+                error))]
+        (if run-failure-error
+          (throw (ex-info "Sol turn start and canonical run termination failed"
+                          {:run-id (:run-id request)
+                           :session-id (:session-id request)
+                           :turn-start-error (error-message turn-start-error)
+                           :ledger-error (error-message run-failure-error)}
+                          run-failure-error))
+          (throw turn-start-error))))))
+
 (defn- ^:async emit-failure-lifecycle!
   [episode request error]
   (let [payload (lifecycle-payload
@@ -111,12 +146,14 @@
 
    With no configured appender the envelopes are still built and validated, so
    current local-only deployments remain compatible. Canonical start failures
-   remain blocking because execution has not begun. Execution failures remain
-   failures and attempt canonical failure events. Once execution succeeds,
-   terminal canonical append failures are reported separately and the produced
-   result is returned so Sol's local EDN/realtime projections stay truthful.
-   `:turn-executor!` and `:event-ledger-report-error!` are optional infra
-   injections used by conformance tests and alternate Sol hosts."
+   remain blocking because execution has not begun. If run start is accepted but
+   turn start fails, Sol attempts to close the accepted run before propagating
+   the start error. Execution failures remain failures and attempt canonical
+   failure events. Once execution succeeds, terminal canonical append failures
+   are reported separately and the produced result is returned so Sol's local
+   EDN/realtime projections stay truthful. `:turn-executor!` and
+   `:event-ledger-report-error!` are optional infra injections used by
+   conformance tests and alternate Sol hosts."
   [runtime config request]
   (let [request (normalized-request request)
         execute! (or (:turn-executor! config) turn/send-agent-turn!)
@@ -127,14 +164,7 @@
                   :conversation-id (:conversation-id request)
                   :agent-spec (:agent-spec request)
                   :auth-context (:auth-context request)})]
-    (await (episode-ledger/emit!
-            episode
-            "sol.run.started"
-            (lifecycle-payload request "running" nil)))
-    (await (episode-ledger/emit!
-            episode
-            "sol.turn.started"
-            (lifecycle-payload request "running" nil)))
+    (await (emit-start-lifecycle! episode request))
     (let [result (await (execute-or-record-failure!
                          execute! runtime config request episode))
           completed (lifecycle-payload

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/episode_turn.cljs
@@ -1,0 +1,83 @@
+(ns open-hax.sol.infra.agent.episode-turn
+  "Canonical event-ledger lifecycle wrapper for one Sol turn.
+
+   The wrapped turn remains responsible for Sol's existing EDN run projection,
+   session state, provider execution, and realtime broadcasts. This namespace
+   adds only the cross-runtime operational envelope owned by event-ledger."
+  (:require [open-hax.sol.extern.agent-turn-node :as xturn-node]
+            [open-hax.sol.infra.agent.episode-ledger :as episode-ledger]
+            [open-hax.sol.infra.agent.turn :as turn]))
+
+(defn- normalized-request
+  [request]
+  (let [session-id (turn/ensure-session-id (:session-id request))
+        conversation-id (or (:conversation-id request)
+                            (xturn-node/random-uuid!))
+        run-id (or (:run-id request)
+                   (xturn-node/random-uuid!))]
+    (assoc request
+           :session-id session-id
+           :conversation-id conversation-id
+           :run-id run-id)))
+
+(defn- lifecycle-payload
+  [request status extra]
+  (merge {:status status
+          :conversation_id (:conversation-id request)}
+         (when-let [model (:model request)]
+           {:model model})
+         (or extra {})))
+
+(defn- ^:async emit-failure-lifecycle!
+  [episode request error]
+  (let [payload (lifecycle-payload request "failed" {:error (str error)})]
+    (try
+      (await (episode-ledger/emit! episode "sol.turn.failed" payload))
+      (await (episode-ledger/emit! episode "sol.run.failed" payload))
+      nil
+      (catch :default ledger-error
+        ledger-error))))
+
+(defn ^:async send-agent-turn!
+  "Execute one existing Sol turn while emitting a four-event canonical episode.
+
+   With no configured appender the envelopes are still built and validated, so
+   current local-only deployments remain compatible. With an appender, any
+   canonical append failure is observable and prevents a false claim of
+   successful canonical persistence."
+  [runtime config request]
+  (let [request (normalized-request request)
+        episode (episode-ledger/create-episode
+                 config
+                 {:run-id (:run-id request)
+                  :session-id (:session-id request)
+                  :conversation-id (:conversation-id request)
+                  :agent-spec (:agent-spec request)
+                  :auth-context (:auth-context request)})]
+    (await (episode-ledger/emit!
+            episode
+            "sol.run.started"
+            (lifecycle-payload request "running" nil)))
+    (await (episode-ledger/emit!
+            episode
+            "sol.turn.started"
+            (lifecycle-payload request "running" nil)))
+    (try
+      (let [result (await (turn/send-agent-turn! runtime config request))
+            completed (lifecycle-payload
+                       request
+                       "completed"
+                       {:model (:model result)})]
+        (await (episode-ledger/emit! episode "sol.turn.completed" completed))
+        (await (episode-ledger/emit! episode "sol.run.completed" completed))
+        result)
+      (catch :default error
+        (let [ledger-error (await (emit-failure-lifecycle! episode request error))]
+          (if ledger-error
+            (throw (ex-info "Sol turn and canonical episode emission failed"
+                            {:run-id (:run-id request)
+                             :session-id (:session-id request)
+                             :turn-error (str error)
+                             :ledger-error (str ledger-error)}
+                            ledger-error))
+            (throw error)))))))

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/runner.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/runner.cljs
@@ -12,11 +12,12 @@
      WS   /ws/stream?run_id=...   -> live run/token events
      GET  /api/agent/run/:id      -> current run state
      GET  /api/agent/run/:id/events -> ordered run event ledger"
-  (:require [open-hax.sol.infra.agent.run-state :as run-state]
+  (:require [open-hax.sol.extern.agent-runner :as xrunner]
+            [open-hax.sol.extern.agent-turn-node :as xturn-node]
+            [open-hax.sol.infra.agent.episode-turn :as episode-turn]
+            [open-hax.sol.infra.agent.run-state :as run-state]
             [open-hax.sol.infra.agent.turn :as agent-turns]
-            [open-hax.sol.runtime.state :as runtime-state]
-            [open-hax.sol.extern.agent-runner :as xrunner]
-            [open-hax.sol.extern.agent-turn-node :as xturn-node]))
+            [open-hax.sol.runtime.state :as runtime-state]))
 
 (defonce active-runs* (atom {}))
 
@@ -58,7 +59,7 @@
   [runtime config body]
   (let [run-id (:run-id body)]
     (try
-      (await (agent-turns/send-agent-turn! runtime config body))
+      (await (episode-turn/send-agent-turn! runtime config body))
       (catch :default err
         (record-async-spawn-error! body err))
       (finally

--- a/packages/sol/src/cljs/open_hax/sol/infra/agent/service.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/agent/service.cljs
@@ -1,9 +1,9 @@
 (ns open-hax.sol.infra.agent.service
   "Small consumer-facing facade for Sol agent runtime operations."
-  (:require [open-hax.sol.infra.agent.runner :as runner]
+  (:require [open-hax.sol.infra.agent.episode-turn :as episode-turn]
+            [open-hax.sol.infra.agent.runner :as runner]
             [open-hax.sol.infra.agent.runtime :as runtime]
-            [open-hax.sol.infra.agent.session :as session]
-            [open-hax.sol.infra.agent.turn :as turn]))
+            [open-hax.sol.infra.agent.session :as session]))
 
 (defprotocol IAgentService
   (-start-turn! [svc turn-request])
@@ -15,7 +15,7 @@
 (defrecord SolAgentService [runtime config delegates]
   IAgentService
   (-start-turn! [_ turn-request]
-    ((or (:start-turn! delegates) turn/send-agent-turn!) runtime config turn-request))
+    ((or (:start-turn! delegates) episode-turn/send-agent-turn!) runtime config turn-request))
 
   (-queue-turn! [this turn-request]
     (if-let [queue-fn (:queue-turn! delegates)]

--- a/packages/sol/src/cljs/open_hax/sol/infra/http.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/infra/http.cljs
@@ -107,9 +107,10 @@
 
 (defn http-error
   [status code message]
-  (doto (ex-info (str status " " message) {:status status :code code})
-    (aset "statusCode" status)
-    (aset "code" code)))
+  (let [error (ex-info (str status " " message) {:status status :code code})]
+    (js/Object.assign error #js {:statusCode status
+                                 :code code})
+    error))
 
 (defn error-status
   [err default-status]
@@ -125,12 +126,12 @@
    (error-response! reply err default-status {}))
   ([reply err default-status _context]
    (let [status (error-status err default-status)
-          code (xfastify/error-code err)
-          payload (cond-> {:detail (error-message err)}
-                    code (assoc :error_code code))]
-      (when (>= status 500)
-        (js/console.error "[sol-http] error response" status code err))
-      (json-response! reply status payload))))
+         code (xfastify/error-code err)
+         payload (cond-> {:detail (error-message err)}
+                   code (assoc :error_code code))]
+     (when (>= status 500)
+       (js/console.error "[sol-http] error response" status code err))
+     (json-response! reply status payload))))
 
 (defn no-content?
   [x]
@@ -162,6 +163,7 @@
 (defn request-forward-body
   [request]
   (xfastify/forward-body request))
+
 (defn request-stream-body
   [request]
   (xfastify/stream-body-options request))

--- a/packages/sol/src/cljs/open_hax/sol/shape/app_shapes.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/shape/app_shapes.cljs
@@ -80,6 +80,7 @@
   [value]
   (let [spec (maybe-cljs-map value)
         contract-id (spec-value spec :contract_id :contract-id :contractId :agent_id :agent-id :agentId)
+        contract-revision (spec-value spec :contract_revision :contract-revision :contractRevision)
         actor-id (spec-value spec :actor_id :actor-id :actorId)
         role (spec-value spec :role :role_slug :role-slug)
         system-prompt (spec-value-raw spec :system_prompt :system-prompt :systemPrompt)
@@ -98,8 +99,10 @@
                     (:runtimeSources spec))
         memory-hydration (memory-hydration-spec spec)
         context-policy (context-policy-spec spec)]
-    (when (or contract-id actor-id role system-prompt task-prompt model thinking-level (seq tool-policies) resource-policies (seq sources) memory-hydration context-policy)
+    (when (or contract-id contract-revision actor-id role system-prompt task-prompt model thinking-level
+              (seq tool-policies) resource-policies (seq sources) memory-hydration context-policy)
       {:contract-id contract-id
+       :contract-revision contract-revision
        :actor-id actor-id
        :role role
        :system-prompt system-prompt
@@ -206,11 +209,11 @@
                                                    "template-context"))
      :mode (or (body-value body "mode") "direct")
      :agent-spec (normalize-agent-spec (or (body-value body "agentId"
-                                                           "agent_id"
-                                                           "agent-id")
-                                            (body-value body "agentSpec"
-                                                        "agent_spec"
-                                                        "agent-spec")))
+                                                       "agent_id"
+                                                       "agent-id")
+                                        (body-value body "agentSpec"
+                                                    "agent_spec"
+                                                    "agent-spec")))
      :auth-context (maybe-cljs-map (body-value body "authContext"
                                                "auth_context"
                                                "auth-context"))}))

--- a/packages/sol/src/cljs/open_hax/sol/shape/episode_event.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/shape/episode_event.cljs
@@ -15,27 +15,73 @@
   [value]
   (some-> value str str/trim not-empty))
 
+(defn- key-string
+  [key]
+  (if (keyword? key)
+    (if-let [key-ns (namespace key)]
+      (str key-ns "/" (name key))
+      (name key))
+    (str key)))
+
 (defn- first-value
   [m keys]
   (some (fn [key]
-          (when (contains? m key)
-            (get m key)))
+          (let [string-key (key-string key)]
+            (cond
+              (contains? m key) (get m key)
+              (contains? m string-key) (get m string-key)
+              :else nil)))
         keys))
 
 (defn- shaped-string
   [m keys]
   (nonblank-string (first-value (or m {}) keys)))
 
-(defn- principal-kind
-  [auth-context agent-spec]
-  (let [requested (some-> (shaped-string auth-context
-                                         [:principalKind :principal-kind :principal_kind
-                                          :actorKind :actor-kind :actor_kind])
+(defn- binding-source
+  [auth-context]
+  (let [auth-context (or auth-context {})
+        nested (first-value auth-context
+                            [:principal/binding
+                             :principalBinding
+                             :principal-binding
+                             :principal_binding
+                             :runtimeBinding
+                             :runtime-binding
+                             :runtime_binding])]
+    (if (map? nested) nested auth-context)))
+
+(defn- supplied-principal-kind
+  [auth-context]
+  (let [source (binding-source auth-context)
+        requested (some-> (or (shaped-string source
+                                              [:principal/kind
+                                               :principalKind
+                                               :principal-kind
+                                               :principal_kind])
+                              (shaped-string auth-context
+                                             [:auth/principal-kind
+                                              :auth/principalKind
+                                              :principalKind
+                                              :principal-kind
+                                              :principal_kind]))
                           str/lower-case)]
+    (when (contains? principal-kinds requested)
+      requested)))
+
+(defn- binding-version
+  [source]
+  (let [value (first-value source
+                           [:binding/version
+                            :bindingVersion
+                            :binding-version
+                            :binding_version])]
     (cond
-      (contains? principal-kinds requested) requested
-      (nonblank-string (:actor-id agent-spec)) "agent"
-      :else "service")))
+      (nil? value) 1
+      (= 1 value) 1
+      (= "1" (str value)) 1
+      :else
+      (throw (ex-info "Unsupported Axxium runtime binding version"
+                      {:binding/version value})))))
 
 (defn resource-ref
   "Project the governing actor/agent resource reference from an agent spec."
@@ -47,26 +93,51 @@
              (nonblank-string (:contract-revision agent-spec))))))
 
 (defn principal-binding
-  "Build PrincipalBindingV1 only when both Axxium actor and entity identities
-   are present. Missing identity is never fabricated from session/run IDs."
+  "Build the event-ledger PrincipalBindingV1 only from supplied Axxium identity.
+
+   Accepted input includes Axxium's canonical RuntimePrincipalBinding map,
+   a nested `:principal/binding`, Axxium `:auth/*` identity keys accompanied by
+   a supplied principal kind, and legacy transport aliases. Agent specs may add
+   a Katamorph resource reference but never fabricate principal identity/kind."
   [auth-context agent-spec]
-  (let [actor-id (or (shaped-string auth-context [:actorId :actor-id :actor_id])
-                     (nonblank-string (:actor-id agent-spec)))
-        entity-id (shaped-string auth-context
-                                 [:entityId :entity-id :entity_id
-                                  :principalEntityId :principal-entity-id
-                                  :principal_entity_id])
-        org-id (shaped-string auth-context
-                              [:orgId :org-id :org_id
-                               :tenantId :tenant-id :tenant_id])
+  (let [source (binding-source auth-context)
+        actor-id (or (shaped-string source
+                                    [:principal/actor-id
+                                     :actorId :actor-id :actor_id])
+                     (shaped-string auth-context
+                                    [:auth/actor-id
+                                     :actorId :actor-id :actor_id]))
+        entity-id (or (shaped-string source
+                                     [:principal/entity-id
+                                      :entityId :entity-id :entity_id
+                                      :principalEntityId :principal-entity-id
+                                      :principal_entity_id])
+                      (shaped-string auth-context
+                                     [:auth/entity-id
+                                      :entityId :entity-id :entity_id]))
+        org-id (or (shaped-string source
+                                  [:principal/org-id
+                                   :orgId :org-id :org_id
+                                   :tenantId :tenant-id :tenant_id])
+                   (shaped-string auth-context
+                                  [:auth/org-id
+                                   :orgId :org-id :org_id
+                                   :tenantId :tenant-id :tenant_id]))
+        principal-kind (supplied-principal-kind auth-context)
         actor-resource (resource-ref agent-spec)]
-    (when (and actor-id entity-id)
-      (cond-> {:binding/version 1
+    (when (and actor-id entity-id principal-kind)
+      (cond-> {:binding/version (binding-version source)
                :principal/actor-id actor-id
                :principal/entity-id entity-id
-               :principal/kind (principal-kind auth-context agent-spec)}
+               :principal/kind principal-kind}
         org-id (assoc :principal/org-id org-id)
         actor-resource (assoc :actor/resource actor-resource)))))
+
+(defn- transport-actor-kind
+  [auth-context agent-spec]
+  (or (supplied-principal-kind auth-context)
+      (when (nonblank-string (:actor-id agent-spec)) "agent")
+      "service"))
 
 (defn actor-descriptor
   "Build transport attribution. The actor descriptor may exist without a
@@ -74,14 +145,19 @@
    invented authenticated principal."
   [auth-context agent-spec node-id]
   (let [binding (principal-binding auth-context agent-spec)
+        source (binding-source auth-context)
         actor-id (or (:principal/actor-id binding)
-                     (shaped-string auth-context [:actorId :actor-id :actor_id])
+                     (shaped-string source
+                                    [:principal/actor-id
+                                     :actorId :actor-id :actor_id])
+                     (shaped-string auth-context
+                                    [:auth/actor-id
+                                     :actorId :actor-id :actor_id])
                      (nonblank-string (:actor-id agent-spec))
                      (nonblank-string node-id)
                      "sol.runtime")
-        actor-kind (if binding
-                     (:principal/kind binding)
-                     (principal-kind auth-context agent-spec))]
+        actor-kind (or (:principal/kind binding)
+                       (transport-actor-kind auth-context agent-spec))]
     (cond-> {:actor-id actor-id
              :actor-kind actor-kind}
       (nonblank-string node-id) (assoc :actor-node (nonblank-string node-id))

--- a/packages/sol/src/cljs/open_hax/sol/shape/episode_event.cljs
+++ b/packages/sol/src/cljs/open_hax/sol/shape/episode_event.cljs
@@ -1,0 +1,141 @@
+(ns open-hax.sol.shape.episode-event
+  "Pure Sol projection onto the standalone event-ledger envelope.
+
+   This namespace shapes references only. Axxium remains the authority for live
+   principals; Katamorph remains the authority for actor/agent resources;
+   event-ledger remains the authority for envelope validation and append
+   semantics."
+  (:require [clojure.string :as str]
+            [open-hax.event-ledger :as event-ledger]))
+
+(def principal-kinds
+  #{"human" "agent" "service" "automation"})
+
+(defn- nonblank-string
+  [value]
+  (some-> value str str/trim not-empty))
+
+(defn- first-value
+  [m keys]
+  (some (fn [key]
+          (when (contains? m key)
+            (get m key)))
+        keys))
+
+(defn- shaped-string
+  [m keys]
+  (nonblank-string (first-value (or m {}) keys)))
+
+(defn- principal-kind
+  [auth-context agent-spec]
+  (let [requested (some-> (shaped-string auth-context
+                                         [:principalKind :principal-kind :principal_kind
+                                          :actorKind :actor-kind :actor_kind])
+                          str/lower-case)]
+    (cond
+      (contains? principal-kinds requested) requested
+      (nonblank-string (:actor-id agent-spec)) "agent"
+      :else "service")))
+
+(defn resource-ref
+  "Project the governing actor/agent resource reference from an agent spec."
+  [agent-spec]
+  (when-let [resource-id (nonblank-string (:contract-id agent-spec))]
+    (cond-> {:resource/id resource-id}
+      (nonblank-string (:contract-revision agent-spec))
+      (assoc :resource/revision
+             (nonblank-string (:contract-revision agent-spec))))))
+
+(defn principal-binding
+  "Build PrincipalBindingV1 only when both Axxium actor and entity identities
+   are present. Missing identity is never fabricated from session/run IDs."
+  [auth-context agent-spec]
+  (let [actor-id (or (shaped-string auth-context [:actorId :actor-id :actor_id])
+                     (nonblank-string (:actor-id agent-spec)))
+        entity-id (shaped-string auth-context
+                                 [:entityId :entity-id :entity_id
+                                  :principalEntityId :principal-entity-id
+                                  :principal_entity_id])
+        org-id (shaped-string auth-context
+                              [:orgId :org-id :org_id
+                               :tenantId :tenant-id :tenant_id])
+        actor-resource (resource-ref agent-spec)]
+    (when (and actor-id entity-id)
+      (cond-> {:binding/version 1
+               :principal/actor-id actor-id
+               :principal/entity-id entity-id
+               :principal/kind (principal-kind auth-context agent-spec)}
+        org-id (assoc :principal/org-id org-id)
+        actor-resource (assoc :actor/resource actor-resource)))))
+
+(defn actor-descriptor
+  "Build transport attribution. The actor descriptor may exist without a
+   principal binding; its fallback identifies the Sol runtime node, not an
+   invented authenticated principal."
+  [auth-context agent-spec node-id]
+  (let [binding (principal-binding auth-context agent-spec)
+        actor-id (or (:principal/actor-id binding)
+                     (shaped-string auth-context [:actorId :actor-id :actor_id])
+                     (nonblank-string (:actor-id agent-spec))
+                     (nonblank-string node-id)
+                     "sol.runtime")
+        actor-kind (if binding
+                     (:principal/kind binding)
+                     (principal-kind auth-context agent-spec))]
+    (cond-> {:actor-id actor-id
+             :actor-kind actor-kind}
+      (nonblank-string node-id) (assoc :actor-node (nonblank-string node-id))
+      binding (assoc :principal/binding binding))))
+
+(defn episode-context
+  "Construct the immutable identity/correlation portion of one Sol turn
+   episode. ID generation belongs to infra and is supplied by the caller."
+  [{:keys [run-id session-id turn-id episode-id conversation-id causal-root
+           node-id auth-context agent-spec]}]
+  (let [actor (actor-descriptor auth-context agent-spec node-id)
+        contract-ref (resource-ref agent-spec)]
+    (cond-> {:run/id run-id
+             :session/id session-id
+             :turn/id turn-id
+             :episode/id episode-id
+             :causal/root causal-root
+             :event/from actor}
+      (nonblank-string conversation-id)
+      (assoc :conversation/id (nonblank-string conversation-id))
+
+      contract-ref
+      (assoc :contracts [(:resource/id contract-ref)]
+             :contract/refs [contract-ref]))))
+
+(defn envelope
+  "Build and validate one canonical event-ledger envelope.
+
+   `parent-id` is nil for the first event. The caller owns sequencing and only
+   advances the parent after successful append/acceptance."
+  [episode event-id event-time parent-id event-type payload]
+  (let [payload (cond-> (or payload {})
+                  (:conversation/id episode)
+                  (assoc :conversation/id (:conversation/id episode)))
+        candidate (cond->
+                   {:envelope/version 1
+                    :event/id event-id
+                    :event/type event-type
+                    :event/time event-time
+                    :event/from (:event/from episode)
+                    :causal/root (:causal/root episode)
+                    :session/id (:session/id episode)
+                    :turn/id (:turn/id episode)
+                    :run/id (:run/id episode)
+                    :episode/id (:episode/id episode)
+                    :delivery/mode "stream"
+                    :payload payload}
+                    parent-id (assoc :causal/parent parent-id)
+                    (:contracts episode) (assoc :contracts (:contracts episode))
+                    (:contract/refs episode) (assoc :contract/refs
+                                                    (:contract/refs episode)))
+        validation (event-ledger/validate-envelope candidate)]
+    (when-not (:valid validation)
+      (throw (ex-info "Sol produced an invalid event-ledger envelope"
+                      {:event/type event-type
+                       :errors (:errors validation)})))
+    candidate))

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_ledger_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_ledger_test.cljs
@@ -1,5 +1,6 @@
 (ns open-hax.sol.infra.agent.episode-ledger-test
   (:require [cljs.test :refer [deftest is testing]]
+            [open-hax.event-ledger :as event-ledger]
             [open-hax.sol.infra.agent.episode-ledger :as episode-ledger]))
 
 (defn- sequential-id-fn
@@ -79,7 +80,7 @@
         db {:name "ledger-db"}
         append! (episode-ledger/configured-appender
                  {:event-ledger-db db})]
-    (with-redefs [open-hax.event-ledger/append-event
+    (with-redefs [event-ledger/append-event
                   (fn [actual-db envelope]
                     (swap! calls* conj [actual-db envelope])
                     (js/Promise.resolve envelope))]

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_ledger_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_ledger_test.cljs
@@ -1,0 +1,113 @@
+(ns open-hax.sol.infra.agent.episode-ledger-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [open-hax.sol.infra.agent.episode-ledger :as episode-ledger]))
+
+(defn- sequential-id-fn
+  [ids]
+  (let [remaining* (atom (vec ids))]
+    (fn []
+      (let [id (first @remaining*)]
+        (swap! remaining* subvec 1)
+        id))))
+
+(def episode-input
+  {:run-id "run-1"
+   :session-id "session-1"
+   :conversation-id "conversation-1"
+   :agent-spec {:actor-id "actor.agent.research"
+                :contract-id "agent/research"
+                :contract-revision "git:abc123"}
+   :auth-context {:actorId "actor.agent.research"
+                  :entityId "entity.agent.research"
+                  :orgId "org.open-hax"
+                  :principalKind "agent"}})
+
+(deftest ^:async causal-lifecycle-test
+  (let [accepted* (atom [])
+        id-fn (sequential-id-fn
+               ["turn-1" "episode-1"
+                "event-1" "event-2" "event-3" "event-4"])
+        episode (episode-ledger/create-episode
+                 {:event-ledger-id-fn id-fn
+                  :sol-node-id "sol.node.local"
+                  :event-ledger-append!
+                  (fn [envelope]
+                    (swap! accepted* conj envelope)
+                    (js/Promise.resolve envelope))}
+                 episode-input)]
+    (doseq [event-type ["sol.run.started"
+                        "sol.turn.started"
+                        "sol.turn.completed"
+                        "sol.run.completed"]]
+      (await (episode-ledger/emit! episode event-type {:status "ok"})))
+    (let [events @accepted*]
+      (is (= ["sol.run.started"
+              "sol.turn.started"
+              "sol.turn.completed"
+              "sol.run.completed"]
+             (mapv :event/type events)))
+      (is (= ["event-1" "event-2" "event-3" "event-4"]
+             (mapv :event/id events)))
+      (is (= [nil "event-1" "event-2" "event-3"]
+             (mapv :causal/parent events)))
+      (is (= #{"event-1"} (set (map :causal/root events))))
+      (is (= #{"turn-1"} (set (map :turn/id events))))
+      (is (= #{"episode-1"} (set (map :episode/id events))))
+      (is (= #{"run-1"} (set (map :run/id events))))
+      (is (= #{"org.open-hax"}
+             (set (map #(get-in % [:event/from :principal/binding
+                                   :principal/org-id])
+                       events)))))))
+
+(deftest ^:async no-appender-remains-valid-test
+  (let [episode (episode-ledger/create-episode
+                 {:event-ledger-id-fn
+                  (sequential-id-fn ["turn-1" "episode-1" "event-1"])}
+                 (assoc episode-input :auth-context nil))
+        envelope (await (episode-ledger/emit!
+                         episode
+                         "sol.run.started"
+                         {:status "running"}))]
+    (is (false? (episode-ledger/configured? episode)))
+    (is (= "sol.run.started" (:event/type envelope)))
+    (is (= "event-1" (:causal/root envelope)))
+    (is (= "actor.agent.research" (get-in envelope [:event/from :actor-id])))
+    (is (not (contains? (:event/from envelope) :principal/binding)))))
+
+(deftest ^:async configured-db-delegates-to-event-ledger-test
+  (let [calls* (atom [])
+        db {:name "ledger-db"}
+        append! (episode-ledger/configured-appender
+                 {:event-ledger-db db})]
+    (with-redefs [open-hax.event-ledger/append-event
+                  (fn [actual-db envelope]
+                    (swap! calls* conj [actual-db envelope])
+                    (js/Promise.resolve envelope))]
+      (let [result (await (append! {:event/type "test"}))]
+        (is (= {:event/type "test"} result))
+        (is (= [[db {:event/type "test"}]] @calls*))))))
+
+(deftest ^:async rejected-append-does-not-advance-causality-test
+  (let [attempts* (atom 0)
+        episode (episode-ledger/create-episode
+                 {:event-ledger-id-fn
+                  (sequential-id-fn ["turn-1" "episode-1" "event-1" "event-2"])
+                  :event-ledger-append!
+                  (fn [envelope]
+                    (swap! attempts* inc)
+                    (if (= 1 @attempts*)
+                      (js/Promise.reject (js/Error. "ledger unavailable"))
+                      (js/Promise.resolve envelope)))}
+                 episode-input)]
+    (try
+      (await (episode-ledger/emit! episode "sol.run.started" {}))
+      (is false "first append should reject")
+      (catch :default error
+        (is (= "ledger unavailable" (.-message error)))))
+    (let [accepted (await (episode-ledger/emit!
+                          episode
+                          "sol.run.started"
+                          {}))]
+      (is (= "event-2" (:event/id accepted)))
+      (is (= "event-2" (:causal/root accepted)))
+      (is (nil? (:causal/parent accepted))))))

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_ledger_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_ledger_test.cljs
@@ -1,5 +1,5 @@
 (ns open-hax.sol.infra.agent.episode-ledger-test
-  (:require [cljs.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is]]
             [open-hax.event-ledger :as event-ledger]
             [open-hax.sol.infra.agent.episode-ledger :as episode-ledger]))
 

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_terminal_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_terminal_test.cljs
@@ -1,5 +1,5 @@
 (ns open-hax.sol.infra.agent.episode-terminal-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [open-hax.sol.infra.agent.episode-turn :as episode-turn]))
 
 (defn- sequential-id-fn
@@ -10,8 +10,18 @@
         (swap! remaining* subvec 1)
         id))))
 
-(deftest ^:async completion-append-failure-never-backfills-turn-failed-test
+(def request
+  {:run-id "run-1"
+   :session-id "session-1"
+   :conversation-id "conversation-1"})
+
+(def result
+  {:answer "done"
+   :model "model-1"})
+
+(deftest ^:async run-completion-failure-is-reported-without-local-failure-test
   (let [attempted-types* (atom [])
+        reports* (atom [])
         config {:event-ledger-id-fn
                 (sequential-id-fn
                  ["turn-1" "episode-1"
@@ -22,23 +32,58 @@
                   (if (= "sol.run.completed" (:event/type envelope))
                     (js/Promise.reject (js/Error. "run terminal unavailable"))
                     (js/Promise.resolve envelope)))
+                :event-ledger-report-error!
+                (fn [failure]
+                  (swap! reports* conj failure)
+                  (js/Promise.resolve failure))
                 :turn-executor!
                 (fn [_runtime _config _request]
-                  (js/Promise.resolve {:answer "done" :model "model-1"}))}]
-    (try
-      (await (episode-turn/send-agent-turn!
-              nil
-              config
-              {:run-id "run-1"
-               :session-id "session-1"
-               :conversation-id "conversation-1"}))
-      (is false "terminal append should reject")
-      (catch :default error
-        (is (= "run terminal unavailable" (.-message error)))))
+                  (js/Promise.resolve result))}
+        actual (await (episode-turn/send-agent-turn! nil config request))]
+    (is (= result actual))
     (is (= ["sol.run.started"
             "sol.turn.started"
             "sol.turn.completed"
             "sol.run.completed"]
            @attempted-types*))
     (is (not-any? #{"sol.turn.failed" "sol.run.failed"}
-                  @attempted-types*))))
+                  @attempted-types*))
+    (is (= [{:failure/kind :canonical-persistence
+             :event/type "sol.run.completed"
+             :run/id "run-1"
+             :session/id "session-1"
+             :conversation/id "conversation-1"
+             :error/message "run terminal unavailable"}]
+           @reports*))))
+
+(deftest ^:async turn-completion-failure-stops-terminal-chain-test
+  (let [attempted-types* (atom [])
+        reports* (atom [])
+        config {:event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1" "event-1" "event-2" "event-3"])
+                :event-ledger-append!
+                (fn [envelope]
+                  (swap! attempted-types* conj (:event/type envelope))
+                  (if (= "sol.turn.completed" (:event/type envelope))
+                    (js/Promise.reject (js/Error. "turn terminal unavailable"))
+                    (js/Promise.resolve envelope)))
+                :event-ledger-report-error!
+                (fn [failure]
+                  (swap! reports* conj failure)
+                  (js/Promise.resolve failure))
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (js/Promise.resolve result))}
+        actual (await (episode-turn/send-agent-turn! nil config request))]
+    (is (= result actual))
+    (is (= ["sol.run.started"
+            "sol.turn.started"
+            "sol.turn.completed"]
+           @attempted-types*))
+    (is (= "sol.turn.completed" (:event/type (first @reports*))))
+    (is (= "turn terminal unavailable"
+           (:error/message (first @reports*)))))
+
+  (testing "failure events are never backfilled after successful execution"
+    (is true)))

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_terminal_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_terminal_test.cljs
@@ -1,5 +1,5 @@
 (ns open-hax.sol.infra.agent.episode-terminal-test
-  (:require [cljs.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is]]
             [open-hax.sol.infra.agent.episode-turn :as episode-turn]))
 
 (defn- sequential-id-fn
@@ -81,9 +81,8 @@
             "sol.turn.started"
             "sol.turn.completed"]
            @attempted-types*))
+    (is (not-any? #{"sol.run.completed" "sol.turn.failed" "sol.run.failed"}
+                  @attempted-types*))
     (is (= "sol.turn.completed" (:event/type (first @reports*))))
     (is (= "turn terminal unavailable"
-           (:error/message (first @reports*)))))
-
-  (testing "failure events are never backfilled after successful execution"
-    (is true)))
+           (:error/message (first @reports*))))))

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_terminal_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_terminal_test.cljs
@@ -1,0 +1,44 @@
+(ns open-hax.sol.infra.agent.episode-terminal-test
+  (:require [cljs.test :refer [deftest is]]
+            [open-hax.sol.infra.agent.episode-turn :as episode-turn]))
+
+(defn- sequential-id-fn
+  [ids]
+  (let [remaining* (atom (vec ids))]
+    (fn []
+      (let [id (first @remaining*)]
+        (swap! remaining* subvec 1)
+        id))))
+
+(deftest ^:async completion-append-failure-never-backfills-turn-failed-test
+  (let [attempted-types* (atom [])
+        config {:event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1"
+                  "event-1" "event-2" "event-3" "event-4"])
+                :event-ledger-append!
+                (fn [envelope]
+                  (swap! attempted-types* conj (:event/type envelope))
+                  (if (= "sol.run.completed" (:event/type envelope))
+                    (js/Promise.reject (js/Error. "run terminal unavailable"))
+                    (js/Promise.resolve envelope)))
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (js/Promise.resolve {:answer "done" :model "model-1"}))}]
+    (try
+      (await (episode-turn/send-agent-turn!
+              nil
+              config
+              {:run-id "run-1"
+               :session-id "session-1"
+               :conversation-id "conversation-1"}))
+      (is false "terminal append should reject")
+      (catch :default error
+        (is (= "run terminal unavailable" (.-message error)))))
+    (is (= ["sol.run.started"
+            "sol.turn.started"
+            "sol.turn.completed"
+            "sol.run.completed"]
+           @attempted-types*))
+    (is (not-any? #{"sol.turn.failed" "sol.run.failed"}
+                  @attempted-types*))))

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_turn_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_turn_test.cljs
@@ -1,5 +1,5 @@
 (ns open-hax.sol.infra.agent.episode-turn-test
-  (:require [cljs.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is]]
             [open-hax.sol.infra.agent.episode-turn :as episode-turn]))
 
 (defn- sequential-id-fn

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_turn_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_turn_test.cljs
@@ -127,6 +127,40 @@
         (is (= "ledger unavailable" (.-message error)))))
     (is (false? @executed?*))))
 
+(deftest ^:async rejected-turn-start-closes-accepted-run-test
+  (let [accepted-events* (atom [])
+        append-count* (atom 0)
+        executed?* (atom false)
+        turn-start-error (js/Error. "turn start rejected")
+        config {:event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1"
+                  "event-1" "event-2" "event-3"])
+                :event-ledger-append!
+                (fn [envelope]
+                  (let [append-number (swap! append-count* inc)]
+                    (if (= 2 append-number)
+                      (js/Promise.reject turn-start-error)
+                      (do
+                        (swap! accepted-events* conj envelope)
+                        (js/Promise.resolve envelope)))))
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (reset! executed?* true)
+                  (js/Promise.resolve {:answer "should not run"}))}]
+    (try
+      (await (episode-turn/send-agent-turn! nil config turn-request))
+      (is false "turn-start append should reject")
+      (catch :default actual-error
+        (is (identical? turn-start-error actual-error))))
+    (is (false? @executed?*))
+    (is (= ["sol.run.started" "sol.run.failed"]
+           (mapv :event/type @accepted-events*)))
+    (is (= [nil "event-1"]
+           (mapv :causal/parent @accepted-events*)))
+    (is (= "turn start rejected"
+           (get-in (last @accepted-events*) [:payload :error])))))
+
 (deftest ^:async original-and-ledger-failures-are-both-observable-test
   (let [append-count* (atom 0)
         config {:event-ledger-id-fn

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_turn_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/episode_turn_test.cljs
@@ -1,0 +1,154 @@
+(ns open-hax.sol.infra.agent.episode-turn-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [open-hax.sol.infra.agent.episode-turn :as episode-turn]))
+
+(defn- sequential-id-fn
+  [ids]
+  (let [remaining* (atom (vec ids))]
+    (fn []
+      (let [id (first @remaining*)]
+        (swap! remaining* subvec 1)
+        id))))
+
+(def turn-request
+  {:run-id "run-1"
+   :session-id "session-1"
+   :conversation-id "conversation-1"
+   :model "model-1"
+   :message "hello"
+   :agent-spec {:actor-id "actor.agent.research"
+                :contract-id "agent/research"
+                :contract-revision "git:abc123"}
+   :auth-context {:actorId "actor.agent.research"
+                  :entityId "entity.agent.research"
+                  :orgId "org.open-hax"
+                  :principalKind "agent"}})
+
+(deftest ^:async successful-turn-emits-complete-episode-test
+  (let [events* (atom [])
+        executed-request* (atom nil)
+        expected-result {:answer "done"
+                         :run_id "run-1"
+                         :session_id "session-1"
+                         :conversation_id "conversation-1"
+                         :model "model-1"}
+        config {:sol-node-id "sol.node.local"
+                :event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1"
+                  "event-1" "event-2" "event-3" "event-4"])
+                :event-ledger-append!
+                (fn [envelope]
+                  (swap! events* conj envelope)
+                  (js/Promise.resolve envelope))
+                :turn-executor!
+                (fn [_runtime _config request]
+                  (reset! executed-request* request)
+                  (js/Promise.resolve expected-result))}
+        actual (await (episode-turn/send-agent-turn!
+                       {:runtime true}
+                       config
+                       turn-request))]
+    (is (= expected-result actual))
+    (is (= turn-request @executed-request*))
+    (is (= ["sol.run.started"
+            "sol.turn.started"
+            "sol.turn.completed"
+            "sol.run.completed"]
+           (mapv :event/type @events*)))
+    (is (= [nil "event-1" "event-2" "event-3"]
+           (mapv :causal/parent @events*)))
+    (is (= #{"event-1"}
+           (set (map :causal/root @events*))))
+    (is (= "completed"
+           (get-in (last @events*) [:payload :status])))
+    (is (= "model-1"
+           (get-in (last @events*) [:payload :model])))))
+
+(deftest ^:async failed-turn-emits-failure-terminal-test
+  (let [events* (atom [])
+        turn-error (js/Error. "provider failed")
+        config {:event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1"
+                  "event-1" "event-2" "event-3" "event-4"])
+                :event-ledger-append!
+                (fn [envelope]
+                  (swap! events* conj envelope)
+                  (js/Promise.resolve envelope))
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (js/Promise.reject turn-error))}]
+    (try
+      (await (episode-turn/send-agent-turn! nil config turn-request))
+      (is false "turn should reject")
+      (catch :default actual-error
+        (is (identical? turn-error actual-error))))
+    (is (= ["sol.run.started"
+            "sol.turn.started"
+            "sol.turn.failed"
+            "sol.run.failed"]
+           (mapv :event/type @events*)))
+    (is (= "provider failed"
+           (get-in (last @events*) [:payload :error])))
+    (is (= [nil "event-1" "event-2" "event-3"]
+           (mapv :causal/parent @events*)))))
+
+(deftest ^:async no-appender-preserves-local-runtime-test
+  (let [executed?* (atom false)
+        expected-result {:answer "local" :model "model-1"}
+        config {:event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1"
+                  "event-1" "event-2" "event-3" "event-4"])
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (reset! executed?* true)
+                  (js/Promise.resolve expected-result))}
+        result (await (episode-turn/send-agent-turn! nil config turn-request))]
+    (is @executed?*)
+    (is (= expected-result result))))
+
+(deftest ^:async canonical-start-failure-prevents-false-execution-test
+  (let [executed?* (atom false)
+        config {:event-ledger-id-fn
+                (sequential-id-fn ["turn-1" "episode-1" "event-1"])
+                :event-ledger-append!
+                (fn [_envelope]
+                  (js/Promise.reject (js/Error. "ledger unavailable")))
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (reset! executed?* true)
+                  (js/Promise.resolve {:answer "should not run"}))}]
+    (try
+      (await (episode-turn/send-agent-turn! nil config turn-request))
+      (is false "canonical start append should reject")
+      (catch :default error
+        (is (= "ledger unavailable" (.-message error)))))
+    (is (false? @executed?*))))
+
+(deftest ^:async original-and-ledger-failures-are-both-observable-test
+  (let [append-count* (atom 0)
+        config {:event-ledger-id-fn
+                (sequential-id-fn
+                 ["turn-1" "episode-1"
+                  "event-1" "event-2" "event-3"])
+                :event-ledger-append!
+                (fn [envelope]
+                  (swap! append-count* inc)
+                  (if (= 3 @append-count*)
+                    (js/Promise.reject (js/Error. "failure event rejected"))
+                    (js/Promise.resolve envelope)))
+                :turn-executor!
+                (fn [_runtime _config _request]
+                  (js/Promise.reject (js/Error. "provider failed")))}]
+    (try
+      (await (episode-turn/send-agent-turn! nil config turn-request))
+      (is false "combined failure should reject")
+      (catch :default error
+        (is (= "Sol turn and canonical episode emission failed"
+               (.-message error)))
+        (is (= "provider failed"
+               (:turn-error (ex-data error))))
+        (is (= "failure event rejected"
+               (:ledger-error (ex-data error))))))))

--- a/packages/sol/test/cljs/open_hax/sol/infra/agent/service_episode_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/infra/agent/service_episode_test.cljs
@@ -1,0 +1,43 @@
+(ns open-hax.sol.infra.agent.service-episode-test
+  (:require [cljs.test :refer [deftest is]]
+            [open-hax.sol.infra.agent.service :as service]))
+
+(defn- sequential-id-fn
+  [ids]
+  (let [remaining* (atom (vec ids))]
+    (fn []
+      (let [id (first @remaining*)]
+        (swap! remaining* subvec 1)
+        id))))
+
+(deftest ^:async service-default-routes-through-episode-wrapper-test
+  (let [events* (atom [])
+        result (await
+                (service/send-agent-turn!
+                 {:runtime true}
+                 {:event-ledger-id-fn
+                  (sequential-id-fn
+                   ["turn-1" "episode-1"
+                    "event-1" "event-2" "event-3" "event-4"])
+                  :event-ledger-append!
+                  (fn [envelope]
+                    (swap! events* conj envelope)
+                    (js/Promise.resolve envelope))
+                  :turn-executor!
+                  (fn [_runtime _config request]
+                    (js/Promise.resolve
+                     {:answer "ok"
+                      :run_id (:run-id request)
+                      :session_id (:session-id request)
+                      :conversation_id (:conversation-id request)
+                      :model "model-1"}))}
+                 {:run-id "run-1"
+                  :session-id "session-1"
+                  :conversation-id "conversation-1"
+                  :model "model-1"}))]
+    (is (= "ok" (:answer result)))
+    (is (= ["sol.run.started"
+            "sol.turn.started"
+            "sol.turn.completed"
+            "sol.run.completed"]
+           (mapv :event/type @events*)))))

--- a/packages/sol/test/cljs/open_hax/sol/shape/app_shapes_episode_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/shape/app_shapes_episode_test.cljs
@@ -1,0 +1,22 @@
+(ns open-hax.sol.shape.app-shapes-episode-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [open-hax.sol.shape.app-shapes :as shapes]))
+
+(deftest normalize-chat-body-preserves-contract-revision-test
+  (doseq [[label agent-spec]
+          [["camelCase" {:contractId "agent/research"
+                         :contractRevision "git:abc123"}]
+           ["snake_case" {:contract_id "agent/research"
+                          :contract_revision "git:def456"}]
+           ["kebab-case" {:contract-id "agent/research"
+                          :contract-revision "git:789abc"}]]]
+    (testing label
+      (let [result (shapes/normalize-chat-body
+                    {:message "hello"
+                     :agentSpec agent-spec})]
+        (is (= "agent/research"
+               (get-in result [:agent-spec :contract-id])))
+        (is (= (or (:contractRevision agent-spec)
+                   (:contract_revision agent-spec)
+                   (:contract-revision agent-spec))
+               (get-in result [:agent-spec :contract-revision])))))))

--- a/packages/sol/test/cljs/open_hax/sol/shape/episode_event_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/shape/episode_event_test.cljs
@@ -8,56 +8,93 @@
    :contract-id "agent/research"
    :contract-revision "git:abc123"})
 
-(def auth-context
-  {:actorId "actor.agent.research"
-   :entityId "entity.agent.research"
-   :orgId "org.open-hax"
-   :principalKind "agent"})
+(def runtime-binding
+  {:binding/version 1
+   :principal/actor-id "actor.agent.research"
+   :principal/entity-id "entity.agent.research"
+   :principal/kind "agent"
+   :principal/org-id "org.open-hax"})
 
-(deftest principal-binding-requires-authoritative-identity-test
-  (testing "complete Axxium references produce a versioned binding"
-    (is (= {:binding/version 1
-            :principal/actor-id "actor.agent.research"
-            :principal/entity-id "entity.agent.research"
-            :principal/kind "agent"
-            :principal/org-id "org.open-hax"
-            :actor/resource {:resource/id "agent/research"
-                             :resource/revision "git:abc123"}}
-           (episode-event/principal-binding auth-context agent-spec))))
+(def expected-ledger-binding
+  (assoc runtime-binding
+         :actor/resource {:resource/id "agent/research"
+                          :resource/revision "git:abc123"}))
+
+(deftest principal-binding-consumes-axxium-authority-test
+  (testing "canonical Axxium binding is preserved and augmented with resource lineage"
+    (is (= expected-ledger-binding
+           (episode-event/principal-binding runtime-binding agent-spec))))
+
+  (testing "nested canonical binding with namespaced JSON string keys is accepted"
+    (is (= expected-ledger-binding
+           (episode-event/principal-binding
+            {"principal/binding"
+             {"binding/version" 1
+              "principal/actor-id" "actor.agent.research"
+              "principal/entity-id" "entity.agent.research"
+              "principal/kind" "agent"
+              "principal/org-id" "org.open-hax"}}
+            agent-spec))))
+
+  (testing "Axxium auth identity without authoritative kind does not fabricate a binding"
+    (is (nil? (episode-event/principal-binding
+               {:auth/actor-id "actor.agent.research"
+                :auth/entity-id "entity.agent.research"
+                :auth/org-id "org.open-hax"}
+               agent-spec))))
+
+  (testing "legacy complete aliases remain compatible"
+    (is (= expected-ledger-binding
+           (episode-event/principal-binding
+            {:actorId "actor.agent.research"
+             :entityId "entity.agent.research"
+             :orgId "org.open-hax"
+             :principalKind "agent"}
+            agent-spec))))
 
   (testing "missing entity identity never fabricates a binding"
     (is (nil? (episode-event/principal-binding
                {:actorId "actor.agent.research"
-                :orgId "org.open-hax"}
+                :orgId "org.open-hax"
+                :principalKind "agent"}
                agent-spec))))
 
-  (testing "actor attribution remains available without a binding"
-    (let [actor (episode-event/actor-descriptor
-                 {:actorId "actor.agent.research"}
-                 agent-spec
-                 "sol.node.local")]
-      (is (= "actor.agent.research" (:actor-id actor)))
-      (is (= "agent" (:actor-kind actor)))
-      (is (= "sol.node.local" (:actor-node actor)))
-      (is (not (contains? actor :principal/binding))))))
+  (testing "unknown principal kind never falls back into an identity binding"
+    (is (nil? (episode-event/principal-binding
+               {:actorId "actor.service"
+                :entityId "entity.service"
+                :principalKind "robot"}
+               {}))))
+
+  (testing "unsupported binding versions fail explicitly"
+    (try
+      (episode-event/principal-binding
+       (assoc runtime-binding :binding/version 2)
+       agent-spec)
+      (is false "unsupported binding version should throw")
+      (catch :default error
+        (is (= 2 (:binding/version (ex-data error))))))))
+
+(deftest actor-attribution-without-binding-test
+  (let [actor (episode-event/actor-descriptor
+               {:auth/actor-id "actor.agent.research"
+                :auth/entity-id "entity.agent.research"}
+               agent-spec
+               "sol.node.local")]
+    (is (= "actor.agent.research" (:actor-id actor)))
+    (is (= "agent" (:actor-kind actor)))
+    (is (= "sol.node.local" (:actor-node actor)))
+    (is (not (contains? actor :principal/binding)))))
 
 (deftest principal-kind-vocabulary-test
   (doseq [kind ["human" "agent" "service" "automation"]]
     (let [binding (episode-event/principal-binding
-                   {:actorId (str "actor." kind)
-                    :entityId (str "entity." kind)
-                    :principalKind kind}
+                   {:binding/version 1
+                    :principal/actor-id (str "actor." kind)
+                    :principal/entity-id (str "entity." kind)
+                    :principal/kind kind}
                    {})]
-      (is (= kind (:principal/kind binding)))))
-
-  (testing "unknown kinds fall back to the shaped runtime category"
-    (is (= "service"
-           (:principal/kind
-            (episode-event/principal-binding
-             {:actorId "actor.service"
-              :entityId "entity.service"
-              :principalKind "robot"}
-             {}))))))
+      (is (= kind (:principal/kind binding))))))
 
 (deftest episode-envelope-correspondence-test
   (let [context (episode-event/episode-context
@@ -68,7 +105,7 @@
                   :conversation-id "conversation-1"
                   :causal-root "event-1"
                   :node-id "sol.node.local"
-                  :auth-context auth-context
+                  :auth-context {:principal/binding runtime-binding}
                   :agent-spec agent-spec})
         envelope (episode-event/envelope
                   context
@@ -89,17 +126,6 @@
     (is (= [{:resource/id "agent/research"
              :resource/revision "git:abc123"}]
            (:contract/refs envelope)))
-    (is (= auth-context
-           {:actorId (get-in envelope
-                             [:event/from :principal/binding
-                              :principal/actor-id])
-            :entityId (get-in envelope
-                              [:event/from :principal/binding
-                               :principal/entity-id])
-            :orgId (get-in envelope
-                           [:event/from :principal/binding
-                            :principal/org-id])
-            :principalKind (get-in envelope
-                                   [:event/from :principal/binding
-                                    :principal/kind])}))
+    (is (= expected-ledger-binding
+           (get-in envelope [:event/from :principal/binding])))
     (is (true? (:valid (event-ledger/validate-envelope envelope))))))

--- a/packages/sol/test/cljs/open_hax/sol/shape/episode_event_test.cljs
+++ b/packages/sol/test/cljs/open_hax/sol/shape/episode_event_test.cljs
@@ -1,0 +1,105 @@
+(ns open-hax.sol.shape.episode-event-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [open-hax.event-ledger :as event-ledger]
+            [open-hax.sol.shape.episode-event :as episode-event]))
+
+(def agent-spec
+  {:actor-id "actor.agent.research"
+   :contract-id "agent/research"
+   :contract-revision "git:abc123"})
+
+(def auth-context
+  {:actorId "actor.agent.research"
+   :entityId "entity.agent.research"
+   :orgId "org.open-hax"
+   :principalKind "agent"})
+
+(deftest principal-binding-requires-authoritative-identity-test
+  (testing "complete Axxium references produce a versioned binding"
+    (is (= {:binding/version 1
+            :principal/actor-id "actor.agent.research"
+            :principal/entity-id "entity.agent.research"
+            :principal/kind "agent"
+            :principal/org-id "org.open-hax"
+            :actor/resource {:resource/id "agent/research"
+                             :resource/revision "git:abc123"}}
+           (episode-event/principal-binding auth-context agent-spec))))
+
+  (testing "missing entity identity never fabricates a binding"
+    (is (nil? (episode-event/principal-binding
+               {:actorId "actor.agent.research"
+                :orgId "org.open-hax"}
+               agent-spec))))
+
+  (testing "actor attribution remains available without a binding"
+    (let [actor (episode-event/actor-descriptor
+                 {:actorId "actor.agent.research"}
+                 agent-spec
+                 "sol.node.local")]
+      (is (= "actor.agent.research" (:actor-id actor)))
+      (is (= "agent" (:actor-kind actor)))
+      (is (= "sol.node.local" (:actor-node actor)))
+      (is (not (contains? actor :principal/binding))))))
+
+(deftest principal-kind-vocabulary-test
+  (doseq [kind ["human" "agent" "service" "automation"]]
+    (let [binding (episode-event/principal-binding
+                   {:actorId (str "actor." kind)
+                    :entityId (str "entity." kind)
+                    :principalKind kind}
+                   {})]
+      (is (= kind (:principal/kind binding)))))
+
+  (testing "unknown kinds fall back to the shaped runtime category"
+    (is (= "service"
+           (:principal/kind
+            (episode-event/principal-binding
+             {:actorId "actor.service"
+              :entityId "entity.service"
+              :principalKind "robot"}
+             {}))))))
+
+(deftest episode-envelope-correspondence-test
+  (let [context (episode-event/episode-context
+                 {:run-id "run-1"
+                  :session-id "session-1"
+                  :turn-id "turn-1"
+                  :episode-id "episode-1"
+                  :conversation-id "conversation-1"
+                  :causal-root "event-1"
+                  :node-id "sol.node.local"
+                  :auth-context auth-context
+                  :agent-spec agent-spec})
+        envelope (episode-event/envelope
+                  context
+                  "event-2"
+                  "2026-07-27T00:00:00.000Z"
+                  "event-1"
+                  "sol.turn.started"
+                  {:status "running"})]
+    (is (= "run-1" (:run/id envelope)))
+    (is (= "session-1" (:session/id envelope)))
+    (is (= "turn-1" (:turn/id envelope)))
+    (is (= "episode-1" (:episode/id envelope)))
+    (is (= "event-1" (:causal/root envelope)))
+    (is (= "event-1" (:causal/parent envelope)))
+    (is (= "conversation-1"
+           (get-in envelope [:payload :conversation/id])))
+    (is (= ["agent/research"] (:contracts envelope)))
+    (is (= [{:resource/id "agent/research"
+             :resource/revision "git:abc123"}]
+           (:contract/refs envelope)))
+    (is (= auth-context
+           {:actorId (get-in envelope
+                             [:event/from :principal/binding
+                              :principal/actor-id])
+            :entityId (get-in envelope
+                              [:event/from :principal/binding
+                               :principal/entity-id])
+            :orgId (get-in envelope
+                           [:event/from :principal/binding
+                            :principal/org-id])
+            :principalKind (get-in envelope
+                                   [:event/from :principal/binding
+                                    :principal/kind])}))
+    (is (true? (:valid (event-ledger/validate-envelope envelope))))))

--- a/packages/turn-processor/deps.edn
+++ b/packages/turn-processor/deps.edn
@@ -1,0 +1,1 @@
+{:paths ["src/cljs"]}


### PR DESCRIPTION
## Summary

Implements #148, the Sol production child of #147.

Sol wraps every synchronous service turn and queued runner turn in one validated event-ledger episode while preserving the existing EDN run projection and realtime WebSocket shapes unchanged.

## Authority boundary

- **Axxium** owns actor/entity/principal-kind/organization identity. Sol consumes a supplied canonical `RuntimePrincipalBinding`; it does not resolve identities or infer an authoritative kind from an agent spec.
- **Katamorph** owns actor/agent resources. Sol carries contract ID and immutable revision as resource lineage only.
- **Sol** owns run, session, turn, episode, execution, and local projection state.
- **event-ledger** owns envelope validation and append semantics. Sol imports the standalone package pinned to `ada7374b7f4e1c3b0ab4e6bbe996f10f06e9b93a`.

The branch is synchronized with eta-mu `main`, including Axxium #151/#153.

## Identity correspondence

Sol accepts:

- a direct canonical Axxium runtime binding;
- a nested `principal/binding` map;
- namespaced JSON keys such as `principal/actor-id`;
- Axxium `auth/*` identity keys when accompanied by an authoritative principal kind;
- legacy camel/snake/kebab aliases during migration.

A binding is emitted only when actor ID, entity ID, and a recognized principal kind are supplied. Missing or unknown kind produces transport attribution without an identity binding. Unsupported binding versions fail explicitly. Agent specs may add `actor/resource` lineage but never manufacture identity.

## Lifecycle

Each wrapped `send-agent-turn!` attempts one causal chain:

```text
sol.run.started
  → sol.turn.started
  → sol.turn.completed | sol.turn.failed
  → sol.run.completed  | sol.run.failed
```

One generated turn ID and episode ID are shared by the chain. The first accepted event becomes `causal/root`; each accepted append becomes the next event's `causal/parent`.

Failure semantics are phase-aware:

- canonical start failure blocks execution;
- provider/turn execution failure remains a failed run and attempts `turn.failed` / `run.failed`;
- if execution succeeded, a `turn.completed` or `run.completed` append failure is reported through `:event-ledger-report-error!` (or structured console logging) without rewriting the successful local EDN run as failed;
- no contradictory failure events are backfilled after successful execution.

## Configuration seam

- `:event-ledger-append!` — injected one-argument appender for alternate hosts and tests;
- `:event-ledger-db` — delegates to `open-hax.event-ledger/append-event`;
- `:event-ledger-report-error!` — optional reporter for post-success canonical persistence failures;
- no appender — envelopes are still shaped and validated, preserving local-only Sol deployments;
- `:sol-node-id` — optional emitting runtime node.

## Compatibility

- Existing local EDN run events and `/api/agent/run/:id/events` remain unchanged.
- Existing realtime lifecycle broadcasts remain unchanged.
- Existing route response shapes remain unchanged.
- Service and queued-run entrypoints converge on the same wrapper.
- Legacy auth-context key dialects remain readable during migration.

## Tests

Focused tests cover:

- direct and nested canonical Axxium bindings;
- namespaced JSON wire keys and legacy aliases;
- missing/unknown kind and unsupported binding versions;
- human, agent, service, and automation principal kinds;
- contract revision normalization;
- event-ledger validation and DB delegation;
- accepted-append causal continuity;
- rejected append does not advance causality;
- successful and failed four-event lifecycles;
- local-only no-appender compatibility;
- service dispatch through the episode wrapper;
- canonical-start failure prevents false execution;
- execution plus failure-ledger errors remain jointly observable;
- terminal completion persistence failure is reported while the produced result remains successful;
- terminal failure never creates contradictory `turn.failed` / `run.failed` events.

## CI status

The workflow now:

- watches Sol packages and root `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml`;
- installs with `--frozen-lockfile`;
- pins actions and clj-kondo versions;
- removes temporary Git authorization in an `always()` cleanup step;
- requires warning-free lint, tests, and release build.

**Current hard blocker:** eta-mu Actions does not receive a cross-repository read credential for the private pinned Katamorph and event-ledger repositories. Sol CI therefore stops before dependency installation. This is tracked separately in #155; no copied authority code or false-green fallback is used.

Closes #148
Refs #147
Blocked by #155
Refs open-hax/event-ledger#2