### PR TITLE
fix(kanban): stop documentation from polluting GitHub issues

### DIFF
--- a/.github/workflows/kanban-sync.yml
+++ b/.github/workflows/kanban-sync.yml
@@ -45,6 +45,11 @@ on:
         required: false
   workflow_dispatch:
     inputs:
+      tasks_dir:
+        description: "Path to kanban tasks directory"
+        required: false
+        default: "kanban"
+        type: string
       dry_run:
         description: "Dry run (do not create/update issues)"
         required: false
@@ -122,10 +127,11 @@ jobs:
           dry_run="${{ inputs.dry-run || github.event.inputs.dry_run }}"
           close_done="${{ inputs.close-done }}"
           close_rejected="${{ inputs.close-rejected }}"
-          tasks_dir="${{ inputs.tasks-dir }}"
-          
+          tasks_dir="${{ inputs.tasks-dir || github.event.inputs.tasks_dir }}"
+          tasks_dir="${tasks_dir:-kanban}"
+
           args="--repo $repo --tasks-dir ${{ github.workspace }}/$tasks_dir"
-          
+
           if [ "$dry_run" = "true" ]; then
             args="$args --dry-run"
           fi
@@ -137,5 +143,5 @@ jobs:
           fi
           args="$args --max-writes ${{ inputs.max-writes || 50 }}"
           args="$args --write-delay-ms ${{ inputs.write-delay-ms || 1000 }}"
-          
+
           pnpm --dir .eta-mu --filter @open-hax/kanban-legacy exec node dist/cli.js sync github $args

