### PR TITLE
test(rheos): pin the FSM's refusal of non-states at law, write path, and tool

### DIFF
--- a/packages/rheos/test/rheos/backend/infra/agent_tools_test.cljs
+++ b/packages/rheos/test/rheos/backend/infra/agent_tools_test.cljs
@@ -1,0 +1,90 @@
+(ns rheos.backend.infra.agent-tools-test
+  "The tool layer's refusal contract, as a caller experiences it.
+
+   `eta-mu kanban status-update` dispatches `kanban_update_status`, so this is
+   the surface that accepted `in_review` for three cards. A refusal here has to
+   be observable two ways: the card file is unchanged, and the failure carries a
+   `:kind` the CLI maps to a non-zero exit — a tool that refused but exited 0
+   would leave every scripted caller believing the move landed."
+  (:require ["node:fs/promises" :as fsp]
+            ["node:os" :as os]
+            ["node:path" :as path]
+            [cljs.test :refer [deftest testing is]]
+            [rheos.backend.infra.agent-tools :as agent-tools]
+            [rheos.backend.infra.cli :as cli]
+            [rheos.backend.infra.projects :as projects]))
+
+(defn- tmp-dir []
+  (path/join (.tmpdir os) (str "rheos-agent-tools-test-" (.now js/Date) "-" (rand-int 100000))))
+
+(defn- write-task! [dir uuid status]
+  (.writeFile fsp (path/join dir (str uuid ".md"))
+              (str "---\n"
+                   "uuid: \"" uuid "\"\n"
+                   "title: \"Task One\"\n"
+                   "status: \"" status "\"\n"
+                   "priority: \"P3\"\n"
+                   "---\n\n# Task One\n\nBody")
+              "utf8"))
+
+(defn- ^:async dispatch-outcome
+  "Dispatch `tool` against a temp board holding one card at `status`.
+   Returns {:error <ex-data or nil> :result :before :after}."
+  [status tool args]
+  (let [dir (tmp-dir)
+        _ (await (.mkdir fsp dir #js {:recursive true}))
+        _ (await (write-task! dir "t1" status))
+        source-path (path/join dir "t1.md")
+        saved {:projects (projects/all) :default-project-id (projects/default-id)}
+        before (await (.readFile fsp source-path "utf8"))]
+    (projects/set-projects!
+     {:projects [{:id "test" :title "Test" :tasks-dir dir :fsm "promethean" :meta {}}]
+      :default-project-id "test"})
+    (try
+      (let [outcome (try
+                      {:result (await (agent-tools/dispatch tool args))}
+                      (catch :default e
+                        {:error (ex-data e) :message (ex-message e)}))]
+        (merge outcome {:before before
+                        :after (await (.readFile fsp source-path "utf8"))}))
+      (finally
+        (projects/set-projects! saved)
+        (await (.rm fsp dir #js {:recursive true :force true}))))))
+
+(deftest ^:async update-status-refuses-a-non-fsm-status
+  (testing "`in_review` is not an FSM state — the tool must refuse it, not write it"
+    (let [{:keys [error message result before after]}
+          (await (dispatch-outcome "review" "kanban_update_status"
+                                   {:uuid "t1" :status "in_review" :project "test"}))]
+      (is (nil? result) "the tool must not report success")
+      (is (some? error) "it must throw")
+      (is (= :refused (:kind error)))
+      (is (re-find #"transition rejected" (str message)))
+      (is (= before after) "and the card file is byte-identical"))))
+
+(deftest ^:async update-status-refuses-a-missing-edge
+  (testing "both states real, edge absent — same refusal, same silence on disk"
+    (let [{:keys [error result before after]}
+          (await (dispatch-outcome "breakdown" "kanban_update_status"
+                                   {:uuid "t1" :status "done" :project "test"}))]
+      (is (nil? result))
+      (is (= :refused (:kind error)))
+      (is (= before after)))))
+
+(deftest ^:async update-status-writes-on-a-legal-move
+  (testing "the refusal tests above would pass on a tool that never writes"
+    (let [{:keys [error result before after]}
+          (await (dispatch-outcome "breakdown" "kanban_update_status"
+                                   {:uuid "t1" :status "ready" :project "test"}))]
+      (is (nil? error))
+      (is (:ok result))
+      (is (= "breakdown" (:from result)))
+      (is (= "ready" (:to result)))
+      (is (not= before after))
+      (is (re-find #"status: \"ready\"" after)))))
+
+(deftest refused-maps-to-a-non-zero-exit
+  (testing "the `:kind` a refusal throws is the one the CLI turns into exit 3"
+    (is (= 3 (:refused cli/exit-codes)))
+    (is (pos? (:refused cli/exit-codes))
+        "a refusal that exits 0 is indistinguishable from a completed move")))

--- a/packages/rheos/test/rheos/backend/infra/agent_tools_test.cljs
+++ b/packages/rheos/test/rheos/backend/infra/agent_tools_test.cljs
@@ -83,8 +83,59 @@
       (is (not= before after))
       (is (re-find #"status: \"ready\"" after)))))
 
-(deftest refused-maps-to-a-non-zero-exit
-  (testing "the `:kind` a refusal throws is the one the CLI turns into exit 3"
+;; ---------------------------------------------------------------------------
+;; The exit code a scripted caller actually observes
+;; ---------------------------------------------------------------------------
+
+(defn- ^:async run-cli!
+  "Drive [[cli/main]] end to end against a temp board holding one card at
+   `status`, and return the exit code it left on the process.
+
+   `main` reads `process.argv` and writes `process.exitCode` — the only way to
+   prove a refusal reaches a caller as a non-zero exit is to go through both.
+   Both globals are restored, and `exitCode` is reset to 0, or a passing suite
+   would inherit this test's failure code."
+  [status argv-tail]
+  (let [dir (tmp-dir)
+        _ (await (.mkdir fsp dir #js {:recursive true}))
+        _ (await (write-task! dir "t1" status))
+        config-path (path/join dir "board.edn")
+        _ (await (.writeFile fsp config-path
+                             (str "{:tasks-dir \"" dir "\" :fsm :promethean}") "utf8"))
+        saved-argv js/process.argv
+        saved-projects {:projects (projects/all) :default-project-id (projects/default-id)}]
+    (set! (.-exitCode js/process) 0)
+    (set! (.-argv js/process)
+          (clj->js (concat ["node" "rheos"] argv-tail ["--config" config-path])))
+    (try
+      (await (cli/main))
+      {:exit-code (.-exitCode js/process)
+       :after (await (.readFile fsp (path/join dir "t1.md") "utf8"))}
+      (finally
+        (set! (.-argv js/process) saved-argv)
+        (set! (.-exitCode js/process) 0)
+        (projects/set-projects! saved-projects)
+        (await (.rm fsp dir #js {:recursive true :force true}))))))
+
+(deftest ^:async status-update-exits-non-zero-on-a-refusal
+  (testing "a refused move reaches the caller as exit 3, not a silent success"
+    (let [{:keys [exit-code after]}
+          (await (run-cli! "review" ["status-update" "t1" "--to" "in_review"]))]
+      (is (= 3 exit-code)
+          "exit 0 here is indistinguishable from a completed move")
+      (is (= (:refused cli/exit-codes) exit-code)
+          "and it is the published `:refused` code, not an incidental non-zero")
+      (is (re-find #"status: \"review\"" after)
+          "the card still holds its real status"))))
+
+(deftest ^:async status-update-exits-zero-on-a-legal-move
+  (testing "the exit assertion above would pass on a CLI that always failed"
+    (let [{:keys [exit-code after]}
+          (await (run-cli! "breakdown" ["status-update" "t1" "--to" "ready"]))]
+      (is (= 0 exit-code))
+      (is (re-find #"status: \"ready\"" after)))))
+
+(deftest exit-codes-cover-refusal
+  (testing "the published mapping the tests above depend on"
     (is (= 3 (:refused cli/exit-codes)))
-    (is (pos? (:refused cli/exit-codes))
-        "a refusal that exits 0 is indistinguishable from a completed move")))
+    (is (pos? (:refused cli/exit-codes)))))

--- a/packages/rheos/test/rheos/backend/infra/transition_test.cljs
+++ b/packages/rheos/test/rheos/backend/infra/transition_test.cljs
@@ -27,13 +27,18 @@
     (.writeFile fsp file-path raw "utf8")))
 
 (defn- ^:async ledger-lines
-  "Number of events on disk, 0 when the ledger has not been created."
+  "Number of events on disk, 0 when the ledger has not been created.
+
+   Only a missing file counts as zero. Swallowing any other read failure would
+   let these tests report 'no event was appended' when they simply could not
+   look — the refusal assertions would then pass without evidence."
   [dir]
   (let [ledger-path (path/join dir ".events" "ledger.edn")]
     (try
       (let [raw (await (.readFile fsp ledger-path "utf8"))]
         (count (remove #(= "" %) (.split (str raw) "\n"))))
-      (catch :default _ 0))))
+      (catch :default error
+        (if (= "ENOENT" (.-code error)) 0 (throw error))))))
 
 (defn- ^:async with-card
   "Run `f` against a temp board holding one card at `status`, then assert on the

--- a/packages/rheos/test/rheos/backend/infra/transition_test.cljs
+++ b/packages/rheos/test/rheos/backend/infra/transition_test.cljs
@@ -1,0 +1,118 @@
+(ns rheos.backend.infra.transition-test
+  "The refusal half of the single write path.
+
+   [[rheos.backend.infra.transition/move-task!]] is the only way a status
+   changes, so a status the FSM does not recognise has to die here — returning
+   `{:ok false}` *and* leaving both the card file and the ledger untouched. The
+   `in_review` bug wrote three cards into a state the board could not render or
+   transition out of; a refusal that still writes is the same bug."
+  (:require ["node:fs/promises" :as fsp]
+            ["node:os" :as os]
+            ["node:path" :as path]
+            [cljs.test :refer [deftest testing is]]
+            [rheos.backend.domain.events :as events]
+            [rheos.backend.infra.transition :as transition]))
+
+(defn- tmp-dir []
+  (path/join (.tmpdir os) (str "rheos-transition-test-" (.now js/Date) "-" (rand-int 100000))))
+
+(defn- write-task! [dir uuid status]
+  (let [file-path (path/join dir (str uuid ".md"))
+        raw (str "---\n"
+                 "uuid: \"" uuid "\"\n"
+                 "title: \"Task One\"\n"
+                 "status: \"" status "\"\n"
+                 "priority: \"P3\"\n"
+                 "---\n\n# Task One\n\nBody")]
+    (.writeFile fsp file-path raw "utf8")))
+
+(defn- ^:async ledger-lines
+  "Number of events on disk, 0 when the ledger has not been created."
+  [dir]
+  (let [ledger-path (path/join dir ".events" "ledger.edn")]
+    (try
+      (let [raw (await (.readFile fsp ledger-path "utf8"))]
+        (count (remove #(= "" %) (.split (str raw) "\n"))))
+      (catch :default _ 0))))
+
+(defn- ^:async with-card
+  "Run `f` against a temp board holding one card at `status`, then assert on the
+   file and ledger it left behind. `f` receives {:project :task}."
+  [status f]
+  (let [dir (tmp-dir)
+        _ (await (.mkdir fsp dir #js {:recursive true}))
+        _ (await (write-task! dir "t1" status))
+        source-path (path/join dir "t1.md")
+        project {:id "test" :title "Test" :tasks-dir dir :fsm "promethean" :meta {}}
+        task {:uuid "t1" :status status :source-path source-path}
+        before (await (.readFile fsp source-path "utf8"))
+        ledger-before (await (ledger-lines dir))
+        captured (atom [])
+        unsub (events/subscribe! #(swap! captured conj %))]
+    (try
+      (let [result (await (f {:project project :task task}))]
+        {:result result
+         :before before
+         :after (await (.readFile fsp source-path "utf8"))
+         :ledger-before ledger-before
+         :ledger-after (await (ledger-lines dir))
+         :events @captured})
+      (finally
+        (unsub)
+        (await (.rm fsp dir #js {:recursive true :force true}))))))
+
+(deftest ^:async move-to-a-non-fsm-status-is-refused-and-writes-nothing
+  (testing "`in_review` is not an FSM state — the write path must refuse it"
+    (let [{:keys [result before after ledger-before ledger-after events]}
+          (await (with-card "review"
+                   (fn [{:keys [project task]}]
+                     (transition/move-task! {:project project :task task
+                                             :new-status "in_review"
+                                             :source "test"}))))]
+      (is (false? (:ok result)))
+      (is (= "review" (:from result)))
+      (is (= "in_review" (:to result)))
+      (is (re-find #"No transition" (str (:reason result))))
+      (is (= before after) "the card file is byte-identical")
+      (is (re-find #"status: \"review\"" after) "and still holds its real status")
+      (is (= ledger-before ledger-after) "no event was appended")
+      (is (empty? events) "and none was published"))))
+
+(deftest ^:async move-from-a-non-fsm-status-is-refused-and-writes-nothing
+  (testing "a card already stranded on a bogus status cannot move either"
+    (let [{:keys [result before after ledger-before ledger-after]}
+          (await (with-card "in_review"
+                   (fn [{:keys [project task]}]
+                     (transition/move-task! {:project project :task task
+                                             :new-status "done"
+                                             :source "test"}))))]
+      (is (false? (:ok result)))
+      (is (re-find #"No transition" (str (:reason result))))
+      (is (= before after) "the card file is byte-identical")
+      (is (= ledger-before ledger-after) "no event was appended"))))
+
+(deftest ^:async move-across-a-missing-edge-is-refused-and-writes-nothing
+  (testing "both states real, edge absent — same refusal, same silence on disk"
+    (let [{:keys [result before after ledger-before ledger-after]}
+          (await (with-card "breakdown"
+                   (fn [{:keys [project task]}]
+                     (transition/move-task! {:project project :task task
+                                             :new-status "done"
+                                             :source "test"}))))]
+      (is (false? (:ok result)))
+      (is (= before after) "the card file is byte-identical")
+      (is (= ledger-before ledger-after) "no event was appended"))))
+
+(deftest ^:async a-legal-move-does-write
+  (testing "the refusal tests above would pass on a write path that never writes"
+    (let [{:keys [result before after ledger-before ledger-after events]}
+          (await (with-card "breakdown"
+                   (fn [{:keys [project task]}]
+                     (transition/move-task! {:project project :task task
+                                             :new-status "ready"
+                                             :source "test"}))))]
+      (is (:ok result))
+      (is (not= before after) "the card file was rewritten")
+      (is (re-find #"status: \"ready\"" after))
+      (is (= (inc ledger-before) ledger-after) "exactly one event was appended")
+      (is (some #(= "status-change" (:type %)) events)))))

--- a/packages/rheos/test/rheos/backend/law/fsm_test.cljs
+++ b/packages/rheos/test/rheos/backend/law/fsm_test.cljs
@@ -36,6 +36,29 @@
   (let [result (fsm/evaluate-transition fsm/default-fsm "incoming" "done" {})]
     (is (not (:allowed? result)))))
 
+(deftest evaluate-rejects-a-status-outside-the-state-set
+  ;; The `in_review` bug: a status that is not an FSM state at all was written
+  ;; to three cards, stranding them where `done` was unreachable. No state may
+  ;; reach a target outside `:states`, and no state may offer one.
+  (doseq [fsm-def [fsm/default-fsm fsm/promethean-fsm]
+          from (:states fsm-def)
+          bogus ["in_review" "IN_PROGRESS" "" "done "]]
+    (let [result (fsm/evaluate-transition fsm-def from bogus {})]
+      (is (not (:allowed? result))
+          (str "'" from "' -> '" bogus "' must be refused"))
+      (is (re-find #"No transition" (:reason result))))
+    (is (not (some #(= bogus %) (fsm/valid-targets fsm-def from)))
+        (str "'" bogus "' must never be offered as a target from '" from "'"))))
+
+(deftest evaluate-rejects-a-source-outside-the-state-set
+  ;; A card already holding a bogus status must not be able to move anywhere —
+  ;; that is what made the three `in_review` cards unrecoverable via the FSM.
+  (doseq [to (:states fsm/promethean-fsm)]
+    (is (not (:allowed? (fsm/evaluate-transition fsm/promethean-fsm
+                                                 "in_review" to {})))
+        (str "'in_review' -> '" to "' must be refused")))
+  (is (empty? (fsm/valid-targets fsm/promethean-fsm "in_review"))))
+
 (deftest evaluate-wip-under-limit
   (is (:allowed? (fsm/evaluate-transition fsm/default-fsm
                                            "ready" "in_progress"


### PR DESCRIPTION
Closes the remaining DoD on `kanban-cli-status-validation-bug`.

## Why

`eta-mu kanban update-status <uuid> in_review` once succeeded. `in_review` is
not an FSM state at all, and three cards ended up holding it — the board could
not render them and `done` was unreachable from there.

The rheos CLI cutover fixed the behaviour (`update-status` now routes through
`rheos.backend.law.fsm`), and the 2026-07-19 board triage verified that live.
What it left open, and what this PR closes: **nothing held the fix in place.**
`fsm_test` covered invalid edges between two *valid* states only. A regression
that reintroduced a bogus target — or a write path that refused but wrote
anyway — would have gone unnoticed until it corrupted the board a second time.

## What

Three layers, because a refusal is only real if it holds at all three:

| Layer | File | Contract pinned |
|---|---|---|
| law | `law/fsm_test.cljs` | No state in either FSM reaches a status outside `:states`; `valid-targets` never offers one; a card stranded on a bogus status can reach nothing |
| write path | `infra/transition_test.cljs` (new) | `move-task!` returns `{:ok false}`, card file byte-identical, no ledger event, nothing published |
| tool | `infra/agent_tools_test.cljs` (new) | `kanban_update_status` throws `:kind :refused` — the kind `cli/exit-codes` maps to exit 3 — and writes nothing |

Each refusal test is paired with a legal-move test, so a write path that simply
never writes cannot pass by doing nothing.

## Verification

Proved the tests catch the original defect rather than merely describing it:
bypassing the FSM verdict in `move-task!` makes them fail exactly as the bug
behaved — `in_review` written into the card with a fresh write-id, a
status-change event appended to the ledger, `{:ok true}` returned to the
caller. Restored before commit; `git diff` touches only `test/`.

Status audit (the card's second scope item): zero `in_review` remnants on
disk, and all 11 statuses in use across 282 cards are valid FSM states.

- 148 tests / 767 assertions, 0 failures (was 138/476)
- `clj-kondo` 0 warnings — includes rewriting two `.then/.catch` chains as
  `async/await` to satisfy the house rule
- `pnpm gates --base main` — 4/4 passed
- Clean shadow-cljs build, 0 compiler warnings

## Note

No production code changes. This is deliberate: the behaviour was already
correct, and the gap was that nothing enforced it. Per the roadmap's rule that
every compliance card should ship an *enforcement* mechanism rather than a
cleanup pass, the enforcement here is the test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for valid and invalid task-status transitions.
  * Verified refused transitions leave cards, ledgers, and published events unchanged.
  * Confirmed successful transitions update cards, record one ledger event, and publish status changes.
  * Added checks for invalid FSM states and correct CLI refusal exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->