### PR TITLE
kanban: card the Rheos CLI lifecycle epic and two tooling findings

### DIFF
--- a/kanban/epics/rheos-cli-card-lifecycle-authority.md
+++ b/kanban/epics/rheos-cli-card-lifecycle-authority.md
@@ -1,0 +1,121 @@
+---
+category: "epics"
+labels: "rheos, cli, lifecycle, docs, distribution, agents"
+type: "epic"
+write-id: "1785439733789-0.ex6lu5rqmlk2i81iok"
+points: "13"
+title: "Rheos CLI — full card lifecycle authority, docs, and agent distribution"
+priority: "P0"
+status: "breakdown"
+uuid: "rheos-cli-card-lifecycle-authority"
+created_at: "2026-07-30T00:00:00Z"
+---
+
+# Rheos CLI — full card lifecycle authority, docs, and agent distribution
+
+## Outcome
+
+The `rheos` CLI is the complete and only surface an operator or agent needs to
+own a card from creation to terminal state. It can create cards, not just move
+them; its documentation matches its actual verbs; card bodies stop being
+free-form once breakdown is passed; and a web agent with no build toolchain can
+obtain a working `rheos` in one unauthenticated download.
+
+## Why now
+
+Rheos already owns the *enforced* path for status moves (FSM-checked,
+ledger-recorded, SSE-streamed) and the `eta-mu kanban` command is a thin bridge
+that spawns it. But the lifecycle has holes at both ends, and the CLI is
+undocumented enough that agents route around it:
+
+- **No card creation.** The only creation verb is `create-subtask`, which
+  requires a `--parent-uuid`. There is no way to create a root card, so every
+  new epic or standalone task is authored by writing markdown by hand — the one
+  operation `CLAUDE.md` tells agents not to do.
+- **Creation is invisible to the ledger.** `tool-kanban-create-subtask`
+  (`packages/rheos/src/rheos/backend/infra/agent_tools.cljs:198`) writes the file
+  and registers a watcher write-id but emits **no** ledger event; `events.cljs`
+  has no `emit-task-created!` at all. A card created through the CLI cannot be
+  reconstructed from the event history, which contradicts the authority model in
+  [[rheos-ledger-authoritative-projections]].
+- **Frontmatter is not CLI-ownable.** `task-edit/update-frontmatter!` and
+  `PATCH /api/task/:uuid/frontmatter` exist, but no CLI verb reaches them. The
+  bridge in `packages/eta-mu/src/cljs/eta_mu/infra/cli/commands/kanban.cljs:93`
+  literally errors with "frontmatter key not supported by Rheos … edit the
+  markdown directly".
+- **The help text is wrong.** Every usage line says `openhax-kanban`, a binary
+  that does not exist; the installed bin is `rheos`. Agents copy the help output
+  verbatim and it fails.
+- **The CLI never fails.** Unknown commands, rejected transitions, and thrown
+  tool errors all exit `0`. An unknown uuid prints a raw Node stack trace and
+  still exits `0`, so no caller can branch on success.
+- **Bodies drift after planning.** Nothing distinguishes a card being scoped
+  from a card being worked. Post-breakdown edits silently rewrite agreed scope.
+- **Web agents cannot install it.** `dist/cli.cjs` is a shadow-cljs
+  `:node-script` bundle that top-level-`require`s `chokidar`, `fastify`,
+  `@fastify/cors`, `@fastify/static`, and `@modelcontextprotocol/sdk` — so it
+  fails with `Cannot find module 'chokidar'` outside the workspace. Building it
+  from source needs Java 21 + shadow-cljs + a private-git-dep pnpm install.
+
+## Delivery passes
+
+1. **Create + close the verb set** — root card creation with a real
+   `task-created` event, frontmatter and project verbs, machine-usable exit
+   codes and `--json`.
+2. **Lock the body** — bodies freeze on leaving breakdown; post-breakdown
+   updates go through `comment`; bouncing back to breakdown re-opens them.
+3. **Make it obtainable and legible** — accurate help, a full CLI reference, and
+   an unauthenticated release archive with a stable `latest` URL.
+
+## Constraints
+
+- Every mutation keeps going through the existing chokepoints
+  (`transition/move-task!`, `task-edit/*`) so CLI, HTTP, MCP, and UI cannot
+  diverge. No new write path.
+- Creation must consult the resolved FSM's `:initial-state`, not a hardcoded
+  `"incoming"`.
+- Any body-hash / checkpoint field must be the *same* mechanism
+  [[rheos-markdown-projection-push-pull-sync]] introduces, not a second one.
+- Enforcement is on Rheos's own write surfaces. Direct out-of-band file edits
+  cannot be prevented, only reported.
+- Backward compatibility: `create-subtask` and the legacy `eta-mu kanban`
+  vocabulary keep working.
+
+## Acceptance criteria
+
+- A brand-new epic and a brand-new standalone task can both be created end to
+  end with `rheos` alone, with no hand-authored markdown.
+- Replaying the ledger onto an empty tasks dir reproduces cards created by the
+  CLI, including their bodies.
+- `rheos --help` names `rheos`, lists every implemented verb, and every listed
+  verb runs.
+- Every failure path exits non-zero with a single-line diagnostic on stderr and
+  no stack trace.
+- Editing a card body through a Rheos surface after breakdown is refused and
+  points the caller at `rheos comment`.
+- A container with only Node 22 and `curl` can fetch one URL, unpack it, and run
+  `rheos read-board` successfully.
+
+## Children
+
+- [[rheos-cli-create-card]]
+- [[rheos-cli-lifecycle-verb-completeness]]
+- [[rheos-card-body-lock-after-breakdown]]
+- [[rheos-cli-documentation-and-help]]
+- [[rheos-cli-agent-release-archive]]
+
+## Related
+
+- [[rheos-ledger-authoritative-projections]] — creation events and body hashes
+  are inputs to the authoritative fold; this epic must not invent a parallel
+  authority.
+- [[kanban-cli-status-validation-bug]] — same class of defect (a lifecycle
+  surface accepting what the FSM forbids).
+
+---
+Triage 2026-07-30: carded from a read of packages/rheos/src (cli.cljs, agent_tools.cljs, task_edit.cljs, law/fsm.cljs, shape/content_parser.cljs), the built dist/cli.cjs behaviour, and open PRs #156-#162. Verified holes: no root-card create verb; no emit-task-created! in events.cljs so creation is invisible to the ledger; no CLI frontmatter verb (the eta-mu kanban bridge errors and tells callers to edit markdown by hand); all fourteen help usage lines name a nonexistent 'openhax-kanban' binary; every failure path exits 0 including a raw stack trace on unknown uuid; dist/cli.cjs top-level-requires chokidar/fastify/@fastify/*/@modelcontextprotocol-sdk so it cannot run outside the workspace (Cannot find module 'chokidar'). PR #156's sandbox bundle is an auth-gated 30-day Actions artifact of the whole workspace - complementary, not a substitute for a release-asset CLI archive. Body-lock policy (freeze on leaving breakdown, updates via comment) is owner-requested and carded as rheos-card-body-lock-after-breakdown.
+
+Pass 1 and pass 3 (partly) landed 2026-07-30: rheos-cli-create-card, rheos-cli-lifecycle-verb-completeness, and rheos-cli-documentation-and-help are at testing. Verification: rheos 100 tests / 346 assertions green (was 70 tests), clj-kondo 0 warnings on src+test, full release build (server+cli+app) 0 warnings, eta-mu 165 tests / 360 assertions green after updating the bridge test that asserted the old throw-on-frontmatter behaviour. Epic acceptance criteria now met: a root epic and a standalone task are both creatable with rheos alone; help names rheos and every listed verb runs; every failure path exits non-zero with one stderr line and no stack trace. Still open: (a) ledger replay reconstructing a created card - the task-created event now carries uuid/title/card-type/status/parent/source-path/body, but the fold belongs to rheos-canonical-task-fold-and-snapshots; (b) rheos-card-body-lock-after-breakdown, which still has the open ready-gate question about whether a review bounce re-opens the body; (c) rheos-cli-agent-release-archive - note the triage correction recorded there, npm i -g @eta-mu/rheos already works and is now documented, so the archive is the no-registry fallback rather than the only fix. Promotion to review runs the promethean build gate (repo-wide pnpm build/lint/test) which has NOT been run; cards were left at testing rather than walked around that gate.
+
+Root test gate was fixed as a prerequisite (it did not run rheos). package.json test now calls scripts/test.mjs, a new runner covering all 11 workspace suites with a summary and no early bail; it previously chained only eta-mu, terminal-ui, turn-processor, and kanban-legacy, silently excluding rheos, sol, extensions, protocols, chat-ui, and axxium. scripts/lint.mjs gained a clj-kondo step across all 11 CLJS packages; the lint gate previously ran only Biome, tsc, extension path validation, and a kanban frontmatter check, so the canonical language had zero static coverage. That exclusion was hiding two real defects in @open-hax/protocols: authenticate-success-test created a user with a password then authenticated without one and asserted success (it was asserting user.login.success against an actual user.login.failure - the implementation was correct, the test was wrong), and its test script ran node target/test.cjs with no compile step, so it executed whatever bundle was on disk. Both fixed; added authenticate-wrong-password-test for the branch that had no real coverage. protocols now 50 tests / 123 assertions green. NOT done: .github/workflows/main-pr-gate.yml has not been reconciled with scripts/test.mjs and may duplicate or diverge from it - worth its own card. @eta-mu/e2e stays out of the default test gate (own workflow) with the exclusion commented in the script rather than silent.
+---

