### PR TITLE
refactor(rheos): route compose filters through shared conditions

### DIFF
--- a/.github/workflows/rheos-github-sync-ci.yml
+++ b/.github/workflows/rheos-github-sync-ci.yml
@@ -44,27 +44,70 @@ jobs:
       - name: Install workspace
         run: pnpm install --frozen-lockfile
 
-      - name: Install clj-kondo
+      - name: Install Clojure CLI and clj-kondo
+        uses: DeLaGuardo/setup-clojure@ada62bb3282a01a296659d48378b812b8e097360 # v13.4
+        with:
+          cli: 1.12.5.1654
+          clj-kondo: 2025.10.23
+
+      - name: Detect eta-mu app credentials
+        id: dependency-credentials
+        env:
+          ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
+          ETA_MU_APP_PRIVATE_KEY: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
         run: |
-          curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
-          chmod +x install-clj-kondo
-          sudo ./install-clj-kondo
+          if [[ -n "${ETA_MU_APP_ID}" && -n "${ETA_MU_APP_PRIVATE_KEY}" ]]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create cross-repository read token
+        id: dependency-token
+        if: steps.dependency-credentials.outputs.available == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.ETA_MU_APP_ID }}
+          private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: katamorph
+
+      - name: Configure private Git dependency reads
+        env:
+          DEPENDENCY_TOKEN: ${{ steps.dependency-token.outputs.token }}
+          CREDENTIALS_AVAILABLE: ${{ steps.dependency-credentials.outputs.available }}
+        run: |
+          if [[ "${CREDENTIALS_AVAILABLE}" != "true" ]]; then
+            echo "ETA_MU_APP_ID / ETA_MU_APP_PRIVATE_KEY are unavailable"
+            exit 1
+          fi
+          if [[ -z "${DEPENDENCY_TOKEN}" ]]; then
+            echo "The eta-mu GitHub App did not mint a dependency token"
+            exit 1
+          fi
+          authorization="$(printf 'x-access-token:%s' "${DEPENDENCY_TOKEN}" | base64 -w0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${authorization}"
 
       - name: Lint Rheos sync change surface
+        working-directory: packages/rheos
         run: |
           clj-kondo --lint \
-            packages/rheos/src/rheos/backend/infra/github_issue_preflight.cljs \
-            packages/rheos/src/rheos/backend/infra/github_issues.cljs \
-            packages/rheos/src/rheos/backend/infra/github_sync_cli.cljs \
-            packages/rheos/src/rheos/backend/infra/task_store.cljs \
-            packages/rheos/test/rheos/backend/infra/github_issue_preflight_test.cljs \
-            packages/rheos/test/rheos/backend/infra/github_issues_test.cljs
+            src/rheos/backend/infra/github_issue_preflight.cljs \
+            src/rheos/backend/infra/github_issues.cljs \
+            src/rheos/backend/infra/github_sync_cli.cljs \
+            src/rheos/backend/infra/task_store.cljs \
+            test/rheos/backend/infra/github_issue_preflight_test.cljs \
+            test/rheos/backend/infra/github_issues_test.cljs
 
       - name: Test Rheos
         run: pnpm --dir packages/rheos test
 
       - name: Release-build Rheos including GitHub projector
         run: pnpm --dir packages/rheos build
+
+      - name: Remove private Git authorization
+        if: always()
+        run: git config --global --unset-all http.https://github.com/.extraheader || true
 
       - name: Generate canonical eta-mu board snapshot
         env:

--- a/packages/rheos/src/rheos/backend/domain/compose.cljs
+++ b/packages/rheos/src/rheos/backend/domain/compose.cljs
@@ -2,41 +2,10 @@
   "Board composition — query DSL for filtering across multiple boards."
   (:require [clojure.string :as str]
             [rheos.backend.domain.board :as board]
+            [rheos.backend.domain.compose-condition :as compose-condition]
             [rheos.backend.domain.events :as events]
             [rheos.backend.infra.ledger :as ledger]
             [rheos.backend.infra.task-store :as tasks]))
