### PR TITLE
fix(workflow): activate terminal PR suppression

### DIFF
--- a/.github/workflows/ensure-pr-to-staging.yml
+++ b/.github/workflows/ensure-pr-to-staging.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: open-hax/eta-mu
-          ref: bafe9aa6a09406cfd83010f5e06538117dc6056c
+          ref: 9f075501ba3b1fae3e6a8865d39f2fea7d11c1dc
           path: .eta-mu
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- update the Proxx ensure-PR workflow’s immutable eta-mu checkout from pre-fix `bafe9aa6a09406cfd83010f5e06538117dc6056c`
- pin only the reviewed landed repair revision from PR #311
- keep the 34 exact-head Proxx recreations open until this activation passes its own exact-head gates/reviews and lands

## Exact state

- base / landed repair: `9f075501ba3b1fae3e6a8865d39f2fea7d11c1dc`
- head: `97f160d7c8ab3676c0fd4b2bb08f954a76a2ea95`
- tree: `41bbab6e28f276fc71bd3ae529a6d9ef7d33d7a0`
- workflow pin: `9f075501ba3b1fae3e6a8865d39f2fea7d11c1dc`

## Containment evidence

- Proxx burst provenance: run `33286614387`, job `99190784438`
- all 34 burst PRs are exact-SHA recreations of previously closed/unmerged heads; PR #406 is zero-ahead
- PR #309 added terminal-head and zero-ahead suppression but its landed revision was not yet active
- PR #311 fixed the review-derived whole-repository comparison-abort defect and landed as `9f075501...` with exact reviewed tree `929d1469...`
- a later old-code sample run `33289012612` completed without another burst only because the quarantine heads remain open

## Required before merge

- fresh exact-head hosted gates
- fresh exact-head Codex/OpenCode review and CodeRabbit review or explicit bounded quota evidence
- zero unresolved review threads
- guarded merge of exactly `97f160d7c8ab3676c0fd4b2bb08f954a76a2ea95`

Refs #308
Refs #309
Refs #311