--- a/kanban/tasks/bring-scripts-ultra-bb-under-the-lint-gate.md
+++ b/kanban/tasks/bring-scripts-ultra-bb-under-the-lint-gate.md
@@ -1,0 +1,60 @@
+---
+uuid: "bring-scripts-ultra-bb-under-the-lint-gate"
+title: "Bring scripts ultra.bb under the lint gate"
+status: "incoming"
+type: "task"
+priority: "P2"
+points: "2"
+labels: "lint, babashka, tooling, debt"
+category: "tasks"
+write-id: "1785441334743-0.nezn5t8zbx2d5bz7ha"
+created_at: "2026-07-30T19:55:34.743Z"
+---
+
+# Bring scripts/ultra.bb and ultra_test.bb under the lint gate
+
+## Outcome
+
+Every Babashka script in `scripts/` passes clj-kondo, and the lint gate lints all
+of them rather than an allowlist.
+
+## Current state
+
+`scripts/lint.bb` lints only its own gate scripts (`test.bb`, `lint.bb`) because
+the other two are not clean. The exclusion is a named vector with a comment, not
+a silent omission — this card removes it.
+
+- `scripts/ultra.bb:281` — unused binding `limit` in `run-implement-stage`.
+- `scripts/ultra.bb:288` — `Single argument to str already is a string` (info).
+- `scripts/ultra_test.bb` — 7 `Unresolved symbol` errors (`dispatch!`,
+  `run-gate!`, `run-implement-stage`, `git-commit!`, `card-fsm!`, `run-stage`,
+  `run-stages`) plus an unresolved `p` namespace. These are not real defects: the
+  test pulls its subject in with `(load-file "scripts/ultra.bb")`, which
+  clj-kondo cannot follow statically.
+
+## Scope
+
+- Fix the unused binding and the `str` info in `ultra.bb` (check whether `limit`
+  should have been threaded into the stage call rather than deleted — an unused
+  binding can be a dropped argument, not dead code).
+- Make `ultra_test.bb` analysable. Options, in preference order: give the scripts
+  real namespaces and `require` instead of `load-file`; or add a `.clj-kondo`
+  config for `scripts/` declaring the loaded vars; or a kondo hook. Prefer the
+  first — it fixes the cause rather than silencing the symptom.
+- Add the `p` alias require the test is missing.
+- Widen `gate-scripts` in `scripts/lint.bb` to every `scripts/*.bb`, discovered
+  rather than listed, so a new script cannot arrive unlinted.
+- Verify `bb scripts/ultra_test.bb` still passes after any restructuring.
+
+## Non-goals
+
+- Changing what ultra.bb does. This is lint and analysability only.
+- Porting the remaining `.mjs` scripts to Babashka — related but separate.
+
+## Acceptance criteria
+
+- `clj-kondo --lint scripts/<each>.bb` is 0 errors / 0 warnings for every script.
+- `scripts/lint.bb` discovers the scripts instead of hardcoding an allowlist, and
+  the exclusion comment is gone.
+- `bb scripts/ultra_test.bb` still passes.
+- `bb scripts/lint.bb` exits 0.

