### PR TITLE
fix(review): pin nested GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -74,33 +74,33 @@ jobs:
       contents: read
     steps:
       - name: Checkout pull request
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Java 21
         if: ${{ inputs.setup_eta_mu_toolchain != false }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Clojure CLI 1.12.5.1654
         if: ${{ inputs.setup_eta_mu_toolchain != false }}
-        uses: DeLaGuardo/setup-clojure@13.4
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08 # 13.4
         with:
           cli: 1.12.5.1654
 
       - name: Set up pnpm 10.14.0
         if: ${{ inputs.setup_eta_mu_toolchain != false }}
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: "10.14.0"
           run_install: false
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload deterministic evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: review-evidence-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: .opencode/review-evidence
@@ -245,7 +245,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Muse compatibility compiler
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: octave-commons/muse
           ref: ${{ inputs.muse_revision || '3510440a01bac8c8ecbe8d5b8d08eb4a5cd46cac' }}
@@ -253,7 +253,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout global agent skills
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: riatzukiza/.agents
           ref: ${{ inputs.agents_revision || '7fd3252e7663ad5e68be5e90429d126aa66c38c8' }}
@@ -261,18 +261,18 @@ jobs:
           persist-credentials: false
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Clojure CLI 1.12.5.1654
-        uses: DeLaGuardo/setup-clojure@13.4
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08 # 13.4
         with:
           cli: 1.12.5.1654
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -432,7 +432,7 @@ jobs:
           (cd "$CONTEXT_OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
 
       - name: Upload review context
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: review-context-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/opencode-review-context
@@ -453,24 +453,24 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout pull request
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 
       - name: Download deterministic evidence
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: review-evidence-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: .opencode/review-evidence
 
       - name: Download Muse tools and global skills
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: review-context-${{ github.event.pull_request.head.sha }}
           path: .review-context
@@ -565,7 +565,7 @@ jobs:
 
       - name: Upload model response
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: review-model-response-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: |
@@ -585,7 +585,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Publish actual GitHub pull request review
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           REVIEW_SUBMISSION_FILE: .opencode/review-evidence/submission.json
         with:
@@ -601,7 +601,7 @@ jobs:
 
       - name: Send new inline review comments to Discord
         if: ${{ always() && env.HAS_DISCORD_REVIEW_WEBHOOK_URL == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}
           REVIEW_STARTED_AT: ${{ steps.review_start.outputs.started_at }}


### PR DESCRIPTION
## Summary

Make the evidence-first reusable review workflow transitively immutable before continuing the Foresight fleet rollout.

The caller repositories already pin `open-hax/eta-mu/.github/workflows/opencode-code-review.yml` by commit SHA, but the reusable workflow itself still referenced several third-party actions by mutable version tags. That meant the outer pin did not fully bind the code executed by a review run.

This change preserves workflow behavior and replaces only those moving action references with the commit identities currently resolved by their existing tags:

- `actions/checkout@v6` → `d23441a48e516b6c34aea4fa41551a30e30af803`
- `actions/setup-java@v4` → `cf277c60eb25467037889841efdb72551f06f6c3`
- `DeLaGuardo/setup-clojure@13.4` → `3fe9b3ae632c6758d0b7757b0838606ef4287b08`
- `pnpm/action-setup@v4` → `b906affcce14559ad1aafd4ab0e942779e9f58b1`
- `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020`
- `actions/upload-artifact@v4` → `ea165f8d65b6e75b540449e92b4886f43607fa02`
- `actions/download-artifact@v4` → `d3f86a106a0bac45b974a628896c90dbdf5c8093`
- `actions/github-script@v7` → `f28e40c7f34bde8b3046d885e986cb6290c5673b`

`actions/create-github-app-token` was already pinned by full commit SHA and is unchanged.

## Why now

The Foresight submodule rollout surfaced this as a real supply-chain gap while reviewing Proxx. Rollout of the old provider pin is paused until this provider revision is reviewed and merged; callers can then repin to the reviewed eta-mu commit.

## Verification

The branch is one commit ahead of `main` and changes only `.github/workflows/opencode-code-review.yml`, with 19 additions / 19 deletions. No workflow inputs, permissions, scripts, gates, or publication behavior are intentionally changed.