### PR TITLE
chore(kanban): card the layer-boundary ratchet as per-package slices

### DIFF
--- a/kanban/epics/eta-mu-quality-ratchet.md
+++ b/kanban/epics/eta-mu-quality-ratchet.md
@@ -63,6 +63,29 @@ Recent work proved the CLJS runtime path and added a 90% runtime line/statement 
 6. `kanban/tasks/eta-mu-quality-ratchet-coverage-expansion.md`
    - Expand meaningful coverage gates beyond `packages/eta-mu-runtime` while avoiding noisy shadow-cljs branch/function false precision.
 
+### Layer boundary ratchet (added 2026-07-31)
+
+Task 4 wired CLJS boundary checks into the package gates. The layer-boundary linter that
+came out of that (`packages/kondo-config`, `hooks/layer_boundaries.clj`) now reports every
+violation of the `law.* → shape.* → extern.* → domain.* → infra.*` construction order at the
+`:require` that causes it. It ships at `:info` repo-wide — printed on every lint run, never
+fatal — and each package pays its own share and then raises the level to `:error`.
+
+Backlog at time of carding: **27 findings** — 17 host requires, 8 upward-to-infra, 2
+domain-to-extern.
+
+7. `kanban/tasks/eta-mu-quality-ratchet-layer-boundary-sol.md` (17 findings, 8sp)
+   - Largest concentration in the repo. Dominated by a `domain/node/*` wrapper family that belongs in `extern.*`.
+
+8. `kanban/tasks/eta-mu-quality-ratchet-layer-boundary-rheos.md` (8 findings, 3sp)
+   - 3 backend (including a `law.*` namespace requiring `node:child_process`) and 5 UI.
+
+9. `kanban/tasks/eta-mu-quality-ratchet-layer-boundary-terminal-ui.md` (1 finding, 1sp)
+   - A `shape.*` host require. Smallest slice; proves the `:error` ratchet end to end.
+
+10. `kanban/tasks/eta-mu-quality-ratchet-layer-boundary-eta-mu.md` (1 finding, 1sp)
+    - One `domain → extern` require in `domain/session.cljs`.
+
 ## Acceptance criteria
 
 - [ ] A baseline report names every current lint, warning, coverage, and test gate plus known blockers.
@@ -72,6 +95,7 @@ Recent work proved the CLJS runtime path and added a 90% runtime line/statement 
 - [ ] Full test-suite failures are reproducible, classified, and either fixed or recorded with a narrow blocker.
 - [ ] Coverage gates cover the CLJS runtime and at least one additional high-value package/surface.
 - [ ] CI and PR workflow require OpenCode review and expose quality summaries.
+- [ ] Every package with `:layer-boundary/*` findings has cleared them and raised both linters to `:error`, so the construction order cannot regress silently.
 
 ## Verification map
 