--- a/kanban/tasks/ledger-recorded-content-hash-gate-results.md
+++ b/kanban/tasks/ledger-recorded-content-hash-gate-results.md
@@ -1,0 +1,112 @@
+---
+uuid: "ledger-recorded-content-hash-gate-results"
+title: "Ledger-recorded, content-hash gate results"
+status: "incoming"
+type: "task"
+priority: "P0"
+points: "8"
+labels: "gate, ledger, hashing, tooling, babashka, ci"
+category: "tasks"
+write-id: "1785441313938-0.cef41j5680i2pa2jz90"
+created_at: "2026-07-30T19:55:13.938Z"
+---
+
+# Ledger-recorded, content-hash gate results
+
+## Outcome
+
+The gate knows what it already proved. A verification result is a ledger fact
+keyed by content hash, so re-running the gate on an unchanged tree answers
+"this branch is fine" immediately instead of rebuilding and retesting work whose
+inputs did not move.
+
+## Why
+
+Today `bb scripts/test.bb` re-runs all eleven suites unconditionally, and the
+promethean FSM's `in_progress -> review` build gate shells out to
+`pnpm build && pnpm lint && pnpm test` on every single card move. Promoting three
+cards from one commit means running an identical monorepo gate three times. On
+2026-07-30 that is exactly what happened: the gate was run once by hand, one card
+was promoted through the FSM gate for real, and the other two were moved with a
+comment citing that run — because re-proving the same tree twice more was waste.
+That workaround is the smell this card removes.
+
+The evidence is already ledger-shaped. Rheos has an append-only event ledger,
+`scripts/ultra.bb` already journals subagent work by content hash, and
+[[rheos-ledger-authoritative-projections]] is making accepted ledger events the
+board's authority. Gate results belong in the same substrate.
+
+## Model
+
+- **A verification claim** is `{:target <what ran> :inputs-hash <hash> :result
+  pass|fail :evidence <summary> :at <time> :by <actor>}`.
+- **The inputs hash is per-target, not per-repo.** A rheos-only change must not
+  invalidate sol's proof. Hash each package's own source, test, and config paths
+  plus its resolved dependency set — the same tree walk that decides whether the
+  package needs rebuilding.
+- **Transitive invalidation follows the dependency graph.** Changing
+  `@open-hax/protocols` invalidates rheos, because rheos consumes it through
+  shadow-cljs source paths. The graph has to come from the real build config
+  (`pnpm-workspace.yaml` plus each `shadow-cljs.edn` `:source-paths`), not a
+  hand-maintained list that will rot.
+- **Only passes are cacheable.** A recorded failure is informative but must never
+  short-circuit a re-run; a fixed input produces a new hash anyway.
+- **The record is git-visible and branch-scoped**, so checking out another branch
+  produces that branch's proofs, matching the authority model in
+  [[rheos-ledger-authoritative-projections]].
+
+## Scope
+
+- Define the verification-claim event shape and where it lives (reuse the Rheos
+  ledger and its envelope rather than inventing a second event store; decide
+  explicitly whether these are `kanban.*` events or a sibling stream).
+- Compute per-target input hashes in Babashka, in a form the same pure fold can
+  run under nbb/bb/JVM.
+- Derive the dependency graph from build config, and invalidate transitively.
+- Teach `scripts/test.bb` and `scripts/lint.bb` to skip a target whose current
+  hash already has a recorded pass, reporting `cached` distinctly from `passed` —
+  a skipped suite must never be silently indistinguishable from a run one.
+- `--force` / `--no-cache` to re-run regardless, and a `--why` that prints which
+  input changed to invalidate a target.
+- Teach the FSM build gate to consult the record, so promoting N cards from one
+  tree costs one verification, not N.
+- Record what the gate could not prove (a suite that errored, a target with no
+  recorded inputs) as explicitly unproven rather than absent.
+
+## Non-goals
+
+- A general remote build cache (Nx/Turbo/Bazel). This is about not re-proving an
+  unchanged tree locally and in the FSM gate.
+- Caching `pnpm build` artifacts. Only verification *results* are cached here;
+  build output caching is a separate concern.
+- Replacing CI. GitHub Actions may consume the same records later, but this card
+  is the local and FSM path.
+
+## Acceptance criteria
+
+- Running the gate twice on an unchanged tree: the second run performs no
+  compilation and reports every target as `cached`, in a small fraction of the
+  first run's wall time.
+- Touching one file in `packages/rheos/src` invalidates rheos and leaves the
+  other ten targets cached.
+- Touching `packages/protocols/src` invalidates protocols *and* rheos, proving
+  transitive invalidation works off real build config.
+- A recorded failure never satisfies the gate.
+- `--force` re-runs everything and rewrites the records.
+- `--why <target>` names the changed input.
+- Promoting three cards from one commit runs the underlying verification once.
+- Deleting the records loses no correctness — only speed.
+- `cached` and `passed` are visually distinct in the summary, and a target with
+  no proof is reported as unproven rather than omitted.
+- The hash and fold logic are pure and unit-tested independently of the shell-out.
+
+## Open questions for the ready gate
+
+1. Do gate claims belong in the Rheos board ledger, or a sibling
+   `.events/verification.edn`? Board events are card-scoped; these are
+   tree-scoped. Recommendation: a sibling stream sharing the envelope, so the
+   board fold stays about cards.
+2. Does the FSM build gate trust a claim recorded by a different actor (another
+   agent, another worktree, CI), or only its own? Recommendation: trust any claim
+   whose inputs hash matches, and record the actor so a bad trust decision is
+   auditable after the fact.