-
-(defn- normalize-value [v]
-  (cond
-    (keyword? v) (name v)
-    :else (str v)))
-
-(defn- apply-operator [field-value op test-value]
-  (let [fv (normalize-value field-value)
-        tv (normalize-value test-value)]
-    (case op
-      :=  (= fv tv)
-      :in (if (vector? test-value)
-            (some #(= fv (normalize-value %)) test-value)
-            (= fv tv))
-      :contains (cond
-                  (vector? field-value) (some #(= (normalize-value %) tv) field-value)
-                  (string? fv) (str/includes? fv tv)
-                  :else false)
-      :regex (try (boolean (re-matches (re-pattern tv) fv)) (catch :default _ false))
-      false)))
-
-(defn- match-where [task [field op value]]
-  (let [field-key (if (keyword? field) field (keyword field))]
-    (apply-operator (get task field-key) op value)))
-
-(defn- match-meta-where [meta [field op value]]
-  (let [field-name (name field)
-        key (if (str/starts-with? field-name "meta.")
-              (keyword (subs field-name 5))
-              (keyword field-name))
-        meta-val (get meta key)]
-    (apply-operator meta-val op value)))
 
 (defn parse-where-clause [clause]
   (let [clause (str/trim clause)]
@@ -63,19 +32,20 @@
   (str/starts-with? (name (first clause)) "meta."))
 
 (defn- filter-task [task {:keys [status priority labels where-clauses]}]
-  (and (or (empty? status) (some #(= (:status task) %) status))
-       (or (empty? priority) (some #(= (:priority task) %) priority))
-       (or (empty? labels) (every? (fn [label] (some #(= % label) (:labels task))) labels))
+  (and (compose-condition/match-any? (:status task) status)
+       (compose-condition/match-any? (:priority task) priority)
+       (compose-condition/contains-all? (:labels task) labels)
        (every? (fn [clause]
                  (or (meta-clause? clause)
-                     (match-where task clause)))
+                     (compose-condition/match-clause? task clause)))
                (or where-clauses []))))
 
 (defn- filter-projects [projects {:keys [across where-clauses]}]
-  (let [meta-clauses (filter #(str/starts-with? (name (first %)) "meta.") where-clauses)]
+  (let [meta-clauses (filter meta-clause? where-clauses)]
     (filterv (fn [project]
                (and (or (empty? across) (some #(= (:id project) %) across))
-                    (every? #(match-meta-where (:meta project) %) meta-clauses)))
+                    (every? #(compose-condition/match-clause? (:meta project) %)
+                            meta-clauses)))
              projects)))
 
 (defn ^:async compose-snapshot [projects query]

--- a/packages/rheos/src/rheos/backend/domain/compose_condition.cljc
+++ b/packages/rheos/src/rheos/backend/domain/compose_condition.cljc
@@ -1,43 +1,27 @@
 (ns rheos.backend.domain.compose-condition
-  "Compatibility adapter from Rheos's legacy compose query dialect to the
-   shared Katamorph condition law. Regex and contains remain adapter-only
-   conveniences; equality and membership use the canonical interpreter."
   (:require [clojure.string :as str]
             [rheos.backend.law.condition :as condition]))
 
 (defn normalize-value [value]
-  (if (keyword? value)
-    (name value)
-    (str value)))
+  (if (keyword? value) (name value) (str value)))
 
 (defn- canonical-match? [field-value op test-value]
   (let [context {:value (normalize-value field-value)}]
     (case op
-      := (condition/match?
-          context
-          {:condition/op :eq
-           :condition/path [:value]
-           :condition/value (normalize-value test-value)})
-      :in (condition/match?
-           context
-           {:condition/op :in
-            :condition/path [:value]
-            :condition/values (mapv normalize-value
-                                    (if (vector? test-value)
-                                      test-value
-                                      [test-value]))})
+      := (condition/match? context {:condition/op :eq :condition/path [:value]
+                                    :condition/value (normalize-value test-value)})
+      :in (condition/match? context {:condition/op :in :condition/path [:value]
+                                     :condition/values (mapv normalize-value
+                                                             (if (vector? test-value)
+                                                               test-value
+                                                               [test-value]))})
       false)))
 
 (defn- legacy-contains? [field-value test-value]
   (let [needle (normalize-value test-value)]
-    (cond
-      (vector? field-value)
+    (if (vector? field-value)
       (boolean (some #(= (normalize-value %) needle) field-value))
-
-      (string? field-value)
-      (str/includes? field-value needle)
-
-      :else false)))
+      (str/includes? (normalize-value field-value) needle))))
 
 (defn- legacy-regex? [field-value pattern]
   (try
@@ -63,9 +47,7 @@
   (apply-operator (get context (field-key field)) op value))
 
 (defn match-any? [field-value values]
-  (or (empty? values)
-      (canonical-match? field-value :in values)))
+  (or (empty? values) (canonical-match? field-value :in values)))
 
 (defn contains-all? [field-value values]
-  (or (empty? values)
-      (every? #(legacy-contains? field-value %) values)))
+  (or (empty? values) (every? #(legacy-contains? field-value %) values)))

--- a/packages/rheos/src/rheos/backend/domain/compose_condition.cljc
+++ b/packages/rheos/src/rheos/backend/domain/compose_condition.cljc
@@ -1,0 +1,71 @@
+(ns rheos.backend.domain.compose-condition
+  "Compatibility adapter from Rheos's legacy compose query dialect to the
+   shared Katamorph condition law. Regex and contains remain adapter-only
+   conveniences; equality and membership use the canonical interpreter."
+  (:require [clojure.string :as str]
+            [rheos.backend.law.condition :as condition]))
+
+(defn normalize-value [value]
+  (if (keyword? value)
+    (name value)
+    (str value)))
+
+(defn- canonical-match? [field-value op test-value]
+  (let [context {:value (normalize-value field-value)}]
+    (case op
+      := (condition/match?
+          context
+          {:condition/op :eq
+           :condition/path [:value]
+           :condition/value (normalize-value test-value)})
+      :in (condition/match?
+           context
+           {:condition/op :in
+            :condition/path [:value]
+            :condition/values (mapv normalize-value
+                                    (if (vector? test-value)
+                                      test-value
+                                      [test-value]))})
+      false)))
+
+(defn- legacy-contains? [field-value test-value]
+  (let [needle (normalize-value test-value)]
+    (cond
+      (vector? field-value)
+      (boolean (some #(= (normalize-value %) needle) field-value))
+
+      (string? field-value)
+      (str/includes? field-value needle)
+
+      :else false)))
+
+(defn- legacy-regex? [field-value pattern]
+  (try
+    (boolean (re-matches (re-pattern (normalize-value pattern))
+                         (normalize-value field-value)))
+    (catch #?(:clj Exception :cljs :default) _ false)))
+
+(defn apply-operator [field-value op test-value]
+  (case op
+    := (canonical-match? field-value := test-value)
+    :in (canonical-match? field-value :in test-value)
+    :contains (legacy-contains? field-value test-value)
+    :regex (legacy-regex? field-value test-value)
+    false))
+
+(defn- field-key [field]
+  (let [field-name (name field)]
+    (keyword (if (str/starts-with? field-name "meta.")
+               (subs field-name 5)
+               field-name))))
+
+(defn match-clause? [context [field op value]]
+  (apply-operator (get context (field-key field)) op value))
+
+(defn match-any? [field-value values]
+  (or (empty? values)
+      (canonical-match? field-value :in values)))
+
+(defn contains-all? [field-value values]
+  (or (empty? values)
+      (every? #(legacy-contains? field-value %) values)))

--- a/packages/rheos/test/rheos/backend/domain/compose_condition_test.cljs
+++ b/packages/rheos/test/rheos/backend/domain/compose_condition_test.cljs
@@ -1,0 +1,31 @@
+(ns rheos.backend.domain.compose-condition-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [rheos.backend.domain.compose-condition :as compose-condition]))
+
+(deftest equality-and-membership-use-shared-condition-semantics
+  (testing "legacy string normalization happens before the shared strict matcher"
+    (is (compose-condition/match-clause? {:status :todo}
+                                         [:status := "todo"]))
+    (is (compose-condition/match-clause? {:priority :P1}
+                                         [:priority :in ["P0" "P1"]]))
+    (is (false? (compose-condition/match-clause? {:priority :P2}
+                                                 [:priority :in ["P0" "P1"]])))))
+
+(deftest meta-prefix-is-an-adapter-concern
+  (is (compose-condition/match-clause? {:domain "infra"}
+                                       [(keyword "meta.domain") := "infra"])))
+
+(deftest contains-and-regex-remain-rheos-query-conveniences
+  (is (compose-condition/match-clause? {:labels [:proxy :infra]}
+                                       [:labels :contains "proxy"]))
+  (is (compose-condition/match-clause? {:title "infra-proxy"}
+                                       [:title :regex "infra-.*"]))
+  (is (false? (compose-condition/match-clause? {:title "frontend"}
+                                               [:title :regex "infra-.*"]))))
+
+(deftest status-and-label-helpers-preserve-compose-behavior
+  (is (compose-condition/match-any? :todo ["ready" "todo"]))
+  (is (compose-condition/contains-all? [:workflow "research"]
+                                       ["workflow" "research"]))
+  (is (compose-condition/match-any? nil []))
+  (is (compose-condition/contains-all? nil [])))

--- a/packages/rheos/test/rheos/backend/domain/compose_condition_test.cljs
+++ b/packages/rheos/test/rheos/backend/domain/compose_condition_test.cljs
@@ -21,7 +21,12 @@
   (is (compose-condition/match-clause? {:title "infra-proxy"}
                                        [:title :regex "infra-.*"]))
   (is (false? (compose-condition/match-clause? {:title "frontend"}
-                                               [:title :regex "infra-.*"]))))
+                                               [:title :regex "infra-.*"])))
+  (testing "contains preserves normalized scalar metadata matching"
+    (is (compose-condition/match-clause? {:domain :music}
+                                         [:domain :contains "mus"]))
+    (is (compose-condition/match-clause? {:rank 1234}
+                                         [:rank :contains "23"]))))
 
 (deftest status-and-label-helpers-preserve-compose-behavior
   (is (compose-condition/match-any? :todo ["ready" "todo"]))


### PR DESCRIPTION
Adapt the legacy Rheos `compose` query path onto the Katamorph-owned condition semantics introduced through #284.

- status and priority filters use the shared strict `:in` matcher after explicit legacy string normalization;
- `where` equality and membership clauses use the shared `:eq` / `:in` interpreter;
- `meta.*` field routing remains a Rheos adapter concern;
- `contains` and regex remain deliberate Rheos query conveniences rather than becoming Katamorph law;
- normalized scalar `contains` behavior is preserved for keyword and numeric metadata;
- existing parse/query syntax and board projection behavior stay unchanged.

Adds a pure `.cljc` compatibility adapter plus focused tests for normalization, scalar and vector `contains`, meta fields, shared equality/membership, regex, and empty-filter behavior.

## Stack

Stacked on eta-mu #284 because it consumes the Katamorph condition facade established there. #284 now pins the merged Katamorph kernel and supplies the tools.deps CI toolchain.

## Verification

- scoped `clj-kondo`: 0 errors, 0 warnings.
- `git diff --check`: clean.
- GitHub Actions is running the authoritative Shadow CLJS test/build suite against this refreshed head and the repaired #284 base.