--- a/packages/legacy/kanban/src/cli.ts
+++ b/packages/legacy/kanban/src/cli.ts
@@ -167,9 +167,14 @@ const printGitHubSyncPlan = (
   console.log(
     `- Skip done/rejected tasks without existing issues: ${result.plan.summary.skippedClosedTasks}`,
   );
+  console.log(`- Exclude non-task markdown: ${result.plan.summary.excludedTasks}`);
   if (!dryRun) {
     console.log(`- Applied operations: ${result.appliedOperations.length}`);
   }
+
+  result.plan.excludedTasks.forEach(({ task, reason }) => {
+    console.log(`  = skip ${task.relativePath ?? task.sourcePath}: ${reason}`);
+  });
 
   result.plan.operations.forEach((operation) => {
     switch (operation.type) {

--- a/packages/legacy/kanban/src/github-sync.ts
+++ b/packages/legacy/kanban/src/github-sync.ts
@@ -62,13 +62,20 @@ export type GitHubSyncOperation =
       stateReason?: "completed" | "not_planned";
     };
 
+export interface GitHubSyncExcludedTask {
+  task: KanbanTask;
+  reason: string;
+}
+
 export interface GitHubSyncPlan {
   operations: GitHubSyncOperation[];
+  excludedTasks: GitHubSyncExcludedTask[];
   summary: {
     createLabels: number;
     createIssues: number;
     updateIssues: number;
     skippedClosedTasks: number;
+    excludedTasks: number;
   };
 }
 
@@ -80,6 +87,7 @@ export interface GitHubSyncResult {
 
 const uuidMarkerPrefix = "openhax-kanban-sync";
 const uuidMarkerPattern = /<!--\s*openhax-kanban-sync\s+uuid="([^"]+)"\s*-->/u;
+const statusMetadataPattern = /^- Status:\s*`([^`]+)`\s*$/imu;
 
 const defaultLabelColors: Record<string, string> = {
   kanban: "5319e7",
@@ -91,6 +99,10 @@ const defaultLabelColors: Record<string, string> = {
 
 const statusColor = "cfd3d7";
 const defaultTaskLabelColor = "ededed";
+const closedTaskStatuses = new Set(["done", "rejected"]);
+const metadataFilePatterns = [/^AGENTS\.md$/iu, /^CHANGELOG(?:\..*)?$/iu, /^CROSS_REFERENCES\.md$/iu];
+const timestampedMarkdownPattern = /^\d{4}-\d{2}-\d{2}(?:[-_].*)?\.md$/iu;
+const taskProjectionSegments = new Set(["tasks", "epics", "cards"]);
 
 const normalizeGitHubLabelName = (label: string): string =>
   label
@@ -101,6 +113,9 @@ const normalizeGitHubLabelName = (label: string): string =>
     .slice(0, 50);
 
 const unique = <T>(items: T[]): T[] => Array.from(new Set(items));
+
+const normalizedTaskPath = (task: KanbanTask): string =>
+  (task.relativePath ?? task.sourcePath).replace(/\\/gu, "/");
 
 export const extractTaskUuidFromIssue = (
   issue: Pick<GitHubIssueState, "body">,
@@ -113,6 +128,45 @@ export const extractTaskUuidFromIssue = (
 
   const legacyMatch = body.match(/^Kanban UUID:\s*(.+)$/imu);
   return legacyMatch?.[1]?.trim();
+};
+
+export const extractTaskStatusFromIssue = (
+  issue: Pick<GitHubIssueState, "body">,
+): string | undefined => issue.body?.match(statusMetadataPattern)?.[1]?.trim().toLowerCase();
+
+export const evaluateGitHubSyncEligibility = (
+  task: KanbanTask,
+): { eligible: true } | { eligible: false; reason: string } => {
+  if (task.syncGitHub === true) {
+    return { eligible: true };
+  }
+
+  if (task.syncGitHub === false) {
+    return { eligible: false, reason: "frontmatter sync_github is false" };
+  }
+
+  const sourcePath = normalizedTaskPath(task);
+  const segments = sourcePath.split("/").filter(Boolean);
+  const basename = segments.at(-1) ?? sourcePath;
+
+  if (metadataFilePatterns.some((pattern) => pattern.test(basename))) {
+    return { eligible: false, reason: `metadata file ${basename}` };
+  }
+
+  if (segments.includes(".ημ")) {
+    return { eligible: false, reason: "path is inside .ημ" };
+  }
+
+  const hasTaskProjectionSegment = segments.some((segment) => taskProjectionSegments.has(segment));
+  if (!hasTaskProjectionSegment && (segments.includes("docs") || segments.includes("notes"))) {
+    return { eligible: false, reason: "documentation or notes path" };
+  }
+
+  if (!hasTaskProjectionSegment && timestampedMarkdownPattern.test(basename)) {
+    return { eligible: false, reason: "timestamped note" };
+  }
+
+  return { eligible: true };
 };
 
 export const desiredIssueLabels = (task: KanbanTask): string[] =>
@@ -182,10 +236,46 @@ const desiredIssueState = (
   return { state: "open" };
 };
 
+const effectiveIssueState = (
+  task: KanbanTask,
+  issue: GitHubIssueState,
+  desiredState: ReturnType<typeof desiredIssueState>,
+): ReturnType<typeof desiredIssueState> => {
+  if (issue.state !== "closed" || desiredState.state !== "open") {
+    return desiredState;
+  }
+
+  const previousStatus = extractTaskStatusFromIssue(issue);
+  const explicitlyReactivated =
+    previousStatus !== undefined &&
+    closedTaskStatuses.has(previousStatus) &&
+    !closedTaskStatuses.has(task.status);
+
+  return explicitlyReactivated ? desiredState : { state: "closed" };
+};
+
 const sameLabels = (current: string[], desired: string[]): boolean => {
   const left = [...current].sort();
   const right = [...desired].sort();
   return left.length === right.length && left.every((label, index) => label === right[index]);
+};
+
+const assertUniqueTaskUuids = (tasks: KanbanTask[]): void => {
+  const tasksByUuid = new Map<string, KanbanTask>();
+
+  for (const task of tasks) {
+    const existing = tasksByUuid.get(task.uuid);
+    if (existing) {
+      throw new Error(
+        [
+          `Duplicate kanban UUID "${task.uuid}" in GitHub sync input:`,
+          `- ${normalizedTaskPath(existing)}`,
+          `- ${normalizedTaskPath(task)}`,
+        ].join("\n"),
+      );
+    }
+    tasksByUuid.set(task.uuid, task);
+  }
 };
 
 export const planGitHubIssueSync = (
@@ -194,6 +284,20 @@ export const planGitHubIssueSync = (
   options: GitHubSyncOptions,
 ): GitHubSyncPlan => {
   const operations: GitHubSyncOperation[] = [];
+  const excludedTasks: GitHubSyncExcludedTask[] = [];
+  const eligibleTasks: KanbanTask[] = [];
+
+  for (const task of tasks) {
+    const eligibility = evaluateGitHubSyncEligibility(task);
+    if (eligibility.eligible) {
+      eligibleTasks.push(task);
+    } else {
+      excludedTasks.push({ task, reason: eligibility.reason });
+    }
+  }
+
+  assertUniqueTaskUuids(eligibleTasks);
+
   const existingLabels = new Set(state.labels.map((label) => label.name.toLowerCase()));
   const issuesByUuid = new Map<string, GitHubIssueState>();
   let skippedClosedTasks = 0;
@@ -201,11 +305,17 @@ export const planGitHubIssueSync = (
   for (const issue of state.issues) {
     const uuid = extractTaskUuidFromIssue(issue);
     if (uuid) {
+      const existing = issuesByUuid.get(uuid);
+      if (existing) {
+        throw new Error(
+          `Duplicate GitHub issue UUID marker "${uuid}" on issues #${existing.number} and #${issue.number}.`,
+        );
+      }
       issuesByUuid.set(uuid, issue);
     }
   }
 