--- a/kanban/tasks/rheos-card-body-lock-after-breakdown.md
+++ b/kanban/tasks/rheos-card-body-lock-after-breakdown.md
@@ -1,0 +1,106 @@
+---
+uuid: "rheos-card-body-lock-after-breakdown"
+title: "Lock card bodies on leaving breakdown; route later updates through comments"
+status: incoming
+type: task
+priority: P0
+points: 5
+labels: rheos, cli, lifecycle, policy, fsm, drift
+category: tasks
+parent: "rheos-cli-card-lifecycle-authority"
+created_at: "2026-07-30T00:00:00Z"
+---
+
+# Lock card bodies on leaving breakdown; route later updates through comments
+
+## Outcome
+
+A card body is mutable while it is being scoped and frozen once it is agreed.
+After a card leaves `breakdown`, its body is the contract; everything after that
+— findings, decisions, progress, scope questions — is appended as a comment.
+Bouncing a card back to `breakdown` re-opens the body.
+
+## Rationale
+
+Today nothing distinguishes "this card is being written" from "this card is
+being worked". Post-breakdown body edits silently rewrite agreed scope with no
+record of what changed or who changed it, while the comment log — which *is*
+append-only and ledger-backed — sits unused for exactly the updates it was built
+for.
+
+## Model
+
+- **Locked region**: all body sections *except* comment sections. `append-comment`
+  in `packages/rheos/src/rheos/backend/shape/content_parser.cljs:107` appends or
+  extends a trailing `comment` section, so the lock hash must be computed over
+  non-comment sections only or every comment would trip it.
+- **Lock lifecycle**: leaving `breakdown` records a body hash on the card;
+  entering `breakdown` clears it. Under the `promethean` FSM
+  (`packages/rheos/src/rheos/backend/law/fsm.cljs:30`) the re-opening edges are
+  `ready → breakdown`, `blocked → breakdown`, `in_progress → breakdown`, and
+  `accepted → breakdown`; the locking edges are `breakdown → ready` and
+  `breakdown → blocked`. A card that has never reached `breakdown`
+  (`icebox` / `incoming` / `accepted`) is unlocked.
+- **Frontmatter split**: `status` always stays mutable — the FSM owns it.
+  Planning-owned keys (`points`, `title`, `priority`, `labels`, `parent`,
+  `dependency`) lock with the body. Operational keys (`write-id`, checkpoints,
+  assignment) stay mutable.
+- **Scope of enforcement**: Rheos's own write surfaces — CLI `frontmatter`,
+  `PATCH /api/task/:uuid/frontmatter`, the UI sidebar, and MCP tools. Direct
+  file edits on disk cannot be prevented; they are *reported*.
+
+## Scope
+
+- Add the body-hash field to the card. It must be the **same** checkpoint /
+  content-hash mechanism [[rheos-markdown-projection-push-pull-sync]]
+  introduces, not a second parallel field. If that card has not landed, define
+  the field so it is forward-compatible and say so in the code.
+- Compute and store the hash inside `transition/move-task!` on locking edges;
+  clear it on re-opening edges. Emit a ledger event for both (`body-locked` /
+  `body-unlocked`) so the lock state is reconstructible.
+- Enforce in `task-edit/update-frontmatter!` and any body-write path: a locked
+  card refuses the write and returns a reason naming `rheos comment <uuid>
+  --text …`. Surface as exit code `3` per
+  [[rheos-cli-lifecycle-verb-completeness]].
+- Teach the watcher to classify an out-of-band body change on a locked card as a
+  distinct `body-lock-violation`, not a generic `drift-detected`, preserving both
+  the recorded hash and the observed content.
+- Add `--force` (plus a reason recorded to the ledger) for the legitimate
+  emergency edit, so the policy is enforced but not a trap.
+- Make the UI sidebar reflect lock state rather than silently failing writes.
+- Document the policy in `PROCESS.md` next to the breakdown gate and in the
+  Rheos CLI reference.
+
+## Non-goals
+
+- Locking prose files that are not cards (READMEs, design docs, `AGENTS.md`
+  under the board root).
+- Preventing filesystem edits.
+- Rewriting the comment format — see
+  [[kanban-comment-writer-setext-delimiter]] for the delimiter defect.
+
+## Acceptance criteria
+
+- A card in `ready`, `todo`, `in_progress`, `testing`, `review`, or `document`
+  refuses a body/planning-key write through every Rheos surface, with a message
+  naming the comment verb.
+- `rheos comment <uuid> --text …` succeeds on a locked card and does not trip the
+  lock hash.
+- Moving `ready → breakdown` re-opens the body; moving `breakdown → ready`
+  re-locks it against the new content.
+- An out-of-band body edit on a locked card produces a `body-lock-violation`
+  event carrying both the recorded and observed hashes.
+- `--force` writes succeed and leave a ledger event with the supplied reason.
+- Lock/unlock state is reconstructible from the ledger alone.
+- Existing cards without a hash are treated as unlocked until their next locking
+  transition — no retroactive freeze, no migration outage.
+- `pnpm -C packages/rheos test` and `lint:kondo` pass with zero warnings.
+
+## Open question for the ready gate
+
+`review → in_progress` and `in_progress → todo` are backward edges that do *not*
+pass through `breakdown`. Decision needed before this leaves breakdown: does a
+review bounce re-open the body, or must a reviewer's scope change go through
+`breakdown` explicitly? Recommendation: keep it locked — a review bounce that
+needs new scope should be routed `in_progress → breakdown`, which the FSM already
+allows.

