### PR TITLE
chore(gate): cover every workspace suite and lint CLJS, in Babashka

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,9 @@
+{:tasks
+ {test {:doc "Run every workspace unit-test suite"
+        :task (shell "bb scripts/test.bb")}
+  lint {:doc "clj-kondo across all CLJS packages, then the TypeScript-era checks"
+        :task (shell "bb scripts/lint.bb")}
+  kondo {:doc "clj-kondo only, skipping the TypeScript-era checks"
+         :task (shell "bb scripts/lint.bb --kondo-only")}
+  build {:doc "Recursive workspace build"
+         :task (shell "pnpm -r --no-bail build")}}}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "dev": "pnpm --filter @eta-mu/rheos watch",
     "build": "pnpm -r --no-bail build",
-    "test": "node --test scripts/contract-guard.test.mjs && pnpm --filter eta-mu test && pnpm --filter @eta-mu/terminal-ui test && pnpm --filter @eta-mu/turn-processor test && pnpm --filter @open-hax/kanban-legacy test",
+    "test": "bb scripts/test.bb",
     "typecheck": "pnpm --filter @open-hax/eta-mu-docs typecheck && pnpm --filter @open-hax/kanban-legacy exec tsc -p tsconfig.json --noEmit",
-    "lint": "node scripts/lint.mjs",
+    "lint": "bb scripts/lint.bb",
     "lint:fix": "node scripts/lint.mjs --fix",
     "lint:kondo": "pnpm -r --no-bail --if-present lint:kondo",
     "docs:cljs": "clojure -X:codox",

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "compile:lib": "shadow-cljs compile lib",
     "compile:test": "shadow-cljs compile test",
-    "test": "node target/test.cjs",
+    "test": "shadow-cljs compile test && node target/test.cjs",
     "lint": "clj-kondo --lint src test",
     "lint:kondo": "clj-kondo --lint src test"
   },

--- a/packages/protocols/test/open_hax/records/mongo/user_management_test.cljs
+++ b/packages/protocols/test/open_hax/records/mongo/user_management_test.cljs
@@ -45,9 +45,22 @@
     (let [db (mock-db)
           record (um/->MongoUserManagement db)]
       (await (protocols/create-user record {:username "alice" :password "secret"}))
-      (let [result (await (protocols/authenticate record {:username "alice"}))]
+      ;; The password has to be supplied — omitting it used to make this assert
+      ;; success against a `user.login.failure`, which is what a green gate is for.
+      (let [result (await (protocols/authenticate record {:username "alice"
+                                                         :password "secret"}))]
         (is (= "user.login.success" (:event/type result)))
         (is (some? (get-in result [:payload :userId])))))))