--- a/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-eta-mu.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-eta-mu.md
@@ -1,0 +1,69 @@
+---
+category: "tasks"
+labels: ["tasks", "quality", "lint", "layers", "eta-mu", "1sp"]
+points: "1"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+title: "Layer Boundary Ratchet — eta-mu"
+priority: "P2"
+status: "icebox"
+uuid: "eta-mu-quality-ratchet-layer-boundary-eta-mu"
+created_at: "2026-07-31T00:00:00Z"
+---
+
+# Layer Boundary Ratchet — eta-mu
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 1
+
+## Purpose
+
+Clear the single `:layer-boundary/*` finding in `packages/eta-mu` and raise both linters to
+`:error`.
+
+## Findings (1)
+
+- [ ] `src/cljs/eta_mu/domain/session.cljs` — requires `eta-mu.extern.path`
+      (`domain → extern`, upward).
+
+The mildest crossing class in the repo: `extern.*` is only one layer below `domain.*`, and
+`extern.path` is a decoder rather than an effect. It is still a crossing — `domain.*`
+depends on `law`, `shape`, and its own layer, and nothing else.
+
+## Scope
+
+- Determine whether `session.cljs` needs path *decoding* (in which case the decoded value
+  should be passed in by the caller) or path *manipulation* (in which case the helper likely
+  belongs in `shape.*`, which `domain.*` may legally require).
+- Small enough to land alongside the terminal-ui slice in a single PR if convenient.
+
+## Work items
+
+- [ ] Establish what `session.cljs` uses from `extern.path`.
+- [ ] Move the dependency to `shape.*` or lift it to the caller.
+- [ ] Raise both linters to `:error` in `packages/eta-mu/.clj-kondo/config.edn`.
+
+## Acceptance criteria
+
+- [ ] `pnpm -C packages/eta-mu lint:kondo` reports zero `:layer-boundary/*` findings.
+- [ ] `packages/eta-mu/.clj-kondo/config.edn` sets both linters to `:error`.
+- [ ] `pnpm -C packages/eta-mu test` stays green.
+- [ ] No behavior change — placement only.
+
+## Verification
+
+```bash
+pnpm -C packages/eta-mu lint:kondo
+pnpm -C packages/eta-mu test
+```
+
+The ratchet, added to `packages/eta-mu/.clj-kondo/config.edn`:
+
+```clojure
+:linters {:layer-boundary/upward-require {:level :error}
+          :layer-boundary/host-require {:level :error}}
+```
+
+## Notes
+
+`packages/eta-mu` is the CLI users install. Once this slice is clean and gated, a layer
+crossing can never silently ship in the package that everything else is reached through.

--- a/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-rheos.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-rheos.md
@@ -1,0 +1,92 @@
+---
+category: "tasks"
+labels: ["tasks", "quality", "lint", "layers", "rheos", "3sp"]
+points: "3"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+title: "Layer Boundary Ratchet — rheos"
+priority: "P1"
+status: "icebox"
+uuid: "eta-mu-quality-ratchet-layer-boundary-rheos"
+created_at: "2026-07-31T00:00:00Z"
+---
+
+# Layer Boundary Ratchet — rheos
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 3
+
+## Purpose
+
+Clear the 8 `:layer-boundary/*` findings in `packages/rheos` so the package can raise
+both linters from `:info` to `:error` and can no longer regress.
+
+The linter landed in `packages/kondo-config` (`hooks/layer_boundaries.clj`) and reports
+crossings of the `law.* → shape.* → extern.* → domain.* → infra.*` construction order at
+the `:require` that causes them. It ships at `:info` repo-wide: findings print on every
+lint run but never fail it. This task pays rheos's share and flips the gate shut.
+
+## Findings (8)
+
+Backend (3) — the smallest coherent first slice:
+
+- [ ] `src/rheos/backend/law/fsm.cljs` — host require `"node:child_process"`.
+      A `law.*` namespace shelling out is the most severe finding in the repo: law is
+      supposed to be the layer with no world in it at all.
+- [ ] `src/rheos/backend/domain/compose.cljs` — requires `rheos.backend.infra.task-store` (upward)
+- [ ] `src/rheos/backend/domain/compose.cljs` — requires `rheos.backend.infra.ledger` (upward)
+
+UI (5):
+
+- [ ] `src/rheos/ui/domain/layout.cljs` — requires `rheos.ui.infra.api` (upward)
+- [ ] `src/rheos/ui/domain/layout.cljs` — requires `rheos.ui.infra.ledger-stream` (upward)
+- [ ] `src/rheos/ui/domain/orchestrator.cljs` — requires `rheos.ui.infra.chat-session` (upward)
+- [ ] `src/rheos/ui/domain/sidebar.cljs` — host require `"marked"`
+- [ ] `src/rheos/ui/domain/sidebar.cljs` — host require `"dompurify"`
+
+## Scope
+
+- The five `domain → infra` crossings follow the pattern already proven on this package in
+  `56aa198`: the domain namespace returns a decision, a sibling `infra/` namespace performs
+  it. `domain/compose.cljs` is the direct analogue of the `task-create` / `task-edit` /
+  `transition` split.
+- `sidebar.cljs`'s `marked` + `dompurify` are markdown/sanitize decoding — an `extern.*`
+  adapter, not a domain concern.
+- `law/fsm.cljs`'s `child_process` should be lifted out entirely rather than relocated;
+  audit what it actually shells out for before choosing a home.
+
+## Work items
+
+- [ ] Clear the 3 backend findings and confirm the rheos suite stays green.
+- [ ] Clear the 5 UI findings.
+- [ ] Raise both linters to `:error` in `packages/rheos/.clj-kondo/config.edn`.
+- [ ] Confirm no finding was silenced with `:config-in-ns` instead of fixed.
+
+## Acceptance criteria
+
+- [ ] `pnpm -C packages/rheos lint:kondo` reports zero `:layer-boundary/*` findings.
+- [ ] `packages/rheos/.clj-kondo/config.edn` sets both linters to `:error`, so a
+      reintroduced crossing fails the lint rather than printing.
+- [ ] `pnpm -C packages/rheos test` stays green (82 tests / 246 assertions at time of writing).
+- [ ] No behavior change — this is a placement task, not a redesign.
+
+## Verification
+
+```bash
+pnpm -C packages/rheos lint:kondo
+pnpm -C packages/rheos test
+```
+
+The ratchet, added to `packages/rheos/.clj-kondo/config.edn`:
+
+```clojure
+:linters {:layer-boundary/upward-require {:level :error}
+          :layer-boundary/host-require {:level :error}}
+```
+
+## Notes
+
+- `*-test` namespaces are exempt from the linter, which means a domain test that needs a
+  filesystem will not be flagged. `test/rheos/backend/domain/compose_test.cljs` was flagged
+  before the exemption was added and is a real signal about `domain/compose` regardless.
+- Splitting this card into backend (3) and UI (5) is reasonable if it is picked up
+  incrementally; the backend slice stands alone.