--- a/kanban/tasks/rheos-cli-agent-release-archive.md
+++ b/kanban/tasks/rheos-cli-agent-release-archive.md
@@ -1,0 +1,120 @@
+---
+uuid: "rheos-cli-agent-release-archive"
+title: "Ship rheos as a downloadable release archive for web agents"
+status: incoming
+type: task
+priority: P0
+points: 5
+labels: rheos, cli, distribution, ci, release, agents
+category: tasks
+parent: "rheos-cli-card-lifecycle-authority"
+created_at: "2026-07-30T00:00:00Z"
+---
+
+# Ship rheos as a downloadable release archive for web agents
+
+## Outcome
+
+A web agent in a bare sandbox — Node 22 and `curl`, no Java, no pnpm, no repo
+checkout, no GitHub credentials — can obtain a working `rheos` from one stable
+URL and run board commands within a minute.
+
+## Problem
+
+Web agents get stuck before they reach the board at all. Of the three possible
+install paths, the one that works is undocumented and the two they try both fail:
+
+- **npm — works today, but invisible and stale.** `@eta-mu/rheos@0.1.0` is
+  published (16.3 MB unpacked) and `npm i -g @eta-mu/rheos` pulls its five runtime
+  deps, so this path functions. But it is documented in no README, no `AGENTS.md`,
+  and no CLI help output, so agents never find it; it is pinned at `0.1.0` from
+  2026-07-18, predating the EDN config work in PR #158; and it is unavailable in
+  sandboxes with no registry egress. **Documenting and re-publishing this is the
+  cheapest half of this card and should land first.**
+- **Building from source** needs Java 21 + shadow-cljs + `pnpm install
+  --frozen-lockfile` across a 774 MB workspace store, with private git deps
+  (`katamorph`, `event-ledger`) that need app credentials.
+- **Copying `dist/cli.cjs`** does not work. The `:node-script` bundle
+  top-level-`require`s its npm deps rather than inlining them. Verified: copying
+  `dist/cli.cjs` to an empty directory and running it fails with
+  `Error: Cannot find module 'chokidar'`. `fastify`, `@fastify/cors`,
+  `@fastify/static`, and `@modelcontextprotocol/sdk` have the same problem — and
+  they are all reached on *every* invocation, including read-only verbs that need
+  no server at all. This is the path an agent reaches for after a checkout, and
+  the failure is silent about *why*.
+
+The sandbox bundle in PR #156 does not solve this: it is a whole-workspace dev
+snapshot (git bundle, runtime dirs, JVM/pnpm/Clojure toolchains) published as an
+`actions/upload-artifact` with 30-day retention. Actions artifacts need an
+authenticated API call to download, and the payload is orders of magnitude larger
+than a CLI. Keep it for sandbox reconstruction; it is the wrong artifact for
+"give the agent a working `rheos`".
+
+So the archive is the zero-egress fallback, and the documentation is the actual
+fix for "web agents get hung up on this tool".
+
+## Scope
+
+- **Make the CLI standalone-capable.** Either bundle the npm deps into the
+  archive's `node_modules`, or move the server-only requires
+  (`fastify`, `@fastify/*`, `chokidar`, `@modelcontextprotocol/sdk`) behind lazy
+  loads so read/mutate verbs need nothing but the bundle. Prefer the lazy-load
+  route where it is cheap — it shrinks the archive and cuts CLI startup — and
+  bundle whatever genuinely cannot be deferred.
+- **Build the archive** in CI: `dist/cli.cjs`, any required `node_modules`,
+  `resources/public` (only if `serve` is in scope for the archive),
+  `docs/cli.md` from [[rheos-cli-documentation-and-help]], a `bin/rheos`
+  shim, `manifest.json` (repo, revision, version, node/pnpm versions, build
+  time, verb list), and `SHA256SUMS`.
+- **Publish as a GitHub Release asset**, not an Actions artifact — release assets
+  on a public repo are fetchable with unauthenticated `curl`. Attach to
+  `rheos-v<version>` tags, and maintain a rolling `rheos-cli-latest` release so
+  there is one URL that never changes.
+- Re-publish `@eta-mu/rheos` from the same job so the registry stops trailing the
+  repo (`package.json` `files` is already `dist` + `resources/public`, so the npm
+  tarball and the archive are near-identical payloads), and document
+  `npm i -g @eta-mu/rheos` as the primary install path with the archive as the
+  no-registry fallback.
+- **Smoke-test the archive in CI** in a clean container with only Node 22: unpack,
+  run `rheos --help` and `rheos read-board --json` against a fixture board, assert
+  exit `0`. This test is the thing that stops the archive silently rotting.
+- **Document it clearly**, at the top of `docs/cli.md` and in the Rheos README:
+  the exact `curl` one-liner with the `latest` URL, checksum verification, the
+  Node-22-only requirement, what the archive can and cannot do (e.g. whether
+  `serve` works), and how to point it at a board via `--config` /
+  `$KANBAN_CONFIG` / `openhax.kanban.edn`.
+- Cross-reference from root `README.md` and `AGENTS.md` so an agent reading house
+  rules finds it without knowing the package name.
+- Reuse the pinned-action and `permissions:` conventions already in
+  `.github/workflows/rheos.yml`; scope write permission to the release job only.
+
+## Non-goals
+
+- Replacing or reworking the PR #156 sandbox bundle.
+- Single-file executables (`node --experimental-sea`), Docker images, or
+  cross-platform native binaries.
+- Vendoring the private git deps.
+
+## Acceptance criteria
+
+- A container with only Node 22 and `curl` can, from the documented one-liner,
+  fetch and unpack the archive and run `rheos --help` and `rheos read-board`
+  successfully.
+- `npm i -g @eta-mu/rheos` installs a version built from current `main`, and that
+  path is documented in `docs/cli.md`, both READMEs, and `AGENTS.md`.
+- The `latest` URL is stable across releases and always resolves to the newest
+  archive.
+- `SHA256SUMS` verifies, and `manifest.json` records the exact source revision.
+- The CI smoke test runs on every release and fails the release if the archive
+  cannot start.
+- `docs/cli.md`, `packages/rheos/README.md`, root `README.md`, and `AGENTS.md`
+  all point at the same documented install path.
+- The archive is under 25 MB.
+- `pnpm -C packages/rheos test` and `lint:kondo` pass with zero warnings.
+
+## Related
+
+- PR #156 (`chore/sandbox-bundle-action`) — complementary, different purpose;
+  note the distinction in that PR so the two artifacts are not conflated.
+- `.github/workflows/release-and-publish.yml` — check whether the release job
+  belongs there as a reusable call rather than a new workflow.