-  const desiredLabels = unique(tasks.flatMap(desiredIssueLabels));
+  const desiredLabels = unique(eligibleTasks.flatMap(desiredIssueLabels));
   if (options.manageLabels !== false) {
     for (const labelName of desiredLabels) {
       if (!existingLabels.has(labelName.toLowerCase())) {
@@ -214,7 +324,7 @@ export const planGitHubIssueSync = (
     }
   }
 
-  for (const task of tasks) {
+  for (const task of eligibleTasks) {
     const issue = issuesByUuid.get(task.uuid);
     const labels = desiredIssueLabels(task);
     const title = task.title;
@@ -231,11 +341,12 @@ export const planGitHubIssueSync = (
       continue;
     }
 
+    const stateToApply = effectiveIssueState(task, issue, desiredState);
     const currentLabels = issue.labels.map((label) => label.name);
     if (
       issue.title !== title ||
       (issue.body ?? "") !== body ||
-      issue.state !== desiredState.state ||
+      issue.state !== stateToApply.state ||
       !sameLabels(currentLabels, labels)
     ) {
       operations.push({
@@ -245,19 +356,21 @@ export const planGitHubIssueSync = (
         title,
         body,
         labels,
-        state: desiredState.state,
-        stateReason: desiredState.stateReason,
+        state: stateToApply.state,
+        stateReason: stateToApply.stateReason,
       });
     }
   }
 
   return {
     operations,
+    excludedTasks,
     summary: {
       createLabels: operations.filter((operation) => operation.type === "createLabel").length,
       createIssues: operations.filter((operation) => operation.type === "createIssue").length,
       updateIssues: operations.filter((operation) => operation.type === "updateIssue").length,
       skippedClosedTasks,
+      excludedTasks: excludedTasks.length,
     },
   };
 };

--- a/packages/legacy/kanban/src/github-sync.ts
+++ b/packages/legacy/kanban/src/github-sync.ts
@@ -100,7 +100,12 @@ const defaultLabelColors: Record<string, string> = {
 const statusColor = "cfd3d7";
 const defaultTaskLabelColor = "ededed";
 const closedTaskStatuses = new Set(["done", "rejected"]);
-const metadataFilePatterns = [/^AGENTS\.md$/iu, /^CHANGELOG(?:\..*)?$/iu, /^CROSS_REFERENCES\.md$/iu];
+const metadataFilePatterns = [
+  /^README(?:\..*)?$/iu,
+  /^AGENTS\.md$/iu,
+  /^CHANGELOG(?:\..*)?$/iu,
+  /^CROSS_REFERENCES\.md$/iu,
+];
 const timestampedMarkdownPattern = /^\d{4}-\d{2}-\d{2}(?:[-_].*)?\.md$/iu;
 const taskProjectionSegments = new Set(["tasks", "epics", "cards"]);
 

--- a/packages/legacy/kanban/src/github-sync.ts
+++ b/packages/legacy/kanban/src/github-sync.ts
@@ -299,19 +299,15 @@ export const planGitHubIssueSync = (
   assertUniqueTaskUuids(eligibleTasks);
 
   const existingLabels = new Set(state.labels.map((label) => label.name.toLowerCase()));
-  const issuesByUuid = new Map<string, GitHubIssueState>();
+  const issuesByUuid = new Map<string, GitHubIssueState[]>();
   let skippedClosedTasks = 0;
 
   for (const issue of state.issues) {
     const uuid = extractTaskUuidFromIssue(issue);
     if (uuid) {
-      const existing = issuesByUuid.get(uuid);
-      if (existing) {
-        throw new Error(
-          `Duplicate GitHub issue UUID marker "${uuid}" on issues #${existing.number} and #${issue.number}.`,
-        );
-      }
-      issuesByUuid.set(uuid, issue);
+      const matchingIssues = issuesByUuid.get(uuid) ?? [];
+      matchingIssues.push(issue);
+      issuesByUuid.set(uuid, matchingIssues);
     }
   }
 
@@ -325,7 +321,15 @@ export const planGitHubIssueSync = (
   }
 
   for (const task of eligibleTasks) {
-    const issue = issuesByUuid.get(task.uuid);
+    const matchingIssues = issuesByUuid.get(task.uuid) ?? [];
+    if (matchingIssues.length > 1) {
+      throw new Error(
+        `Duplicate GitHub issue UUID marker "${task.uuid}" on issues ${matchingIssues
+          .map((issue) => `#${issue.number}`)
+          .join(" and ")}.`,
+      );
+    }
+    const issue = matchingIssues[0];
     const labels = desiredIssueLabels(task);
     const title = task.title;
     const body = buildIssueBody(task, { cwd: options.cwd });

--- a/packages/legacy/kanban/src/tasks.ts
+++ b/packages/legacy/kanban/src/tasks.ts
@@ -55,6 +55,26 @@ const normalizeStringArray = (value: unknown): string[] => {
   return [];
 };
 
+const normalizeBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["true", "yes", "1", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "no", "0", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+};
+
 const parseInlineValue = (value: string): unknown => {
   const trimmedValue = value.trim();
   if (!trimmedValue) {
@@ -97,7 +117,7 @@ const parseFallbackFrontmatter = (
     }
 
     currentArrayKey = undefined;
-    const keyValueMatch = rawLine.match(/^\s*([A-Za-z0-9_]+):\s*(.*)$/u);
+    const keyValueMatch = rawLine.match(/^\s*([A-Za-z0-9_-]+):\s*(.*)$/u);
     if (!keyValueMatch) {
       continue;
     }
@@ -172,6 +192,12 @@ const taskSort = (left: KanbanTask, right: KanbanTask): number => {
   return left.title.localeCompare(right.title);
 };
 
+const normalizeRelativePath = (tasksDir: string, filePath: string): string =>
+  path.relative(tasksDir, filePath).split(path.sep).join("/");
+
+const pathQualifiedUuid = (relativePath: string): string =>
+  slugify(relativePath.replace(/\.md$/iu, ""));
+
 export const buildColumnTitle = (status: string): string => titleCase(status);
 
 export const loadTasks = async (tasksDir: string): Promise<KanbanTask[]> => {
@@ -182,6 +208,7 @@ export const loadTasks = async (tasksDir: string): Promise<KanbanTask[]> => {
       const parsed = parseTaskFile(source);
       const fileStats = await stat(filePath);
       const frontmatter = parsed.data;
+      const relativePath = normalizeRelativePath(tasksDir, filePath);
 
       const title =
         typeof frontmatter.title === "string"
@@ -195,7 +222,13 @@ export const loadTasks = async (tasksDir: string): Promise<KanbanTask[]> => {
       ];
 
       const uniqueLabels = Array.from(new Set(labels));
-      const uuid = typeof frontmatter.uuid === "string" ? frontmatter.uuid : slugify(title);
+      const uuid =
+        typeof frontmatter.uuid === "string" && frontmatter.uuid.trim()
+          ? frontmatter.uuid.trim()
+          : pathQualifiedUuid(relativePath);
+      const syncGitHub = normalizeBoolean(
+        frontmatter.sync_github ?? frontmatter.syncGitHub ?? frontmatter["sync-github"],
+      );
 
       return {
         uuid,
@@ -212,6 +245,8 @@ export const loadTasks = async (tasksDir: string): Promise<KanbanTask[]> => {
             : fileStats.mtime.toISOString(),
         content: parsed.content.trim(),
         sourcePath: filePath,
+        relativePath,
+        syncGitHub,
       } satisfies KanbanTask;
     }),
   );

--- a/packages/legacy/kanban/src/tasks.ts
+++ b/packages/legacy/kanban/src/tasks.ts
@@ -151,12 +151,17 @@ const parseTaskFile = (source: string): { data: Record<string, unknown>; content
   }
 };
 
+const ignoredDiscoveryDirectories = new Set([".eta-mu", ".ημ"]);
+
 const collectMarkdownFiles = async (directory: string): Promise<string[]> => {
   const entries = await readdir(directory, { withFileTypes: true });
   const files = await Promise.all(
     entries.map(async (entry) => {
       const entryPath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
+        if (ignoredDiscoveryDirectories.has(entry.name)) {
+          return [];
+        }
         return collectMarkdownFiles(entryPath);
       }
 
@@ -195,9 +200,6 @@ const taskSort = (left: KanbanTask, right: KanbanTask): number => {
 const normalizeRelativePath = (tasksDir: string, filePath: string): string =>
   path.relative(tasksDir, filePath).split(path.sep).join("/");
 
-const pathQualifiedUuid = (relativePath: string): string =>
-  slugify(relativePath.replace(/\.md$/iu, ""));
-
 export const buildColumnTitle = (status: string): string => titleCase(status);
 
 export const loadTasks = async (tasksDir: string): Promise<KanbanTask[]> => {
@@ -225,7 +227,7 @@ export const loadTasks = async (tasksDir: string): Promise<KanbanTask[]> => {
       const uuid =
         typeof frontmatter.uuid === "string" && frontmatter.uuid.trim()
           ? frontmatter.uuid.trim()
-          : pathQualifiedUuid(relativePath);
+          : slugify(title);
       const syncGitHub = normalizeBoolean(
         frontmatter.sync_github ?? frontmatter.syncGitHub ?? frontmatter["sync-github"],
       );

--- a/packages/legacy/kanban/src/types.ts
+++ b/packages/legacy/kanban/src/types.ts
@@ -30,6 +30,8 @@ export interface KanbanTask {
   createdAt: string;
   content: string;
   sourcePath: string;
+  relativePath?: string;
+  syncGitHub?: boolean;
 }
 
 export interface KanbanColumnSnapshot {

--- a/packages/legacy/kanban/tests/github-sync-readme.test.ts
+++ b/packages/legacy/kanban/tests/github-sync-readme.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateGitHubSyncEligibility, planGitHubIssueSync } from "../src/github-sync.js";
+import type { KanbanTask } from "../src/index.js";
+
+const readmeTask = (relativePath: string, syncGitHub?: boolean): KanbanTask => ({
+  uuid: "readme",
+  title: "README",
+  slug: "readme",
+  status: "incoming",
+  priority: "P3",
+  labels: [],
+  createdAt: "2026-07-29T00:00:00.000Z",
+  content: "Package documentation.",
+  sourcePath: `/workspace/${relativePath}`,
+  relativePath,
+  syncGitHub,
+});
+
+describe("GitHub README filtering", () => {
+  it("excludes README variants before duplicate UUID validation", () => {
+    const tasks = [
+      readmeTask("packages/eta-mu/README.md"),
+      readmeTask("packages/rheos/README.markdown"),
+    ];
+
+    const plan = planGitHubIssueSync(tasks, { labels: [], issues: [] }, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace",
+    });
+
+    expect(plan.operations).toEqual([]);
+    expect(plan.summary.excludedTasks).toBe(2);
+    expect(plan.excludedTasks.map(({ reason }) => reason)).toEqual([
+      "metadata file README.md",
+      "metadata file README.markdown",
+    ]);
+  });
+
+  it("allows explicit README opt-in", () => {
+    const task = readmeTask("docs/README.md", true);
+
+    expect(evaluateGitHubSyncEligibility(task)).toEqual({ eligible: true });
+  });
+});

--- a/packages/legacy/kanban/tests/github-sync.test.ts
+++ b/packages/legacy/kanban/tests/github-sync.test.ts
@@ -144,6 +144,31 @@ describe("GitHub issue sync", () => {
     ]);
   });
 
+  it("ignores duplicate issue markers when their source tasks are excluded", () => {
+    const excludedTask = {
+      ...sampleTask,
+      uuid: "agents",
+      relativePath: "packages/foo/AGENTS.md",
+    };
+    const duplicateBody = buildIssueBody(excludedTask, { cwd: "/workspace" });
+    const state: GitHubRepoState = {
+      labels: [],
+      issues: [
+        { number: 73, title: "AGENTS", body: duplicateBody, state: "closed", labels: [] },
+        { number: 76, title: "AGENTS", body: duplicateBody, state: "closed", labels: [] },
+      ],
+    };
+
+    const plan = planGitHubIssueSync([excludedTask], state, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace",
+    });
+
+    expect(plan.operations).toEqual([]);
+    expect(plan.summary.excludedTasks).toBe(1);
+  });
+
   it("allows explicit frontmatter opt-in for documentation", () => {
     const optedIn = {
       ...sampleTask,

--- a/packages/legacy/kanban/tests/github-sync.test.ts
+++ b/packages/legacy/kanban/tests/github-sync.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildIssueBody,
   desiredIssueLabels,
+  evaluateGitHubSyncEligibility,
   extractTaskUuidFromIssue,
   planGitHubIssueSync,
 } from "../src/github-sync.js";
@@ -17,15 +18,33 @@ const sampleTask: KanbanTask = {
   labels: ["kanban sync", "github"],
   createdAt: "2026-05-31T00:00:00.000Z",
   content: "Create or update GitHub issues from markdown cards.",
-  sourcePath: "/workspace/kanban/sync-kanban.md",
+  sourcePath: "/workspace/kanban/tasks/sync-kanban.md",
+  relativePath: "tasks/sync-kanban.md",
 };
+
+const stateForTask = (
+  task: KanbanTask,
+  state: "open" | "closed",
+  bodyTask: KanbanTask = task,
+): GitHubRepoState => ({
+  labels: desiredIssueLabels(task).map((name) => ({ name })),
+  issues: [
+    {
+      number: 42,
+      title: task.title,
+      body: buildIssueBody(bodyTask, { cwd: "/workspace" }),
+      state,
+      labels: desiredIssueLabels(task).map((name) => ({ name })),
+    },
+  ],
+});
 
 describe("GitHub issue sync", () => {
   it("embeds and reads a stable task UUID marker", () => {
     const body = buildIssueBody(sampleTask, { cwd: "/workspace" });
 
     expect(body).toContain('<!-- openhax-kanban-sync uuid="task-123" -->');
-    expect(body).toContain("`kanban/sync-kanban.md`");
+    expect(body).toContain("`kanban/tasks/sync-kanban.md`");
     expect(extractTaskUuidFromIssue({ body })).toBe("task-123");
   });
 
@@ -97,5 +116,94 @@ describe("GitHub issue sync", () => {
 
     expect(plan.summary.createIssues).toBe(0);
     expect(plan.summary.skippedClosedTasks).toBe(1);
+  });
+
+  it("excludes metadata, docs, notes, and .ημ sources by default", () => {
+    const excluded = [
+      { ...sampleTask, uuid: "agents", relativePath: "packages/foo/AGENTS.md" },
+      { ...sampleTask, uuid: "note", relativePath: "docs/notes/2026-07-29-audit.md" },
+      { ...sampleTask, uuid: "internal", relativePath: ".ημ/packages/foo/docs/reference.md" },
+    ];
+
+    for (const task of excluded) {
+      expect(evaluateGitHubSyncEligibility(task)).toMatchObject({ eligible: false });
+    }
+
+    const plan = planGitHubIssueSync(excluded, { labels: [], issues: [] }, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace",
+    });
+
+    expect(plan.operations).toEqual([]);
+    expect(plan.summary.excludedTasks).toBe(3);
+    expect(plan.excludedTasks.map(({ reason }) => reason)).toEqual([
+      "metadata file AGENTS.md",
+      "documentation or notes path",
+      "path is inside .ημ",
+    ]);
+  });
+
+  it("allows explicit frontmatter opt-in for documentation", () => {
+    const optedIn = {
+      ...sampleTask,
+      uuid: "published-spec",
+      relativePath: "docs/specs/published.md",
+      syncGitHub: true,
+    };
+    const plan = planGitHubIssueSync([optedIn], { labels: [], issues: [] }, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace",
+    });
+
+    expect(plan.summary.excludedTasks).toBe(0);
+    expect(plan.summary.createIssues).toBe(1);
+  });
+
+  it("preserves a manually closed issue when the task did not reactivate", () => {
+    const state = stateForTask(sampleTask, "closed");
+    const plan = planGitHubIssueSync([sampleTask], state, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace",
+    });
+
+    expect(plan.operations).toEqual([]);
+  });
+
+  it("reopens a closed issue only when a closed task status becomes active", () => {
+    const doneTask = { ...sampleTask, status: "done" };
+    const readyTask = { ...sampleTask, status: "ready" };
+    const state = stateForTask(readyTask, "closed", doneTask);
+    const plan = planGitHubIssueSync([readyTask], state, {
+      repo: "open-hax/example",
+      dryRun: true,
+      cwd: "/workspace",
+    });
+
+    expect(plan.operations).toContainEqual(
+      expect.objectContaining({
+        type: "updateIssue",
+        issueNumber: 42,
+        state: "open",
+      }),
+    );
+  });
+
+  it("rejects duplicate eligible UUIDs with both source paths", () => {
+    const duplicate = {
+      ...sampleTask,
+      sourcePath: "/workspace/kanban/epics/other.md",
+      relativePath: "epics/other.md",
+    };
+
+    expect(() =>
+      planGitHubIssueSync([sampleTask, duplicate], { labels: [], issues: [] }, {
+        repo: "open-hax/example",
+        dryRun: true,
+        cwd: "/workspace",
+      }),
+    ).toThrow(/tasks\/sync-kanban\.md[\s\S]*epics\/other\.md/u);
   });
 });

--- a/packages/legacy/kanban/tests/kanban-sync-workflow.test.ts
+++ b/packages/legacy/kanban/tests/kanban-sync-workflow.test.ts
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const workflowUrl = new URL("../../../../.github/workflows/kanban-sync.yml", import.meta.url);
+
+describe("kanban sync workflow", () => {
+  it("keeps scheduled and manual syncs scoped to the kanban directory", async () => {
+    const workflow = await readFile(workflowUrl, "utf8");
+
+    expect(workflow).toContain('tasks_dir="${{ inputs.tasks-dir || github.event.inputs.tasks_dir }}"');
+    expect(workflow).toContain('tasks_dir="${tasks_dir:-kanban}"');
+    expect(workflow).toContain('default: "kanban"');
+  });
+});

--- a/packages/legacy/kanban/tests/tasks.test.ts
+++ b/packages/legacy/kanban/tests/tasks.test.ts
@@ -34,6 +34,7 @@ Ship alpha.
 title: Beta Task
 status: ready
 tags: [beta, sync]
+sync_github: true
 ---
 
 Ship beta.
@@ -45,16 +46,20 @@ Ship beta.
 
     expect(tasks).toHaveLength(2);
     expect(tasks[0]).toMatchObject({
+      uuid: "nested-beta",
       title: "Beta Task",
       status: "ready",
       priority: "P3",
       labels: ["beta", "sync"],
+      relativePath: "nested/beta.md",
+      syncGitHub: true,
     });
     expect(tasks[1]).toMatchObject({
       uuid: "alpha-1",
       status: "in_progress",
       priority: "P1",
       labels: ["alpha", "platform"],
+      relativePath: "alpha.md",
     });
   });
 
@@ -78,9 +83,29 @@ Still readable.
 
     expect(tasks).toHaveLength(1);
     expect(tasks[0]).toMatchObject({
+      uuid: "broken",
       title: "Broken Task",
       status: "todo",
     });
+  });
+
+  it("derives distinct path-qualified UUIDs for equal titles", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openhax-kanban-uuid-"));
+    await mkdir(path.join(tempDir, "one"), { recursive: true });
+    await mkdir(path.join(tempDir, "two"), { recursive: true });
+
+    const source = `---
+title: Shared Title
+status: ready
+---
+
+Work.
+`;
+    await writeFile(path.join(tempDir, "one", "task.md"), source, "utf8");
+    await writeFile(path.join(tempDir, "two", "task.md"), source, "utf8");
+
+    const tasks = await loadTasks(tempDir);
+    expect(tasks.map((task) => task.uuid).sort()).toEqual(["one-task", "two-task"]);
   });
 });
 

--- a/packages/legacy/kanban/tests/tasks.test.ts
+++ b/packages/legacy/kanban/tests/tasks.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -46,7 +46,7 @@ Ship beta.
 
     expect(tasks).toHaveLength(2);
     expect(tasks[0]).toMatchObject({
-      uuid: "nested-beta",
+      uuid: "beta-task",
       title: "Beta Task",
       status: "ready",
       priority: "P3",
@@ -83,29 +83,63 @@ Still readable.
 
     expect(tasks).toHaveLength(1);
     expect(tasks[0]).toMatchObject({
-      uuid: "broken",
+      uuid: "broken-task",
       title: "Broken Task",
       status: "todo",
     });
   });
 
-  it("derives distinct path-qualified UUIDs for equal titles", async () => {
+  it("preserves legacy fallback UUIDs when status folders change", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openhax-kanban-uuid-"));
-    await mkdir(path.join(tempDir, "one"), { recursive: true });
-    await mkdir(path.join(tempDir, "two"), { recursive: true });
+    const incomingDir = path.join(tempDir, "incoming");
+    const doneDir = path.join(tempDir, "done");
+    await mkdir(incomingDir, { recursive: true });
+    await mkdir(doneDir, { recursive: true });
 
-    const source = `---
+    const incomingPath = path.join(incomingDir, "task.md");
+    const donePath = path.join(doneDir, "task.md");
+    await writeFile(
+      incomingPath,
+      `---
 title: Shared Title
+status: incoming
+---
+
+Work.
+`,
+      "utf8",
+    );
+
+    const beforeMove = await loadTasks(tempDir);
+    await rename(incomingPath, donePath);
+    const afterMove = await loadTasks(tempDir);
+
+    expect(beforeMove[0]?.uuid).toBe("shared-title");
+    expect(afterMove[0]?.uuid).toBe("shared-title");
+  });
+
+  it("ignores nested eta-mu tooling checkouts", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openhax-kanban-checkout-"));
+    const taskDir = path.join(tempDir, "kanban", "tasks");
+    const toolingDir = path.join(tempDir, ".eta-mu", "kanban", "tasks");
+    await mkdir(taskDir, { recursive: true });
+    await mkdir(toolingDir, { recursive: true });
+
+    const taskSource = `---
+uuid: shared-task
+title: Shared Task
 status: ready
 ---
 
 Work.
 `;
-    await writeFile(path.join(tempDir, "one", "task.md"), source, "utf8");
-    await writeFile(path.join(tempDir, "two", "task.md"), source, "utf8");
+    await writeFile(path.join(taskDir, "shared.md"), taskSource, "utf8");
+    await writeFile(path.join(toolingDir, "shared.md"), taskSource, "utf8");
 
     const tasks = await loadTasks(tempDir);
-    expect(tasks.map((task) => task.uuid).sort()).toEqual(["one-task", "two-task"]);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.relativePath).toBe("kanban/tasks/shared.md");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the legacy `kanban sync github` exporter so recursive Markdown discovery does not turn repository documentation into active GitHub work.

- keeps scheduled and manual workflows scoped to `kanban` instead of accidentally scanning the repository root
- exposes a manual `tasks_dir` input with the same `kanban` default and preserves a shell fallback for scheduled runs
- excludes README variants, `AGENTS.md`, changelogs, cross-reference files, `.ημ/**`, and non-card `docs/**` / `notes/**` paths by default
- prunes nested `.eta-mu` and `.ημ` tooling checkouts before task loading and UUID validation
- supports explicit `sync_github: true|false` frontmatter overrides, including README opt-in
- preserves the existing title-slug fallback UUID so previously synced GitHub and Trello cards retain identity across status-directory moves
- rejects duplicate UUIDs among export-eligible tasks and reports both source paths, requiring explicit UUID frontmatter where fallback titles collide
- preserves manually closed issues unless the previously synced card was `done`/`rejected` and is now explicitly active
- reports every excluded source and reason in dry-run/live plan output
- tolerates historical duplicate issue markers when the corresponding source tasks are excluded

## Verification

- strict TypeScript semantic check over the modified task loader using local boundary stubs
- runtime assertions for nested tooling-checkout pruning and fallback UUID stability across status-folder moves
- focused regression coverage for README exclusion before UUID validation and explicit README opt-in
- direct workflow regression coverage for the `kanban` directory fallback across scheduled/manual triggers
- pure planner assertions for exclusion, opt-in, closure preservation, explicit reactivation, eligible UUID collisions, and the historical duplicate `AGENTS` marker case
- repository CI should run the canonical `@open-hax/kanban-legacy` Vitest suite

Closes #163