--- a/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-sol.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-sol.md
@@ -1,0 +1,98 @@
+---
+category: "tasks"
+labels: ["tasks", "quality", "lint", "layers", "sol", "8sp"]
+points: "8"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+title: "Layer Boundary Ratchet — sol"
+priority: "P1"
+status: "icebox"
+uuid: "eta-mu-quality-ratchet-layer-boundary-sol"
+created_at: "2026-07-31T00:00:00Z"
+---
+
+# Layer Boundary Ratchet — sol
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 8
+
+## Purpose
+
+Clear the 17 `:layer-boundary/*` findings in `packages/sol` — the largest concentration in
+the repo, 63% of the 27 total — so the package can raise both linters from `:info` to
+`:error`.
+
+## Findings (17)
+
+### The `domain/node/*` family — a misplaced extern layer (9)
+
+`open-hax.sol.domain.node.*` is a set of thin host wrappers that happen to live in
+`domain.*`. This is the dominant sub-move: the namespaces are not wrong, their address is.
+Relocating the family to `extern.node.*` clears 9 of the 17 findings in one rename.
+
+- [ ] `domain/node/fs.cljs` — `"node:fs"`, `"node:fs/promises"`, `"node:path"` (3)
+- [ ] `domain/node/path.cljs` — `"node:path"`, `"node:process"` (2)
+- [ ] `domain/node/crypto.cljs` — `"node:crypto"` (1)
+- [ ] `domain/contracts/loader.cljs` — `"node:fs"`, `"node:fs/promises"`, `"node:path"` (3)
+
+### `domain/realtime.cljs` — host requires (4)
+
+- [ ] `"node:child_process"`
+- [ ] `"node:crypto"`
+- [ ] `"node:os"`
+- [ ] `"node:util"`
+
+Four host modules in one domain namespace suggests `realtime` is an orchestrator wearing a
+domain name, not a decision surface. Audit before relocating.
+
+### Upward requires (4)
+
+- [ ] `domain/text.cljs` — requires `open-hax.sol.infra.http` (upward)
+- [ ] `domain/agent/agent_templates.cljs` — requires `open-hax.sol.infra.config` (upward)
+- [ ] `domain/agent/agent_templates.cljs` — requires `open-hax.sol.infra.defaults` (upward)
+- [ ] `domain/contracts/client.cljs` — requires `open-hax.sol.extern.fetch` (`domain → extern`)
+
+## Scope
+
+- Prefer relocation over rewriting. Most of these are correctly-written namespaces sitting
+  at the wrong address; moving them is lower risk than restructuring them.
+- `agent_templates` reaching for `infra.config`/`infra.defaults` is configuration being read
+  at decision time. The usual repair is to pass the resolved config in as an argument.
+- Do this in reviewable slices rather than one commit: the `node/*` rename, then `realtime`,
+  then the four upward requires.
+
+## Work items
+
+- [ ] Relocate the `domain/node/*` family and update every consumer's `:require`.
+- [ ] Audit and repair `domain/realtime.cljs`.
+- [ ] Clear the four upward requires.
+- [ ] Raise both linters to `:error` in `packages/sol/.clj-kondo/config.edn`.
+- [ ] Confirm no finding was silenced with `:config-in-ns` instead of fixed.
+
+## Acceptance criteria
+
+- [ ] `pnpm -C packages/sol lint:kondo` reports zero `:layer-boundary/*` findings.
+- [ ] `packages/sol/.clj-kondo/config.edn` sets both linters to `:error`.
+- [ ] The sol suite stays green.
+- [ ] No behavior change — placement only.
+
+## Verification
+
+```bash
+pnpm -C packages/sol lint:kondo
+pnpm -C packages/sol test
+```
+
+The ratchet, added to `packages/sol/.clj-kondo/config.edn`:
+
+```clojure
+:linters {:layer-boundary/upward-require {:level :error}
+          :layer-boundary/host-require {:level :error}}
+```
+
+## Notes
+
+- Sequence this against the open `Sol — Provider Swap and Legacy Dependency Drop` and
+  `Sol Cutover Verification and Cutover-Ratchet Unblock` cards. A namespace rename across
+  `domain/node/*` will conflict loudly with anything else touching sol's requires.
+- 8 points is a size estimate on a card that has not been through Breakdown. If picked up,
+  split it along the three slices above first.