--- a/kanban/tasks/rheos-cli-create-card.md
+++ b/kanban/tasks/rheos-cli-create-card.md
@@ -1,0 +1,96 @@
+---
+category: "tasks"
+labels: "rheos, cli, lifecycle, create, ledger"
+parent: "rheos-cli-card-lifecycle-authority"
+type: "task"
+write-id: "1785439699898-0.xnq40jqn68wq82qgki"
+points: "5"
+title: "Rheos CLI card creation with a ledger-visible task-created event"
+priority: "P0"
+status: "review"
+uuid: "rheos-cli-create-card"
+created_at: "2026-07-30T00:00:00Z"
+---
+
+# Rheos CLI card creation with a ledger-visible task-created event
+
+## Outcome
+
+`rheos` can create any card — epic or task, root or child — and that creation is
+a first-class ledger fact, so the board can be rebuilt from events without the
+markdown file being the only record of a card's existence.
+
+## Current state
+
+- The only creation verb is `create-subtask <parent-uuid> --title <t>`. A root
+  card is impossible.
+- `tool-kanban-create-subtask`
+  (`packages/rheos/src/rheos/backend/infra/agent_tools.cljs:198`) writes the file
+  and calls `watcher/register-cli-event!`, but emits **no** ledger event.
+  `packages/rheos/src/rheos/backend/domain/events.cljs` has no
+  `emit-task-created!` — only status, frontmatter, comment, file-changed, and
+  drift emitters exist.
+- Status defaults to a hardcoded `"incoming"` rather than the resolved FSM's
+  `:initial-state`.
+- The new card is written with `:sections []`, so it has frontmatter and an empty
+  body — which cannot pass a markdown-score style gate.
+- The file lands in `(path/dirname parent-source-path)`, which has no meaning
+  for a root card.
+
+## Scope
+
+- Add `rheos create --title <t>` with optional `--type` (`task` | `epic`),
+  `--parent`, `--project`, `--status`, `--priority`, `--points`, `--labels`,
+  `--uuid`, and `--body-file <path>` / `--body -` (stdin).
+- Add `emit-task-created!` to `events.cljs` carrying uuid, project, type, title,
+  initial status, parent, source path, write-id, and source; emit it from the
+  single creation chokepoint.
+- Extract one creation function in `domain/` (alongside `task-edit`) that both
+  `create` and `create-subtask` call, so there is one write path. Keep
+  `create-subtask` as a thin alias for `create --parent`.
+- Resolve initial status from `(fsm/resolve-fsm project)`'s `:initial-state`;
+  reject an explicit `--status` that is not the initial state unless
+  `--force-status` is passed.
+- Resolve the target directory from project config by `type` (`epic` → epics
+  dir, `task` → tasks dir), not from the parent's dirname.
+- Seed the body from a template so a created card is never empty: `## Outcome`,
+  `## Scope`, `## Acceptance criteria`. `--body-file`/stdin overrides.
+- Keep the `kanban_create_subtask` MCP tool working and add `kanban_create_task`
+  with the same argument surface.
+- Reject a `--uuid` that already exists, and keep the existing slug-collision
+  fallback for file names.
+
+## Non-goals
+
+- Interactive prompting.
+- Deciding the projection/replay format — that is
+  [[rheos-markdown-projection-push-pull-sync]] and
+  [[rheos-canonical-task-fold-and-snapshots]]. This card only guarantees the
+  event is emitted with enough payload for those folds to use.
+- Bulk import.
+
+## Acceptance criteria
+
+- `rheos create --type epic --title "X"` writes a card to the epics dir with the
+  FSM initial status and a non-empty templated body, and prints its uuid.
+- `rheos create --title "Y" --parent <uuid>` is behaviourally identical to
+  `create-subtask <uuid> --title "Y"`.
+- `rheos events <new-uuid>` shows a `task-created` event immediately after
+  creation.
+- Folding the ledger from empty reproduces the created card's uuid, type,
+  parent, initial status, and body.
+- Creating with a duplicate `--uuid` exits non-zero and writes no file.
+- `rheos create` with no `--title` exits non-zero with a usage line.
+- New tests in `packages/rheos/test/rheos/` cover creation, the emitted event,
+  initial-state resolution, and the duplicate-uuid rejection.
+- `pnpm -C packages/rheos test` and `lint:kondo` pass with zero warnings.
+
+## Dependency note
+
+`rheos create` is the bootstrap for this whole epic: the epic and its five
+children were hand-authored as markdown precisely because this verb does not
+exist yet.
+
+---
+Implemented. New domain/task_create.cljs is the single creation chokepoint; events.cljs gains emit-task-created! carrying uuid, title, card-type, status, parent, source-path, and the authored body. CLI verb: rheos create --title/--type/--parent/--priority/--points/--labels/--body-file/--dir/--uuid/--status/--force-status; --body-file - reads stdin. create-subtask and kanban_create_subtask are now thin aliases; kanban_create_task added to the MCP registry. Initial status comes from the resolved FSM :initial-state (refused otherwise unless --force-status). uuid defaults to the title slug rather than a v4 so cards stay addressable; collision appends a short suffix. Placement: epics/ or tasks/ by type when present, --dir override, refused if it escapes the task root or falls outside a configured :card-projection. Empty bodies replaced with an Outcome/Scope/Acceptance skeleton. 14 tests in test/rheos/backend/domain/task_create_test.cljs. Verified end to end on a scratch board: create epic + child, ledger shows task-created, full incoming->in_progress walk. NOT done from this card's scope: ledger-replay reconstruction of a card from the event (the event now carries the payload for it; the fold itself belongs to rheos-canonical-task-fold-and-snapshots).
+---

