### PR TITLE
fix(rheos): hint the lstat result so :cli builds without warnings

### DIFF
--- a/packages/rheos/src/rheos/backend/infra/task_store.cljs
+++ b/packages/rheos/src/rheos/backend/infra/task_store.cljs
@@ -96,7 +96,9 @@
    a link rather than as whatever it points at."
   [full-path]
   (try
-    (let [st (await (.lstat fsp full-path))]
+    ;; ^js: `isSymbolicLink` is not in the externs shadow infers from, so the
+    ;; call compiles to a munged name under :advanced without the hint.
+    (let [^js st (await (.lstat fsp full-path))]
       (cond
         (.isSymbolicLink st) :link
         (.isDirectory st) :dir


### PR DESCRIPTION
**Card:** follow-up to `rheos-edn-config-and-card-selection` (#158, merged)

## What

`entry-kind`, added in #158's symlink-containment fix, reads `isSymbolicLink`. That method is not in the externs shadow-cljs infers from, so `:cli` and `:github-sync` each emitted:

```
------ WARNING #1 - :infer-warning ------
 task_store.cljs:101:9
 Cannot infer target type in expression (. st isSymbolicLink)
```

Under `:advanced` the call would compile to a munged name. Adding `^js` to the binding fixes it.

## Why it reached main

Nothing gates it. The `rheos` CI job runs `test` + `lint:kondo` only. `rheos-github-sync` does build rheos, but ignores compiler warnings. `sol` and `axxium` both fail on any `WARNING` line — rheos does not.

Found by `pnpm gates` after adding a warning check to the local rheos gate, which is now deliberately stricter than CI. Carded as `rheos-ci-does-not-gate-build-warnings` so CI catches up and the divergence goes away.

## Verification

All four rheos targets at **0 warnings**; **121 tests / 336 assertions**, clj-kondo 0/0. Reverting the `^js` hint makes the local gate fail with `2 WARNING line(s)`, so the check demonstrably catches this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)