--- a/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-terminal-ui.md
+++ b/kanban/tasks/eta-mu-quality-ratchet-layer-boundary-terminal-ui.md
@@ -1,0 +1,68 @@
+---
+category: "tasks"
+labels: ["tasks", "quality", "lint", "layers", "terminal-ui", "1sp"]
+points: "1"
+source: "kanban/epics/eta-mu-quality-ratchet.md"
+title: "Layer Boundary Ratchet — terminal-ui"
+priority: "P2"
+status: "icebox"
+uuid: "eta-mu-quality-ratchet-layer-boundary-terminal-ui"
+created_at: "2026-07-31T00:00:00Z"
+---
+
+# Layer Boundary Ratchet — terminal-ui
+
+> Parent epic: `kanban/epics/eta-mu-quality-ratchet.md`
+> Points: 1
+
+## Purpose
+
+Clear the single `:layer-boundary/*` finding in `packages/terminal-ui` and raise both
+linters to `:error`. Smallest slice in the ratchet and a good first one to land, because it
+proves the per-package `:error` mechanism end to end at almost no cost.
+
+## Findings (1)
+
+- [ ] `src/cljs/eta_mu/terminal_ui/shape/text_utils.cljs` — host require
+      `"get-east-asian-width"`.
+
+A `shape.*` namespace requiring a host module. Shape is meant to be pure structure, one
+layer below `extern.*` where foreign data is decoded.
+
+## Scope
+
+Two defensible repairs — pick based on what `text_utils` actually does with the import:
+
+1. **Wrap it in `extern.*`** if the width lookup is genuinely foreign data being decoded,
+   and have `shape.text-utils` take the resolved widths as input.
+2. **Silence it with `:config-in-ns`** if this is judged a legitimate exception — a pure,
+   synchronous, data-only table lookup with no effects. Record the reason in the namespace.
+
+Option 1 is the default. Option 2 is available but must be argued, not assumed.
+
+## Work items
+
+- [ ] Decide between the extern wrap and a documented `:config-in-ns` exception.
+- [ ] Apply it.
+- [ ] Raise both linters to `:error` in `packages/terminal-ui/.clj-kondo/config.edn`.
+
+## Acceptance criteria
+
+- [ ] `pnpm -C packages/terminal-ui lint:kondo` reports zero `:layer-boundary/*` findings.
+- [ ] `packages/terminal-ui/.clj-kondo/config.edn` sets both linters to `:error`.
+- [ ] If `:config-in-ns` was used, the namespace carries a comment saying why.
+- [ ] The terminal-ui suite stays green.
+
+## Verification
+
+```bash
+pnpm -C packages/terminal-ui lint:kondo
+pnpm -C packages/terminal-ui test
+```
+
+The ratchet, added to `packages/terminal-ui/.clj-kondo/config.edn`:
+
+```clojure
+:linters {:layer-boundary/upward-require {:level :error}
+          :layer-boundary/host-require {:level :error}}
+```


