### PR TITLE
chore(ci): pin reusable workflow logic to the fixed eta-mu commit

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: open-hax/eta-mu
-          ref: c06308d940654ab51ae043cde20e10cc71f27b99
+          ref: bafe9aa6a09406cfd83010f5e06538117dc6056c
           path: .eta-mu
           persist-credentials: false
 

--- a/.github/workflows/ensure-pr-to-staging.yml
+++ b/.github/workflows/ensure-pr-to-staging.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: open-hax/eta-mu
-          ref: c06308d940654ab51ae043cde20e10cc71f27b99
+          ref: bafe9aa6a09406cfd83010f5e06538117dc6056c
           path: .eta-mu
           persist-credentials: false
 

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: open-hax/eta-mu
-          ref: c06308d940654ab51ae043cde20e10cc71f27b99
+          ref: bafe9aa6a09406cfd83010f5e06538117dc6056c
           path: .eta-mu
           persist-credentials: false
 

--- a/.github/workflows/review-resolution-gate.yml
+++ b/.github/workflows/review-resolution-gate.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: open-hax/eta-mu
-          ref: c06308d940654ab51ae043cde20e10cc71f27b99
+          ref: bafe9aa6a09406cfd83010f5e06538117dc6056c
           path: .eta-mu
           persist-credentials: false
 


### PR DESCRIPTION
Follow-up to #173.

`review-resolution-gate`, `auto-merge`, `ensure-pr-to-staging`, and `release-and-publish` each check out eta-mu logic at `ref: c06308d9`, which predates the standalone-install fix. Without this bump they keep installing the broken tree and failing with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`, no matter what `main` contains.

All four now pin `bafe9aa` — the merge commit of #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)