+
+(deftest ^:async authenticate-wrong-password-test
+  (testing "Rejects a known user with the wrong password"
+    (let [db (mock-db)
+          record (um/->MongoUserManagement db)]
+      (await (protocols/create-user record {:username "alice" :password "secret"}))
+      (let [result (await (protocols/authenticate record {:username "alice"
+                                                          :password "wrong"}))]
+        (is (= "user.login.failure" (:event/type result)))
+        (is (= "invalid credentials" (get-in result [:payload :reason])))))))
 
 (deftest ^:async authenticate-failure-test
   (testing "Fails to authenticate with invalid user"

--- a/packages/rheos/bb.edn
+++ b/packages/rheos/bb.edn
@@ -4,7 +4,7 @@
   watch {:doc "Dev watch with hot-reload"
          :task (shell "shadow-cljs watch server-dev")}
   test {:doc "Run tests"
-        :task (shell "shadow-cljs compile test && node target/test.cjs")}
+        :task (shell "shadow-cljs compile test && node dist/test.cjs")}
   lint {:doc "Lint source with clj-kondo"
         :task (shell "clj-kondo --lint src test")}
   clean {:doc "Clean build artifacts"

--- a/scripts/lint.bb
+++ b/scripts/lint.bb
@@ -1,0 +1,126 @@
+#!/usr/bin/env bb
+;; Eta-mu lint gate.
+;;
+;; Runs clj-kondo across every ClojureScript package, then delegates the
+;; TypeScript-era checks to the legacy `scripts/lint.mjs` unchanged.
+;;
+;; The static gate used to be lint.mjs alone: Biome, tsc, extension path
+;; validation, and a kanban frontmatter check — all pointed at legacy
+;; TypeScript. ClojureScript is the canonical language here and had zero static
+;; coverage in the gate, despite AGENTS.md requiring clj-kondo to pass with zero
+;; warnings.
+;;
+;;   bb scripts/lint.bb [--fix] [--only rheos,sol] [--kondo-only]
+;;
+;; `--fix` is forwarded to lint.mjs (Biome write mode); clj-kondo has no fix mode.
+;;
+;; Exit 0 when every check passed, 1 otherwise.
+
+(require '[babashka.process :as p]
+         '[clojure.java.io :as io]
+         '[clojure.string :as str])
+
+(def root
+  (-> (io/file *file*) .getAbsoluteFile .getParentFile .getParentFile))
+
+(def kondo-packages
+  "Every CLJS package, by pnpm filter name. Each owns its own `lint:kondo` paths,
+   so run those rather than guessing a global source list.
+
+   Keep this complete — a CLJS package absent here is unlinted by the gate."
+  ["eta-mu"
+   "@eta-mu/rheos"
+   "@eta-mu/sol"
+   "@eta-mu/terminal-ui"
+   "@eta-mu/turn-processor"
+   "@eta-mu/extensions"
+   "@eta-mu/e2e"
+   "@open-hax/protocols"
+   "@open-hax/chat-ui"
+   "@open-hax/axxium"
+   "@open-hax/mcp-contracts"])
+
+(def rule (apply str (repeat 60 "=")))
+
+(defn run-check
+  "Run one check with inherited stdio. Returns {:name :ok}."
+  [check-name command]
+  (println (str "\n" rule "\nRunning: " check-name "\n" rule "\n"))
+  (flush)
+  (let [{:keys [exit]} (apply p/shell {:dir root :continue true} command)
+        ok (zero? exit)]
+    (if ok
+      (println (str "\n✓ " check-name " passed"))
+      (binding [*out* *err*]
+        (println (str "\n✗ " check-name " failed (exit code " exit ")"))))
+    {:name check-name :ok ok}))
+
+(defn short-name
+  "`@open-hax/protocols` -> `protocols`, so `--only` takes the readable name."
+  [pkg]
+  (last (str/split pkg #"/")))
+
+(def gate-scripts
+  "The gate's own babashka scripts, so the tooling is held to the same bar as the
+   code it checks.
+
+   Not yet the whole of scripts/*.bb: `ultra.bb` has an unused binding and
+   `ultra_test.bb` reports seven unresolved symbols because it pulls its subject
+   in with `load-file`, which clj-kondo cannot follow without config. That is
+   pre-existing debt with its own card — widen this vector once it is clean,
+   rather than leaving the exclusion implicit."
+  ["scripts/test.bb" "scripts/lint.bb"])
+
+(defn lint-bb-scripts
+  "clj-kondo over the bb scripts, one file per invocation.
+
+   Linting several together trips redefinition warnings: each script is its own
+   `user`-namespace file, so kondo sees `root`/`rule`/`-main` defined repeatedly."
+  []
+  (let [results (mapv (fn [file]
+                        (run-check (str "clj-kondo (" file ")")
+                                   ["clj-kondo" "--lint" file]))
+                      gate-scripts)]
+    {:name "clj-kondo (gate scripts)"
+     :ok (every? :ok results)}))
+
+(defn -main [& args]
+  (let [args (vec args)
+        fix? (contains? (set args) "--fix")
+        kondo-only? (contains? (set args) "--kondo-only")
+        only-idx (.indexOf args "--only")
+        only (when (and (not= -1 only-idx) (get args (inc only-idx)))
+               (into #{} (map str/trim) (str/split (get args (inc only-idx)) #",")))
+        selected (if only
+                   (filterv #(or (only %) (only (short-name %))) kondo-packages)
+                   kondo-packages)]
+    (when (and only (empty? selected))
+      (binding [*out* *err*]
+        (println (str "No CLJS package matched --only. Known: "
+                      (str/join ", " (map short-name kondo-packages)))))
+      (System/exit 1))
+    (let [kondo-results
+          (into (mapv (fn [pkg]
+                        (run-check (str "clj-kondo (" pkg ")")
+                                   ["pnpm" "--filter" pkg "lint:kondo"]))
+                      selected)
+                (when-not only [(lint-bb-scripts)]))
+          ;; The TS-era checks still live in lint.mjs. Delegate rather than
+          ;; extend it — new gate logic belongs in Clojure.
+          legacy-results
+          (if (or kondo-only? only)
+            []
+            [(run-check "TypeScript-era checks (scripts/lint.mjs)"
+                        (cond-> ["node" "scripts/lint.mjs"] fix? (conj "--fix")))])
+          results (into kondo-results legacy-results)
+          failed (remove :ok results)]
+      (println (str "\n" rule "\nLINT SUMMARY\n" rule "\n"))
+      (doseq [{:keys [name ok]} results]
+        (println (str "  " (if ok "✓" "✗") " " name)))
+      (when (or kondo-only? only)
+        (println "\n  (TypeScript-era checks skipped)"))
+      (println (str "\n" (if (empty? failed) "All checks passed!" "Some checks failed!")))
+      (flush)
+      (System/exit (if (empty? failed) 0 1)))))
+
+(apply -main *command-line-args*)

--- a/scripts/test.bb
+++ b/scripts/test.bb
@@ -1,0 +1,129 @@
+#!/usr/bin/env bb
+;; Eta-mu test gate.
+;;
+;; Runs every workspace unit-test suite and reports one summary.
+;;
+;; This exists because the root `test` script was a four-package `&&` chain
+;; (eta-mu, terminal-ui, turn-processor, kanban-legacy). It silently excluded
+;; rheos, sol, axxium, chat-ui, protocols, and extensions — which is how
+;; @open-hax/protocols sat with two failing assertions nobody saw. ClojureScript
+;; is canonical here; the gate has to cover it.
+;;
+;; Every suite runs even when an earlier one fails, so one red package does not
+;; hide the state of the rest. `--bail` opts out.
+;;
+;;   bb scripts/test.bb [--bail] [--only rheos,sol]
+;;
+;; Exit 0 when every selected suite passed, 1 otherwise.
+
+(require '[babashka.process :as p]
+         '[clojure.java.io :as io]
+         '[clojure.string :as str])
+
+(def root
+  (-> (io/file *file*) .getAbsoluteFile .getParentFile .getParentFile))
+
+(def suites
+  "The suites, in the order a failure is most likely to matter.
+
+   `:label` is what shows in the summary and what `--only` matches. `:pkg` is the
+   pnpm filter; `:cmd` overrides it for anything not run through pnpm.
+
+   Keep this complete — a package with a `test` script that is not listed here is
+   a package whose failures nobody will see.
+
+   Deliberately excluded:
+     @eta-mu/e2e — browser/server suite, run by .github/workflows/e2e.yml"
+  [{:label "contract-guard" :cmd ["node" "--test" "scripts/contract-guard.test.mjs"]}
+   {:label "eta-mu" :pkg "eta-mu"}
+   {:label "rheos" :pkg "@eta-mu/rheos"}
+   {:label "sol" :pkg "@eta-mu/sol"}
+   {:label "terminal-ui" :pkg "@eta-mu/terminal-ui"}
+   {:label "turn-processor" :pkg "@eta-mu/turn-processor"}
+   {:label "extensions" :pkg "@eta-mu/extensions"}
+   {:label "protocols" :pkg "@open-hax/protocols"}
+   {:label "chat-ui" :pkg "@open-hax/chat-ui"}
+   {:label "axxium" :pkg "@open-hax/axxium"}
+   {:label "kanban-legacy" :pkg "@open-hax/kanban-legacy"}])
+
+(def rule (apply str (repeat 60 "=")))
+
+(defn suite-command [{:keys [pkg cmd]}]
+  (or cmd ["pnpm" "--filter" pkg "test"]))
+
+(defn run-suite
+  "Run one suite with inherited stdio. Returns {:label :ok :seconds}."
+  [{:keys [label] :as suite}]
+  (println (str "\n" rule "\nTesting: " label "\n" rule "\n"))
+  (flush)
+  (let [started (System/currentTimeMillis)
+        {:keys [exit]} (apply p/shell
+                              {:dir root :continue true
+                               :extra-env {"NODE_OPTIONS" "--experimental-vm-modules"}}
+                              (suite-command suite))
+        seconds (format "%.1f" (/ (- (System/currentTimeMillis) started) 1000.0))
+        ok (zero? exit)]
+    (if ok
+      (println (str "\n✓ " label " passed (" seconds "s)"))
+      (binding [*out* *err*]
+        (println (str "\n✗ " label " failed (exit code " exit ", " seconds "s)"))))
+    {:label label :ok ok :seconds seconds}))
+
+(defn parse-args
+  "`--only` may legitimately be argv[0], so test the sentinel -1 rather than
+   truthiness of the index — conflating those made `--only rheos` select nothing
+   and then report success."
+  [args]
+  (let [args (vec args)
+        only-idx (.indexOf args "--only")
+        only-value (when (not= -1 only-idx) (get args (inc only-idx)))]
+    (when (and (not= -1 only-idx) (str/blank? only-value))
+      (binding [*out* *err*] (println "--only needs a comma-separated list of suite labels."))
+      (System/exit 1))
+    {:bail? (contains? (set args) "--bail")
+     :only (when only-value
+             (into #{} (comp (map str/trim) (remove str/blank?))
+                   (str/split only-value #",")))}))
+
+(defn -main [& args]
+  (let [{:keys [bail? only]} (parse-args args)
+        known (into #{} (map :label) suites)]
+    (when only
+      (when-let [unknown (seq (remove known only))]
+        (binding [*out* *err*]
+          (println (str "Unknown suite(s): " (str/join ", " unknown)))
+          (println (str "Known: " (str/join ", " (map :label suites)))))
+        (System/exit 1)))
+    (let [selected (if only (filterv #(only (:label %)) suites) suites)
+          ;; Running zero suites is a failure, never a pass. Without this an empty
+          ;; selection printed "All suites passed!" and exited 0.
+          _ (when (empty? selected)
+              (binding [*out* *err*]
+                (println "No suites selected — refusing to report a pass for zero tests."))
+              (System/exit 1))
+          results (reduce (fn [acc suite]
+                            (let [result (run-suite suite)
+                                  acc (conj acc result)]
+                              (if (and bail? (not (:ok result)))
+                                (do (binding [*out* *err*]
+                                      (println "\n--bail: stopping at the first failure."))
+                                    (reduced acc))
+                                acc)))
+                          []
+                          selected)
+          failed (remove :ok results)
+          skipped (- (count selected) (count results))]
+      (println (str "\n" rule "\nTEST SUMMARY\n" rule "\n"))
+      (doseq [{:keys [label ok seconds]} results]
+        (println (str "  " (if ok "✓" "✗") " " label " (" seconds "s)")))
+      (when (pos? skipped)
+        (println (str "\n  " skipped " suite(s) not run (bailed early).")))
+      (println
+       (str "\n" (if (empty? failed)
+                   "All suites passed!"
+                   (str (count failed) " suite(s) failed: "
+                        (str/join ", " (map :label failed))))))
+      (flush)
+      (System/exit (if (and (seq results) (empty? failed) (zero? skipped)) 0 1)))))
+
+(apply -main *command-line-args*)


### PR DESCRIPTION
## Summary

The root `test` script covered **4 of 11** workspace suites and the root `lint` script ran **no clj-kondo at all**. This fixes both, in Babashka rather than `.mjs`.

- `scripts/test.bb` — all 11 suites, one summary, no early bail (`--bail` opts out), `--only <labels>` to narrow
- `scripts/lint.bb` — clj-kondo across all 11 CLJS packages + the gate's own scripts, then delegates the TypeScript-era checks to the existing `scripts/lint.mjs` **unchanged**
- root `bb.edn` mirroring the npm scripts, matching `packages/rheos/bb.edn`
- `packages/rheos/bb.edn` `test` pointed at `target/test.cjs`; shadow-cljs writes `dist/test.cjs`, so that task never ran

## The hole was hiding real defects

`test` chained only eta-mu, terminal-ui, turn-processor, and kanban-legacy — excluding **rheos, sol, extensions, protocols, chat-ui, axxium**. `lint` pointed entirely at legacy TypeScript, so ClojureScript had zero static coverage despite `AGENTS.md` requiring clj-kondo to pass with zero warnings.

Two defects in `@open-hax/protocols` fell out immediately:

1. **`authenticate-success-test` was asserting against a failure.** It created a user with `:password "secret"`, then called `authenticate` with `{:username "alice"}` and no password — so `provided-password` was `nil`, the comparison failed, and it asserted `"user.login.success"` against an actual `"user.login.failure"`. The implementation was correct; the test was wrong. Added `authenticate-wrong-password-test`, because the test that appeared to cover success was the only thing exercising the wrong-password branch.
2. **Its `test` script never compiled.** `node target/test.cjs` ran whatever bundle was on disk.

## Verification

| Stage | Result |
|---|---|
| `pnpm build` | exit 0 |
| `pnpm lint` | exit 0 — 11/11 clj-kondo, Biome, tsc, extension paths, kanban markdown |
| `pnpm test` | exit 0 — 11/11 suites |

`protocols`: 49 tests / 121 assertions with 2 failures → **50 / 123 green**.

Also verified the failure paths of the new scripts: unknown `--only` label exits 1 with the known list, `--only` with no value exits 1, and an empty selection **refuses to report a pass** — an early version of `test.bb` had a bug where `--only rheos` selected nothing and printed "All suites passed!", which is now guarded against explicitly.

## Deliberate exclusions, named in code rather than silent

- `@eta-mu/e2e` stays out of the default test gate — browser/server suite with its own `.github/workflows/e2e.yml`. Its clj-kondo **is** in the lint gate.
- `scripts/ultra.bb` and `ultra_test.bb` stay out of the self-lint: pre-existing kondo debt (an unused binding, and 7 unresolved symbols because the test uses `load-file`, which kondo cannot follow). Separately carded.

## Not done

`.github/workflows/main-pr-gate.yml` has **not** been reconciled with `scripts/test.bb` and may duplicate or diverge from it. Worth its own card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added workspace commands for running tests, linting, static analysis, and builds.
  * Added consolidated test and lint gates with suite selection, failure handling, timing, and summaries.

* **Bug Fixes**
  * Corrected authentication test setup to require a password for successful login.
  * Updated protocol and Rheos test commands to compile and run the correct test output.

* **Tests**
  * Improved test execution consistency across workspace packages.
  * Added validation for missing authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->