### PR DESCRIPTION
## Summary

The layer-boundary linter added in #167 (`packages/kondo-config`, `hooks/layer_boundaries.clj`) ships at `:info`: its findings print on every lint run but fail nothing, and belong to nobody. This cards the backlog so paying it down is deliberate and attributable.

**27 findings**, sliced one card per package, each ending in that package raising both linters to `:error` so it can't regress:

| Card | Findings | Points | Shape of the work |
|---|---|---|---|
| `…-layer-boundary-sol` | 17 | 8 | A `domain/node/*` host-wrapper family sitting at the wrong address — relocating it to `extern.node.*` clears 9 in one rename |
| `…-layer-boundary-rheos` | 8 | 3 | 3 backend (incl. `law/fsm.cljs` requiring `node:child_process`), 5 UI |
| `…-layer-boundary-terminal-ui` | 1 | 1 | A `shape.*` host require |
| `…-layer-boundary-eta-mu` | 1 | 1 | One `domain → extern` require in `domain/session.cljs` |

By type: 17 host requires, 8 upward-to-infra, 2 domain-to-extern.

## Why under the existing epic

Slices of `eta-mu-quality-ratchet` rather than a new epic. Its child task 4, **Lint and Static Gates** (already `done`), was explicitly scoped to "wire CLJS boundary/static checks into the relevant package gate" — the layer linter is the thing that came out of that, so its backlog is the same programme continuing, not a new one. The board is already 41 cards deep in icebox; a 42nd epic competing with this one would fragment the same work.

One new epic-level acceptance criterion was added to match.

## Suggested order

`terminal-ui` (1 finding) first — it proves the per-package `:error` mechanism end to end at almost no cost. Then rheos backend (3), which is a direct analogue of the domain/infra split already landed in `56aa198`. `sol` should go through Breakdown before it is picked up; 8 points is an estimate on an un-broken-down card.

## Verification

- All four cards parse: `eta-mu kanban search "Layer Boundary Ratchet"` returns all 4 with correct uuid/status/priority
- Findings enumerated from a full `pnpm -r lint:kondo` run and reconciled against the 27 total by both package and type
- Path-scoped staging; no `receipts.edn` swept in, per the epic's process constraints
- Branched from current `origin/main` in a clean worktree, also per the epic

Cards only — no source changes, nothing to lint or test beyond board parseability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)