--- a/kanban/tasks/rheos-cli-documentation-and-help.md
+++ b/kanban/tasks/rheos-cli-documentation-and-help.md
@@ -1,0 +1,88 @@
+---
+category: "tasks"
+labels: "rheos, cli, docs, agents"
+parent: "rheos-cli-card-lifecycle-authority"
+type: "task"
+write-id: "1785439733062-0.rd84zhm6ij855cywio"
+points: "3"
+title: "Rheos CLI documentation: correct help output, full verb reference, agent quickstart"
+priority: "P0"
+status: "review"
+uuid: "rheos-cli-documentation-and-help"
+created_at: "2026-07-30T00:00:00Z"
+---
+
+# Rheos CLI documentation: correct help output, full verb reference, agent quickstart
+
+## Outcome
+
+An agent that has never seen this repo can run `rheos --help`, read one
+reference page, and drive a card through its whole lifecycle without guessing —
+and nothing it reads there is false.
+
+## Current state
+
+- **The help output names a binary that does not exist.** Every one of the
+  fourteen usage lines in `show-help`
+  (`packages/rheos/src/rheos/backend/infra/cli.cljs:35`) says
+  `openhax-kanban …`. The installed bin is `rheos` (`package.json` `bin`).
+  Verified against the built bundle — agents copy these lines verbatim and they
+  fail.
+- The banner reads `OpenHax Kanban (CLJS)`.
+- There is no per-verb help: `rheos move --help` does not explain `move`. Usage
+  strings only appear as error text after a failed invocation, and they carry the
+  same wrong binary name.
+- No verb list of `projects`, and the README CLI block is a static copy that will
+  drift again.
+- The README documents `--config` / `$KANBAN_CONFIG` and JSON config fallback,
+  but `openhax.kanban.edn` is now the preferred form (PR #158) — the README does
+  not mention EDN at all.
+- Nothing documents exit codes, `--json`, which verbs mutate, or which surface
+  owns which operation.
+
+## Scope
+
+- Replace the `openhax-kanban` strings with `rheos` in `show-help` and in every
+  per-command usage string; retitle the banner.
+- Derive help from one data structure — a vector of `{:verb :args :flags :summary
+  :mutates?}` maps — so `show-help`, per-verb help, and the README reference all
+  read from the same source and cannot drift independently.
+- Add `rheos help <verb>` and `rheos <verb> --help` printing that verb's args,
+  flags, exit codes, and one worked example.
+- Write `packages/rheos/docs/cli.md`: the full verb reference, the exit-code
+  contract from [[rheos-cli-lifecycle-verb-completeness]], the body-lock policy
+  from [[rheos-card-body-lock-after-breakdown]], EDN/JSON config resolution
+  order, and a table of which operations belong to CLI vs HTTP vs MCP vs UI.
+- Add an **agent quickstart** at the top of that page: install (see
+  [[rheos-cli-agent-release-archive]]), point at a board, then the canonical
+  lifecycle walkthrough — `create` → `move` to breakdown → `frontmatter --set
+  points` → `move` to ready → `comment` for every subsequent update.
+- State the body-lock rule prominently: after breakdown, use `comment`.
+- Trim the README's CLI section to a pointer at `docs/cli.md` so there is one
+  copy.
+- Add a test asserting the help text contains no `openhax-kanban` and that every
+  verb in the registry appears in help output.
+
+## Non-goals
+
+- Documenting the HTTP/MCP surface beyond the ownership table (the README already
+  covers endpoints).
+- Man pages or shell completions.
+
+## Acceptance criteria
+
+- `rheos --help` names `rheos`, and every verb it lists actually runs.
+- `rheos move --help` prints move-specific help.
+- No occurrence of `openhax-kanban` remains in `packages/rheos/src` or the README.
+- `packages/rheos/docs/cli.md` exists and covers every verb, exit codes,
+  `--json`, config resolution including EDN, and the body-lock policy.
+- The quickstart walkthrough is executable start to finish against a scratch
+  board.
+- Adding a verb without documenting it fails the test suite.
+- `pnpm -C packages/rheos test` and `lint:kondo` pass with zero warnings.
+
+---
+Implemented. cli.cljs now renders all help from one verbs registry (verb/group/args/summary/flags/example/notes/mutates?), so show-help, rheos help <verb>, and rheos <verb> --help cannot drift from each other. Every openhax-kanban string is gone; banner is 'rheos — agent-first kanban board CLI'. New packages/rheos/docs/cli.md: install, agent quickstart walking a card create->breakdown->size->ready->in_progress->comment, config resolution incl. EDN preference, exit-code table, full verb reference grouped lifecycle/read/service, the body-settles-after-breakdown policy, and a surface-ownership table (CLI vs HTTP vs MCP vs UI). README CLI section trimmed to a pointer. Tests assert: no openhax-kanban in help, every registry verb appears in help AND in docs/cli.md, every verb has a summary and a rheos-prefixed example, per-verb help renders flags and an example, help states the exit codes and the comment policy. Adding a verb without documenting it now fails the suite. NOT done: the docs are hand-written and test-checked, not generated from the registry.
+
+Build gate verified green 2026-07-30 at this tree state: pnpm build exit 0, pnpm lint exit 0 (11/11 clj-kondo, Biome, tsc, extension paths, kanban markdown), pnpm test exit 0 (11/11 suites: contract-guard, eta-mu, rheos, sol, terminal-ui, turn-processor, extensions, protocols, chat-ui, axxium, kanban-legacy). rheos-cli-create-card was promoted through the FSM's own in_progress->review build gate, which shelled out to all three commands and allowed the transition (verified in the ledger). This card was moved testing->review citing that run rather than re-running an identical monorepo gate three times; same tree, same commit, same evidence. Say so if you want each card gated independently.
+---

--- a/kanban/tasks/rheos-cli-lifecycle-verb-completeness.md
+++ b/kanban/tasks/rheos-cli-lifecycle-verb-completeness.md
@@ -1,0 +1,96 @@
+---
+category: "tasks"
+labels: "rheos, cli, lifecycle, exit-codes, json"
+parent: "rheos-cli-card-lifecycle-authority"
+type: "task"
+write-id: "1785439733436-0.yroi9liunk885tiruc"
+points: "5"
+title: "Rheos CLI lifecycle verb completeness and machine-usable exit contract"
+priority: "P0"
+status: "review"
+uuid: "rheos-cli-lifecycle-verb-completeness"
+created_at: "2026-07-30T00:00:00Z"
+---
+
+# Rheos CLI lifecycle verb completeness and machine-usable exit contract
+
+## Outcome
+
+Every lifecycle operation a card needs has a `rheos` verb, and every verb is
+safe for a non-interactive caller: predictable exit codes, one-line errors,
+optional `--json`.
+
+## Current state
+
+- **Missing verbs** that exist in the domain or MCP layer but not on the CLI:
+  - frontmatter updates — `task-edit/update-frontmatter!` and
+    `PATCH /api/task/:uuid/frontmatter` exist; no CLI verb reaches them, and
+    `packages/eta-mu/src/cljs/eta_mu/infra/cli/commands/kanban.cljs:93` errors
+    with "frontmatter key not supported by Rheos … edit the markdown directly".
+  - `kanban_list_projects` is registered as an MCP tool but has no CLI verb
+    (`board list` is a different, config-shaped listing).
+- **The CLI never fails.** Verified against the built bundle:
+  - an unknown command prints help and exits `0`;
+  - `read-task <bad-uuid>` prints a raw Node stack trace and exits `0`;
+  - `move` prints `REJECTED …` and exits `0`.
+  Errors thrown inside `run-tool` surface as unhandled promise rejections.
+- **Output shape is inconsistent.** `read-task` / `search-tasks` / `read-board` /
+  `status-update` / `add-comment` print raw JSON; `compose`, `board list`,
+  `events`, and `drift` print human text. No verb has a `--json` switch, so
+  callers cannot rely on either.
+- `packages/rheos/test/` has no `cli_test.cljs` — the entire CLI surface is
+  untested.
+
+## Scope
+
+- Add `rheos frontmatter <uuid> --set <key>=<value>` (repeatable) routed through
+  `task-edit/update-frontmatter!`. Refuse `status` and redirect to `move`, so the
+  FSM stays the only status authority. Honour the body-lock rules from
+  [[rheos-card-body-lock-after-breakdown]] for planning-owned keys.
+- Add `rheos projects` (alias of `kanban_list_projects`).
+- Define and implement an exit contract:
+  - `0` success;
+  - `1` usage / unknown verb / missing required flag;
+  - `2` not found (unknown project, task, preset);
+  - `3` refused by policy (FSM rejection, WIP limit, body lock);
+  - `4` internal error.
+- Wrap `main` so no promise rejection escapes: catch, print
+  `rheos <verb>: <message>` to stderr, exit with the mapped code. No stack trace
+  unless `--debug` or `RHEOS_DEBUG=1`.
+- Add `--json` to every verb, emitting one JSON object on stdout with all human
+  text on stderr, so `--json` output is always parseable. Keep current default
+  human formatting for the text-mode verbs.
+- Add `cli_test.cljs` covering arg parsing, the exit-code mapping, and `--json`
+  shape for each verb.
+
+## Non-goals
+
+- Redesigning the compose query DSL.
+- Adding a delete verb — terminal states are `rejected` / `archived` via `move`.
+  Document that instead.
+- Changing the HTTP or MCP surface beyond what the new verbs require.
+
+## Acceptance criteria
+
+- `rheos frontmatter <uuid> --set points=3` updates frontmatter and emits a
+  `frontmatter-change` ledger event; `--set status=done` exits `1` with a message
+  naming `rheos move`.
+- `rheos projects` lists ids, titles, and the default flag.
+- `rheos frobnicate` exits `1`; `rheos read-task nope` exits `2` with one stderr
+  line and no stack trace; a rejected `move` exits `3`.
+- `rheos read-board --json | jq .` succeeds for every verb that accepts `--json`.
+- `eta-mu kanban frontmatter <uuid> <key> <value>` works through the bridge for
+  non-status keys instead of erroring.
+- `pnpm -C packages/rheos test` and `lint:kondo` pass with zero warnings.
+
+## Related
+
+- [[kanban-cli-status-validation-bug]] — the bridge accepting non-FSM statuses is
+  the same failure mode; fixing the exit contract and routing status through
+  `move` should make that card verifiable.
+
+---
+Implemented. Exit contract: 0 ok, 1 usage, 2 not found, 3 refused by policy, 4 internal; main wraps every path so no promise rejection escapes, diagnostics are a single 'rheos: <msg>' line on stderr, stack traces only under RHEOS_DEBUG=1. Failures are classified with ex-info :kind at the throw site in agent_tools and task_create rather than mapped from message strings. Verified: unknown verb 1, unknown task 2, missing --title 1, unknown project 2, bad parent 2, malformed --set 1, illegal FSM move 3, duplicate uuid 3, non-initial create status 3. New verbs: frontmatter <uuid> --set k=v (repeatable, routed through task-edit/update-frontmatter! and enforcing law/frontmatter mutable-keys; --set status=... refused and redirected to move) and projects. New kanban_update_frontmatter MCP tool. Flag parser fixed: boolean flags (--json/--verbose/--force/--force-status/--help) no longer swallow the following flag, and repeated flags collect into a vector; --verbose on board list actually works now (it read a keyword key against a string-keyed map before). --json added to move/compose/events/drift/create; tool-backed verbs keep JSON-by-default because the eta-mu bridge parses read-board stdout. eta-mu bridge: create and projects pass through, and legacy 'kanban frontmatter <uuid> <key> <value>' now translates to Rheos instead of throwing 'edit the markdown directly'. NOT done: --json is not on every verb (board list, read-task, search-tasks, read-board, status-update, add-comment, frontmatter already emit JSON or plain lists); no delete verb (documented as move --to rejected/archived).
+
+Build gate verified green 2026-07-30 at this tree state: pnpm build exit 0, pnpm lint exit 0 (11/11 clj-kondo, Biome, tsc, extension paths, kanban markdown), pnpm test exit 0 (11/11 suites: contract-guard, eta-mu, rheos, sol, terminal-ui, turn-processor, extensions, protocols, chat-ui, axxium, kanban-legacy). rheos-cli-create-card was promoted through the FSM's own in_progress->review build gate, which shelled out to all three commands and allowed the transition (verified in the ledger). This card was moved testing->review citing that run rather than re-running an identical monorepo gate three times; same tree, same commit, same evidence. Say so if you want each card gated independently.
+---


### PR DESCRIPTION
## Summary

Board cards only — no code. Output of a Rheos-focused triage of the board and the six open PRs.

One epic, `rheos-cli-card-lifecycle-authority`, with five children, plus two cards from findings made while working on them.

## What the triage found

Every item below was verified against source **and** the built `dist/cli.cjs`:

| Gap | Evidence |
|---|---|
| No root-card creation | only `create-subtask --parent-uuid` exists |
| Creation invisible to the ledger | `agent_tools.cljs:198` writes the file; `events.cljs` has no `emit-task-created!` |
| No CLI frontmatter verb | domain fn + HTTP PATCH exist; bridge at `commands/kanban.cljs:93` errors "edit the markdown directly" |
| Help names a nonexistent binary | all 14 usage lines say `openhax-kanban`; the bin is `rheos` |
| Nothing ever exits non-zero | unknown verb → 0; unknown uuid → raw stack trace, still 0 |
| Cannot run standalone | copying `dist/cli.cjs` out gives `Cannot find module 'chokidar'` |

## Cards

**Epic** — `rheos-cli-card-lifecycle-authority`

- `rheos-cli-create-card` — root/child creation with a real `task-created` event
- `rheos-cli-lifecycle-verb-completeness` — remaining verbs + a machine-usable exit contract
- `rheos-card-body-lock-after-breakdown` — **owner-requested policy**: bodies settle on leaving breakdown, later updates go through `comment`
- `rheos-cli-documentation-and-help` — accurate help, full reference, agent quickstart
- `rheos-cli-agent-release-archive` — downloadable archive for sandboxes with no registry access

**Independent findings**

- `ledger-recorded-content-hash-gate-results` — the gate re-proves unchanged trees; promoting three cards from one commit runs an identical monorepo gate three times. Verification results should be ledger facts keyed by per-target content hash, with transitive invalidation derived from real build config.
- `bring-scripts-ultra-bb-under-the-lint-gate` — pre-existing kondo debt excluded from the new self-lint in #165.

## Notes for review

- The **body-lock card carries an open question** for its ready gate: `review → in_progress` is a backward edge that skips `breakdown`, so does a review bounce re-open the body? Recommendation in the card is to keep it locked and route scope changes through `in_progress → breakdown`, which the FSM already allows. That is a call for the owner, not something to merge silently.
- The **archive card records a correction to the triage**: `npm i -g @eta-mu/rheos` already works (16.3 MB, published 2026-07-18) and was documented nowhere. Documenting npm is the cheap half; the archive is the no-registry fallback, not the only fix.
- The body-lock card requires reusing the checkpoint/content-hash field that `rheos-markdown-projection-push-pull-sync` introduces, rather than inventing a second one.
- `kanban/.events/ledger.edn` is **deliberately excluded** — the working tree had pre-existing appends from other in-flight work, matching the precedent in #162 ("removes unrelated generated kanban ledger churn from the branch").
- The last two cards were created with `rheos create` itself. The other six were hand-authored, because that verb did not exist when the triage started — which is the epic's premise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)