### PR TITLE
Review: define typed expert evidence lanes and fail-closed aggregation

### DIFF
--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence_lane_catalog.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence_lane_catalog.cljs
@@ -18,7 +18,12 @@
    #{:contracts-schema :tests-failures :ci-provenance}
    :catalog/lanes
    [{:lane/id :contracts-schema
-     :lane/actor :eta-mu.agent/contracts-schema-reviewer
+     :lane/revision :eta-mu.lane/contracts-schema-v1
+     :lane/producer
+     {:producer/actor :eta-mu.agent/contracts-schema-reviewer
+      :producer/actor-binding "axxium:binding:contracts-schema-reviewer-v1"
+      :producer/profile-revision :eta-mu.profile/contracts-schema-reviewer-v1
+      :producer/workflow-revision :eta-mu.workflow/github-evidence-lanes-v1}
      :lane/description
      "Validate declared contracts, schemas, resolvers, and executable resource references."
      :lane/artifact-kinds
@@ -32,7 +37,12 @@
       :max-findings 25}}
 
     {:lane/id :tests-failures
-     :lane/actor :eta-mu.agent/tests-failures-reviewer
+     :lane/revision :eta-mu.lane/tests-failures-v1
+     :lane/producer
+     {:producer/actor :eta-mu.agent/tests-failures-reviewer
+      :producer/actor-binding "axxium:binding:tests-failures-reviewer-v1"
+      :producer/profile-revision :eta-mu.profile/tests-failures-reviewer-v1
+      :producer/workflow-revision :eta-mu.workflow/github-evidence-lanes-v1}
      :lane/description
      "Inspect executed suites, exits, retained failure traces, fixtures, and coverage artifacts."
      :lane/artifact-kinds
@@ -46,7 +56,12 @@
       :max-findings 25}}
 
     {:lane/id :ci-provenance
-     :lane/actor :eta-mu.agent/ci-provenance-reviewer
+     :lane/revision :eta-mu.lane/ci-provenance-v1
+     :lane/producer
+     {:producer/actor :eta-mu.agent/ci-provenance-reviewer
+      :producer/actor-binding "axxium:binding:ci-provenance-reviewer-v1"
+      :producer/profile-revision :eta-mu.profile/ci-provenance-reviewer-v1
+      :producer/workflow-revision :eta-mu.workflow/github-evidence-lanes-v1}
      :lane/description
      "Verify exact-head workflow identity, action pins, dependency closure, and check provenance."
      :lane/artifact-kinds
@@ -59,12 +74,25 @@
       :output-bytes 1048576
       :max-findings 20}}]})
 
+(defn- qualified-resource-revision?
+  [revision]
+  (or (string? revision)
+      (and (keyword? revision) (some? (namespace revision)))))
+
 (defn catalog-admissibility-errors
   [catalog]
   (let [shape-valid? (law/valid-catalog-shape? catalog)
         lanes (:catalog/lanes catalog)
         lane-ids (mapv :lane/id lanes)
-        actor-ids (mapv :lane/actor lanes)
+        lane-revisions (mapv :lane/revision lanes)
+        actor-ids (mapv #(get-in % [:lane/producer :producer/actor]) lanes)
+        actor-bindings (mapv #(get-in % [:lane/producer :producer/actor-binding]) lanes)
+        producer-revisions (mapcat (fn [lane]
+                                     [(get-in lane [:lane/producer
+                                                    :producer/profile-revision])
+                                      (get-in lane [:lane/producer
+                                                    :producer/workflow-revision])])
+                                   lanes)
         declared-lanes (set lane-ids)
         required-lanes (:catalog/required-lanes catalog)
         granted-tools (set (mapcat :lane/tools lanes))]
@@ -75,11 +103,22 @@
       (and shape-valid? (empty? lanes))
       (conj :empty-lane-catalog)
 
+      (and shape-valid? (empty? required-lanes))
+      (conj :empty-required-lanes)
+
       (and shape-valid? (not= (count lane-ids) (count (distinct lane-ids))))
       (conj :duplicate-lane-id)
 
+      (and shape-valid?
+           (not= (count lane-revisions) (count (distinct lane-revisions))))
+      (conj :shared-lane-revision)
+
       (and shape-valid? (not= (count actor-ids) (count (distinct actor-ids))))
       (conj :shared-lane-actor)
+
+      (and shape-valid?
+           (not= (count actor-bindings) (count (distinct actor-bindings))))
+      (conj :shared-lane-actor-binding)
 
       (and shape-valid? (not (set/subset? required-lanes declared-lanes)))
       (conj :unknown-required-lane)
@@ -93,6 +132,11 @@
       (and shape-valid?
            (some #(nil? (namespace %)) actor-ids))
       (conj :unqualified-lane-actor)
+
+      (and shape-valid?
+           (not-every? qualified-resource-revision?
+                       (concat lane-revisions producer-revisions)))
+      (conj :unqualified-resource-revision)
 
       (and shape-valid?
            (seq (set/intersection forbidden-lane-tools granted-tools)))

--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence_lane_catalog.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence_lane_catalog.cljs
@@ -1,0 +1,115 @@
+(ns eta-mu.domain.evidence-lane-catalog
+  "Pure catalog and admission rules for narrow evidence-review agents."
+  (:require [clojure.set :as set]
+            [eta-mu.law.evidence-lane-catalog :as law]))
+
+(def forbidden-lane-tools
+  #{:filesystem/write
+    :github/publish
+    :github/write
+    :network/request
+    :process/run
+    :secret/read})
+
+(def first-lane-catalog
+  {:catalog/version 1
+   :catalog/id :eta-mu/github-evidence-lanes-v1
+   :catalog/required-lanes
+   #{:contracts-schema :tests-failures :ci-provenance}
+   :catalog/lanes
+   [{:lane/id :contracts-schema
+     :lane/actor :eta-mu.agent/contracts-schema-reviewer
+     :lane/description
+     "Validate declared contracts, schemas, resolvers, and executable resource references."
+     :lane/artifact-kinds
+     #{:contract-manifest :diff-manifest :schema-validation :resolver-trace}
+     :lane/tools
+     #{:artifact/read :contract/inspect :contract/validate}
+     :lane/budgets
+     {:wall-ms 180000
+      :input-bytes 2097152
+      :output-bytes 1048576
+      :max-findings 25}}
+
+    {:lane/id :tests-failures
+     :lane/actor :eta-mu.agent/tests-failures-reviewer
+     :lane/description
+     "Inspect executed suites, exits, retained failure traces, fixtures, and coverage artifacts."
+     :lane/artifact-kinds
+     #{:coverage-summary :junit :test-log :test-manifest}
+     :lane/tools
+     #{:artifact/read :coverage/inspect :test/result-query}
+     :lane/budgets
+     {:wall-ms 180000
+      :input-bytes 4194304
+      :output-bytes 1048576
+      :max-findings 25}}
+
+    {:lane/id :ci-provenance
+     :lane/actor :eta-mu.agent/ci-provenance-reviewer
+     :lane/description
+     "Verify exact-head workflow identity, action pins, dependency closure, and check provenance."
+     :lane/artifact-kinds
+     #{:check-run-manifest :dependency-closure :workflow-manifest}
+     :lane/tools
+     #{:artifact/read :dependency-closure/inspect :workflow/inspect}
+     :lane/budgets
+     {:wall-ms 120000
+      :input-bytes 2097152
+      :output-bytes 1048576
+      :max-findings 20}}]})
+
+(defn catalog-admissibility-errors
+  [catalog]
+  (let [shape-valid? (law/valid-catalog-shape? catalog)
+        lanes (:catalog/lanes catalog)
+        lane-ids (mapv :lane/id lanes)
+        actor-ids (mapv :lane/actor lanes)
+        declared-lanes (set lane-ids)
+        required-lanes (:catalog/required-lanes catalog)
+        granted-tools (set (mapcat :lane/tools lanes))]
+    (cond-> []
+      (not shape-valid?)
+      (conj :invalid-catalog-shape)
+
+      (and shape-valid? (empty? lanes))
+      (conj :empty-lane-catalog)
+
+      (and shape-valid? (not= (count lane-ids) (count (distinct lane-ids))))
+      (conj :duplicate-lane-id)
+
+      (and shape-valid? (not= (count actor-ids) (count (distinct actor-ids))))
+      (conj :shared-lane-actor)
+
+      (and shape-valid? (not (set/subset? required-lanes declared-lanes)))
+      (conj :unknown-required-lane)
+
+      (and shape-valid?
+           (some #(or (empty? (:lane/artifact-kinds %))
+                      (empty? (:lane/tools %)))
+                 lanes))
+      (conj :unbounded-lane-input)
+
+      (and shape-valid?
+           (some #(nil? (namespace %)) actor-ids))
+      (conj :unqualified-lane-actor)
+
+      (and shape-valid?
+           (seq (set/intersection forbidden-lane-tools granted-tools)))
+      (conj :forbidden-lane-tool))))
+
+(defn admissible-catalog?
+  [catalog]
+  (empty? (catalog-admissibility-errors catalog)))
+
+(defn lane-profile
+  [catalog lane]
+  (->> (:catalog/lanes catalog)
+       (filter #(= lane (:lane/id %)))
+       first))
+
+(defn required-lane-profiles
+  [catalog]
+  (->> (:catalog/required-lanes catalog)
+       (sort-by str)
+       (mapv #(lane-profile catalog %))))

--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence_review.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence_review.cljs
@@ -2,10 +2,11 @@
   "Pure admission and aggregation laws for parallel evidence-review lanes.
 
   Model and agent outputs enter as candidate lane results. This namespace binds
-  them to one immutable review snapshot, rejects unsupported evidence, preserves
-  contradictions, and computes a deterministic conclusion. It performs no I/O
-  and has no GitHub publication authority."
-  (:require [eta-mu.law.evidence-review :as law]))
+  them to one immutable review snapshot and one admitted lane catalog, rejects
+  unsupported evidence, preserves contradictions, and computes a deterministic
+  conclusion. It performs no I/O and has no GitHub publication authority."
+  (:require [eta-mu.domain.evidence-lane-catalog :as lane-catalog]
+            [eta-mu.law.evidence-review :as law]))
 
 (def ^:private snapshot-keys
   [:schema/version
@@ -15,6 +16,12 @@
    :review/snapshot-hash
    :review/dependency-closure-hash
    :review/episode])
+
+(def ^:private producer-profile-keys
+  [:producer/actor
+   :producer/actor-binding
+   :producer/profile-revision
+   :producer/workflow-revision])
 
 (defn confirmed-blocker?
   [finding]
@@ -52,22 +59,23 @@
     false))
 
 (defn- evidence-retained?
-  [inspected-hashes finding]
-  (let [evidence (:finding/evidence finding)]
+  [inspected-artifacts finding]
+  (let [retained-references (set inspected-artifacts)
+        evidence (:finding/evidence finding)]
     (and (seq evidence)
-         (every? #(contains? inspected-hashes (:artifact/hash %)) evidence))))
+         (every? #(contains? retained-references %) evidence))))
 
 (defn admissible-finding?
-  "True when a finding is structurally valid, scoped, and cites retained lane
-  artifacts. Confirmed blockers additionally require a concrete failure trace."
+  "True when a finding is structurally valid, scoped, and cites exact retained
+  lane artifact references. Confirmed blockers additionally require a concrete
+  failure trace."
   [inspected-artifacts finding]
-  (let [inspected-hashes (set (map :artifact/hash inspected-artifacts))]
-    (and (confidence-valid? finding)
-         (scope-valid? finding)
-         (evidence-retained? inspected-hashes finding)
-         (or (not (confirmed-blocker? finding))
-             (and (string? (:finding/failure-trace finding))
-                  (seq (:finding/failure-trace finding)))))))
+  (and (confidence-valid? finding)
+       (scope-valid? finding)
+       (evidence-retained? inspected-artifacts finding)
+       (or (not (confirmed-blocker? finding))
+           (and (string? (:finding/failure-trace finding))
+                (seq (:finding/failure-trace finding))))))
 
 (defn- snapshot-facts
   [value]
@@ -78,18 +86,34 @@
   (= (snapshot-facts snapshot)
      (snapshot-facts lane-result)))
 
+(defn- producer-matches?
+  [lane-profile lane-result]
+  (= (:lane/producer lane-profile)
+     (select-keys (:evidence/producer lane-result)
+                  producer-profile-keys)))
+
 (defn- result-rejection-reasons
-  [snapshot required-lanes lane-result]
+  [snapshot catalog lane-result]
   (let [shape-valid? (law/valid-lane-result-shape? lane-result)
         lane (:evidence/lane lane-result)
+        lane-profile (when shape-valid?
+                       (lane-catalog/lane-profile catalog lane))
         inspected (:coverage/inspected lane-result)
         findings (:findings lane-result)]
     (cond-> []
       (not shape-valid?)
       (conj :invalid-result-shape)
 
-      (and shape-valid? (not (contains? required-lanes lane)))
+      (and shape-valid? (nil? lane-profile))
       (conj :unexpected-lane)
+
+      (and lane-profile
+           (not= (:lane/revision lane-profile)
+                 (:evidence/lane-revision lane-result)))
+      (conj :lane-revision-mismatch)
+
+      (and lane-profile (not (producer-matches? lane-profile lane-result)))
+      (conj :producer-profile-mismatch)
 
       (and shape-valid? (not (target-matches? snapshot lane-result)))
       (conj :review-snapshot-mismatch)
@@ -120,8 +144,7 @@
    (:finding/status finding)
    (:finding/disposition finding)
    (->> (:finding/evidence finding)
-        (map :artifact/hash)
-        sort
+        (sort-by pr-str)
         vec)])
 
 (defn- dedupe-findings
@@ -175,25 +198,27 @@
                      :verdict verdict}))))
 
 (defn aggregate-verdict
-  "Validate and fold candidate lane results for one immutable review snapshot.
+  "Validate and fold candidate lane results for one immutable review snapshot
+  and one admitted lane catalog.
 
   A sound confirmed blocker yields `:failure` even when another lane is
   incomplete. Without a blocker, missing, rejected, conflicting, stale, partial,
   timed-out, failed, blocked, or unavailable required evidence yields `:blocked`.
-  `:success` requires every required lane to be complete."
-  [snapshot required-lanes lane-results]
+  `:success` requires every catalog-required lane to be complete."
+  [snapshot catalog lane-results]
   (when-not (law/valid-review-snapshot? snapshot)
     (throw (ex-info "Invalid review snapshot"
                     {:errors (law/explain-review-snapshot snapshot)})))
-  (when-not (and (set? required-lanes)
-                 (seq required-lanes)
-                 (every? keyword? required-lanes))
-    (throw (ex-info "Required evidence lanes must be a non-empty keyword set"
-                    {:required-lanes required-lanes})))
-  (let [validation (mapv (fn [lane-result]
+  (let [catalog-errors (lane-catalog/catalog-admissibility-errors catalog)]
+    (when (seq catalog-errors)
+      (throw (ex-info "Invalid evidence lane catalog"
+                      {:errors catalog-errors
+                       :catalog catalog}))))
+  (let [required-lanes (:catalog/required-lanes catalog)
+        validation (mapv (fn [lane-result]
                            {:result lane-result
                             :reasons (result-rejection-reasons
-                                      snapshot required-lanes lane-result)})
+                                      snapshot catalog lane-result)})
                          lane-results)
         rejected (filterv (comp seq :reasons) validation)
         accepted (->> validation
@@ -256,7 +281,9 @@
                      :else :success)]
     (validated-verdict
      (merge snapshot
-            {:aggregate/conclusion conclusion
+            {:aggregate/catalog-id (:catalog/id catalog)
+             :aggregate/catalog-version (:catalog/version catalog)
+             :aggregate/conclusion conclusion
              :aggregate/reasons reasons
              :aggregate/required-lanes required-lanes
              :aggregate/lane-statuses lane-statuses

--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence_review.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence_review.cljs
@@ -1,0 +1,267 @@
+(ns eta-mu.domain.evidence-review
+  "Pure admission and aggregation laws for parallel evidence-review lanes.
+
+  Model and agent outputs enter as candidate lane results. This namespace binds
+  them to one immutable review snapshot, rejects unsupported evidence, preserves
+  contradictions, and computes a deterministic conclusion. It performs no I/O
+  and has no GitHub publication authority."
+  (:require [eta-mu.law.evidence-review :as law]))
+
+(def ^:private snapshot-keys
+  [:schema/version
+   :review/repository-id
+   :review/pull-request
+   :review/head
+   :review/snapshot-hash
+   :review/dependency-closure-hash
+   :review/episode])
+
+(defn confirmed-blocker?
+  [finding]
+  (and (= :confirmed (:finding/status finding))
+       (= :blocking (:finding/disposition finding))))
+
+(defn- confirmed-advisory?
+  [finding]
+  (and (= :confirmed (:finding/status finding))
+       (= :advisory (:finding/disposition finding))))
+
+(defn- contradiction?
+  [finding]
+  (= :contradicted (:finding/status finding)))
+
+(defn- confidence-valid?
+  [finding]
+  (let [confidence (:finding/confidence finding)]
+    (and (number? confidence)
+         (<= 0 confidence 1))))
+
+(defn- scope-valid?
+  [finding]
+  (case (:finding/scope finding)
+    :changed-line
+    (and (string? (:finding/path finding))
+         (seq (:finding/path finding))
+         (int? (:finding/line finding))
+         (pos? (:finding/line finding)))
+
+    :repository-invariant
+    (and (string? (:finding/invariant finding))
+         (seq (:finding/invariant finding)))
+
+    false))
+
+(defn- evidence-retained?
+  [inspected-hashes finding]
+  (let [evidence (:finding/evidence finding)]
+    (and (seq evidence)
+         (every? #(contains? inspected-hashes (:artifact/hash %)) evidence))))
+
+(defn admissible-finding?
+  "True when a finding is structurally valid, scoped, and cites retained lane
+  artifacts. Confirmed blockers additionally require a concrete failure trace."
+  [inspected-artifacts finding]
+  (let [inspected-hashes (set (map :artifact/hash inspected-artifacts))]
+    (and (confidence-valid? finding)
+         (scope-valid? finding)
+         (evidence-retained? inspected-hashes finding)
+         (or (not (confirmed-blocker? finding))
+             (and (string? (:finding/failure-trace finding))
+                  (seq (:finding/failure-trace finding)))))))
+
+(defn- snapshot-facts
+  [value]
+  (select-keys value snapshot-keys))
+
+(defn- target-matches?
+  [snapshot lane-result]
+  (= (snapshot-facts snapshot)
+     (snapshot-facts lane-result)))
+
+(defn- result-rejection-reasons
+  [snapshot required-lanes lane-result]
+  (let [shape-valid? (law/valid-lane-result-shape? lane-result)
+        lane (:evidence/lane lane-result)
+        inspected (:coverage/inspected lane-result)
+        findings (:findings lane-result)]
+    (cond-> []
+      (not shape-valid?)
+      (conj :invalid-result-shape)
+
+      (and shape-valid? (not (contains? required-lanes lane)))
+      (conj :unexpected-lane)
+
+      (and shape-valid? (not (target-matches? snapshot lane-result)))
+      (conj :review-snapshot-mismatch)
+
+      (and shape-valid?
+           (= :complete (:coverage/status lane-result))
+           (empty? inspected))
+      (conj :complete-without-inspected-artifacts)
+
+      (and shape-valid?
+           (not-every? #(admissible-finding? inspected %) findings))
+      (conj :unsupported-finding))))
+
+(defn- rejection-records
+  [lane-result reasons]
+  (mapv (fn [reason]
+          (cond-> {:rejection/reason reason}
+            (keyword? (:evidence/lane lane-result))
+            (assoc :evidence/lane (:evidence/lane lane-result))))
+        reasons))
+
+(defn- finding-key
+  [finding]
+  [(:finding/claim finding)
+   (:finding/path finding)
+   (:finding/line finding)
+   (:finding/invariant finding)
+   (:finding/status finding)
+   (:finding/disposition finding)
+   (->> (:finding/evidence finding)
+        (map :artifact/hash)
+        sort
+        vec)])
+
+(defn- dedupe-findings
+  [findings]
+  (->> findings
+       (sort-by pr-str)
+       (reduce (fn [{:keys [seen values] :as state} finding]
+                 (let [key (finding-key finding)]
+                   (if (contains? seen key)
+                     state
+                     {:seen (conj seen key)
+                      :values (conj values finding)})))
+               {:seen #{} :values []})
+       :values))
+
+(defn- lane-status
+  [lane selected-results conflict-lanes rejected-lanes]
+  (cond
+    (contains? conflict-lanes lane)
+    :conflicted
+
+    (contains? selected-results lane)
+    (:coverage/status (get selected-results lane))
+
+    (contains? rejected-lanes lane)
+    :rejected
+
+    :else
+    :missing))
+
+(defn- status-reason
+  [status]
+  (case status
+    :missing :missing-required-lane
+    :rejected :rejected-required-lane
+    :conflicted :conflicting-lane-results
+    :partial :partial-required-lane
+    :blocked :blocked-required-lane
+    :unavailable :unavailable-required-lane
+    :timed-out :timed-out-required-lane
+    :failed :failed-required-lane
+    :stale :stale-required-lane
+    nil))
+
+(defn- validated-verdict
+  [verdict]
+  (if (law/valid-aggregate-verdict? verdict)
+    verdict
+    (throw (ex-info "Evidence aggregation produced an invalid verdict"
+                    {:errors (law/explain-aggregate-verdict verdict)
+                     :verdict verdict}))))
+
+(defn aggregate-verdict
+  "Validate and fold candidate lane results for one immutable review snapshot.
+
+  A sound confirmed blocker yields `:failure` even when another lane is
+  incomplete. Without a blocker, missing, rejected, conflicting, stale, partial,
+  timed-out, failed, blocked, or unavailable required evidence yields `:blocked`.
+  `:success` requires every required lane to be complete."
+  [snapshot required-lanes lane-results]
+  (when-not (law/valid-review-snapshot? snapshot)
+    (throw (ex-info "Invalid review snapshot"
+                    {:errors (law/explain-review-snapshot snapshot)})))
+  (when-not (and (set? required-lanes)
+                 (seq required-lanes)
+                 (every? keyword? required-lanes))
+    (throw (ex-info "Required evidence lanes must be a non-empty keyword set"
+                    {:required-lanes required-lanes})))
+  (let [validation (mapv (fn [lane-result]
+                           {:result lane-result
+                            :reasons (result-rejection-reasons
+                                      snapshot required-lanes lane-result)})
+                         lane-results)
+        rejected (filterv (comp seq :reasons) validation)
+        accepted (->> validation
+                      (remove (comp seq :reasons))
+                      (map :result)
+                      distinct
+                      vec)
+        accepted-by-lane (group-by :evidence/lane accepted)
+        conflict-lanes (->> accepted-by-lane
+                            (keep (fn [[lane results]]
+                                    (when (> (count results) 1) lane)))
+                            set)
+        selected-results (->> accepted-by-lane
+                              (remove (fn [[lane _]]
+                                        (contains? conflict-lanes lane)))
+                              (map (fn [[lane results]] [lane (first results)]))
+                              (into {}))
+        rejected-lanes (->> rejected
+                            (keep (comp :evidence/lane :result))
+                            set)
+        rejections (->> rejected
+                        (mapcat (fn [{:keys [result reasons]}]
+                                  (rejection-records result reasons)))
+                        (concat (map (fn [lane]
+                                       {:rejection/reason :conflicting-lane-results
+                                        :evidence/lane lane})
+                                     conflict-lanes))
+                        (sort-by pr-str)
+                        vec)
+        lane-statuses (->> required-lanes
+                           (sort-by str)
+                           (mapv (fn [lane]
+                                   {:evidence/lane lane
+                                    :coverage/status (lane-status lane
+                                                                  selected-results
+                                                                  conflict-lanes
+                                                                  rejected-lanes)})))
+        findings (->> selected-results
+                      vals
+                      (mapcat :findings)
+                      dedupe-findings
+                      vec)
+        blockers (filterv confirmed-blocker? findings)
+        advisories (filterv confirmed-advisory? findings)
+        contradictions (filterv contradiction? findings)
+        incomplete-statuses (->> lane-statuses
+                                 (remove #(= :complete (:coverage/status %)))
+                                 vec)
+        reasons (->> (concat
+                      (when (seq blockers) [:confirmed-blocker])
+                      (when (seq rejections) [:rejected-evidence])
+                      (keep (comp status-reason :coverage/status)
+                            incomplete-statuses))
+                     distinct
+                     (sort-by str)
+                     vec)
+        conclusion (cond
+                     (seq blockers) :failure
+                     (or (seq rejections) (seq incomplete-statuses)) :blocked
+                     :else :success)]
+    (validated-verdict
+     (merge snapshot
+            {:aggregate/conclusion conclusion
+             :aggregate/reasons reasons
+             :aggregate/required-lanes required-lanes
+             :aggregate/lane-statuses lane-statuses
+             :aggregate/rejections rejections
+             :aggregate/findings findings
+             :aggregate/confirmed-blockers blockers
+             :aggregate/advisories advisories
+             :aggregate/contradictions contradictions}))))

--- a/packages/eta-mu/src/cljs/eta_mu/law/evidence_lane_catalog.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/law/evidence_lane_catalog.cljs
@@ -2,9 +2,10 @@
   "Closed contracts for the bounded expert-lane catalog.
 
   A catalog declares which evidence class a lane owns and the artifacts, tools,
-  and budgets it may use. It contains no provider credentials or executable
-  host objects."
-  (:require [malli.core :as m]))
+  producer identity, and budgets it may use. It contains no provider credentials
+  or executable host objects."
+  (:require [eta-mu.law.evidence-review :as review-law]
+            [malli.core :as m]))
 
 (def non-empty-string-schema
   [:string {:min 1}])
@@ -16,10 +17,18 @@
    [:output-bytes [:int {:min 1}]]
    [:max-findings [:int {:min 0}]]])
 
+(def producer-profile-schema
+  [:map {:closed true}
+   [:producer/actor :keyword]
+   [:producer/actor-binding non-empty-string-schema]
+   [:producer/profile-revision review-law/revision-schema]
+   [:producer/workflow-revision review-law/revision-schema]])
+
 (def lane-profile-schema
   [:map {:closed true}
    [:lane/id :keyword]
-   [:lane/actor :keyword]
+   [:lane/revision review-law/revision-schema]
+   [:lane/producer producer-profile-schema]
    [:lane/description non-empty-string-schema]
    [:lane/artifact-kinds [:set :keyword]]
    [:lane/tools [:set :keyword]]

--- a/packages/eta-mu/src/cljs/eta_mu/law/evidence_lane_catalog.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/law/evidence_lane_catalog.cljs
@@ -1,0 +1,41 @@
+(ns eta-mu.law.evidence-lane-catalog
+  "Closed contracts for the bounded expert-lane catalog.
+
+  A catalog declares which evidence class a lane owns and the artifacts, tools,
+  and budgets it may use. It contains no provider credentials or executable
+  host objects."
+  (:require [malli.core :as m]))
+
+(def non-empty-string-schema
+  [:string {:min 1}])
+
+(def budget-schema
+  [:map {:closed true}
+   [:wall-ms [:int {:min 1}]]
+   [:input-bytes [:int {:min 1}]]
+   [:output-bytes [:int {:min 1}]]
+   [:max-findings [:int {:min 0}]]])
+
+(def lane-profile-schema
+  [:map {:closed true}
+   [:lane/id :keyword]
+   [:lane/actor :keyword]
+   [:lane/description non-empty-string-schema]
+   [:lane/artifact-kinds [:set :keyword]]
+   [:lane/tools [:set :keyword]]
+   [:lane/budgets budget-schema]])
+
+(def lane-catalog-schema
+  [:map {:closed true}
+   [:catalog/version [:= 1]]
+   [:catalog/id :keyword]
+   [:catalog/required-lanes [:set :keyword]]
+   [:catalog/lanes [:vector lane-profile-schema]]])
+
+(defn valid-catalog-shape?
+  [value]
+  (m/validate lane-catalog-schema value))
+
+(defn explain-catalog
+  [value]
+  (m/explain lane-catalog-schema value))

--- a/packages/eta-mu/src/cljs/eta_mu/law/evidence_review.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/law/evidence_review.cljs
@@ -15,7 +15,7 @@
   [:re #"^[0-9a-f]{40}$"])
 
 (def revision-schema
-  [:or git-sha-schema sha256-schema])
+  [:or git-sha-schema sha256-schema :keyword])
 
 (def coverage-status-schema
   [:enum :complete :partial :blocked :unavailable :timed-out :failed :stale])
@@ -40,6 +40,7 @@
 
 (def producer-schema
   [:map {:closed true}
+   [:producer/actor :keyword]
    [:producer/actor-binding non-empty-string-schema]
    [:producer/profile-revision revision-schema]
    [:producer/workflow-revision revision-schema]
@@ -107,6 +108,8 @@
    [:review/snapshot-hash sha256-schema]
    [:review/dependency-closure-hash sha256-schema]
    [:review/episode non-empty-string-schema]
+   [:aggregate/catalog-id :keyword]
+   [:aggregate/catalog-version [:int {:min 1}]]
    [:aggregate/conclusion [:enum :success :failure :blocked]]
    [:aggregate/reasons [:vector :keyword]]
    [:aggregate/required-lanes [:set :keyword]]

--- a/packages/eta-mu/src/cljs/eta_mu/law/evidence_review.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/law/evidence_review.cljs
@@ -1,0 +1,142 @@
+(ns eta-mu.law.evidence-review
+  "Closed Malli contracts for exact-head evidence lanes and deterministic verdicts.
+
+  These schemas describe admitted review data. They do not execute agents, read
+  artifacts, or publish GitHub outcomes."
+  (:require [malli.core :as m]))
+
+(def non-empty-string-schema
+  [:string {:min 1}])
+
+(def sha256-schema
+  [:re #"^sha256:[0-9a-f]{64}$"])
+
+(def git-sha-schema
+  [:re #"^[0-9a-f]{40}$"])
+
+(def revision-schema
+  [:or git-sha-schema sha256-schema])
+
+(def coverage-status-schema
+  [:enum :complete :partial :blocked :unavailable :timed-out :failed :stale])
+
+(def aggregate-lane-status-schema
+  [:enum :complete :partial :blocked :unavailable :timed-out :failed :stale
+   :missing :rejected :conflicted])
+
+(def artifact-location-schema
+  [:map {:closed true}
+   [:path {:optional true} non-empty-string-schema]
+   [:line-start {:optional true} [:int {:min 1}]]
+   [:line-end {:optional true} [:int {:min 1}]]
+   [:log-start {:optional true} [:int {:min 1}]]
+   [:log-end {:optional true} [:int {:min 1}]]])
+
+(def artifact-ref-schema
+  [:map {:closed true}
+   [:artifact/kind :keyword]
+   [:artifact/hash sha256-schema]
+   [:artifact/location {:optional true} artifact-location-schema]])
+
+(def producer-schema
+  [:map {:closed true}
+   [:producer/actor-binding non-empty-string-schema]
+   [:producer/profile-revision revision-schema]
+   [:producer/workflow-revision revision-schema]
+   [:producer/attestation-hash sha256-schema]])
+
+(def review-snapshot-schema
+  [:map {:closed true}
+   [:schema/version [:= 1]]
+   [:review/repository-id [:int {:min 1}]]
+   [:review/pull-request [:int {:min 1}]]
+   [:review/head git-sha-schema]
+   [:review/snapshot-hash sha256-schema]
+   [:review/dependency-closure-hash sha256-schema]
+   [:review/episode non-empty-string-schema]])
+
+(def finding-schema
+  [:map {:closed true}
+   [:finding/id sha256-schema]
+   [:finding/status [:enum :confirmed :contradicted :unresolved :rejected]]
+   [:finding/disposition [:enum :blocking :advisory]]
+   [:finding/severity [:enum :critical :high :medium :low :info]]
+   [:finding/scope [:enum :changed-line :repository-invariant]]
+   [:finding/path {:optional true} non-empty-string-schema]
+   [:finding/line {:optional true} [:int {:min 1}]]
+   [:finding/invariant {:optional true} non-empty-string-schema]
+   [:finding/claim non-empty-string-schema]
+   [:finding/failure-trace {:optional true} non-empty-string-schema]
+   [:finding/evidence [:vector artifact-ref-schema]]
+   [:finding/confidence number?]])
+
+(def lane-result-schema
+  [:map {:closed true}
+   [:schema/version [:= 1]]
+   [:evidence/lane :keyword]
+   [:evidence/lane-revision revision-schema]
+   [:evidence/producer producer-schema]
+   [:review/repository-id [:int {:min 1}]]
+   [:review/pull-request [:int {:min 1}]]
+   [:review/head git-sha-schema]
+   [:review/snapshot-hash sha256-schema]
+   [:review/dependency-closure-hash sha256-schema]
+   [:review/episode non-empty-string-schema]
+   [:coverage/status coverage-status-schema]
+   [:coverage/inspected [:vector artifact-ref-schema]]
+   [:coverage/reason {:optional true} :keyword]
+   [:coverage/note {:optional true} non-empty-string-schema]
+   [:findings [:vector finding-schema]]])
+
+(def lane-status-schema
+  [:map {:closed true}
+   [:evidence/lane :keyword]
+   [:coverage/status aggregate-lane-status-schema]])
+
+(def rejection-schema
+  [:map {:closed true}
+   [:rejection/reason :keyword]
+   [:evidence/lane {:optional true} :keyword]])
+
+(def aggregate-verdict-schema
+  [:map {:closed true}
+   [:schema/version [:= 1]]
+   [:review/repository-id [:int {:min 1}]]
+   [:review/pull-request [:int {:min 1}]]
+   [:review/head git-sha-schema]
+   [:review/snapshot-hash sha256-schema]
+   [:review/dependency-closure-hash sha256-schema]
+   [:review/episode non-empty-string-schema]
+   [:aggregate/conclusion [:enum :success :failure :blocked]]
+   [:aggregate/reasons [:vector :keyword]]
+   [:aggregate/required-lanes [:set :keyword]]
+   [:aggregate/lane-statuses [:vector lane-status-schema]]
+   [:aggregate/rejections [:vector rejection-schema]]
+   [:aggregate/findings [:vector finding-schema]]
+   [:aggregate/confirmed-blockers [:vector finding-schema]]
+   [:aggregate/advisories [:vector finding-schema]]
+   [:aggregate/contradictions [:vector finding-schema]]])
+
+(defn valid-review-snapshot?
+  [value]
+  (m/validate review-snapshot-schema value))
+
+(defn explain-review-snapshot
+  [value]
+  (m/explain review-snapshot-schema value))
+
+(defn valid-lane-result-shape?
+  [value]
+  (m/validate lane-result-schema value))
+
+(defn explain-lane-result
+  [value]
+  (m/explain lane-result-schema value))
+
+(defn valid-aggregate-verdict?
+  [value]
+  (m/validate aggregate-verdict-schema value))
+
+(defn explain-aggregate-verdict
+  [value]
+  (m/explain aggregate-verdict-schema value))

--- a/packages/eta-mu/test/cljs/eta_mu/domain/evidence_lane_catalog_test.cljs
+++ b/packages/eta-mu/test/cljs/eta_mu/domain/evidence_lane_catalog_test.cljs
@@ -1,0 +1,59 @@
+(ns eta-mu.domain.evidence-lane-catalog-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.domain.evidence-lane-catalog :as catalog]
+            [eta-mu.law.evidence-lane-catalog :as law]))
+
+(deftest first-lane-catalog-is-admissible
+  (testing "the first three expert lanes are closed, independent, and bounded"
+    (is (law/valid-catalog-shape? catalog/first-lane-catalog))
+    (is (catalog/admissible-catalog? catalog/first-lane-catalog))
+    (is (= [:ci-provenance :contracts-schema :tests-failures]
+           (mapv :lane/id
+                 (catalog/required-lane-profiles
+                  catalog/first-lane-catalog)))))
+  (testing "each lane has a dedicated actor and no direct effect authority"
+    (let [lanes (:catalog/lanes catalog/first-lane-catalog)
+          actors (mapv :lane/actor lanes)
+          tools (set (mapcat :lane/tools lanes))]
+      (is (= (count actors) (count (distinct actors))))
+      (is (empty? (filter catalog/forbidden-lane-tools tools))))))
+
+(deftest catalog-shape-is-closed
+  (testing "credentials and executable host values cannot be added to a profile"
+    (let [with-secret (assoc-in catalog/first-lane-catalog
+                                [:catalog/lanes 0 :lane/github-token]
+                                "secret")]
+      (is (not (law/valid-catalog-shape? with-secret)))
+      (is (some? (law/explain-catalog with-secret))))))
+
+(deftest duplicate-or-shared-lanes-fail-admission
+  (let [first-lane (first (:catalog/lanes catalog/first-lane-catalog))
+        duplicate-lane (update catalog/first-lane-catalog
+                               :catalog/lanes
+                               conj
+                               first-lane)
+        shared-actor (assoc-in catalog/first-lane-catalog
+                               [:catalog/lanes 1 :lane/actor]
+                               (:lane/actor first-lane))]
+    (testing "one lane identity cannot silently map to two profiles"
+      (is (= [:duplicate-lane-id :shared-lane-actor]
+             (catalog/catalog-admissibility-errors duplicate-lane))))
+    (testing "dedicated lanes cannot share one actor identity"
+      (is (= [:shared-lane-actor]
+             (catalog/catalog-admissibility-errors shared-actor))))))
+
+(deftest undeclared-required-lanes-and-effect-tools-fail-admission
+  (let [unknown-required (update catalog/first-lane-catalog
+                                 :catalog/required-lanes
+                                 conj
+                                 :security-secrets)
+        direct-publisher (update-in catalog/first-lane-catalog
+                                    [:catalog/lanes 0 :lane/tools]
+                                    conj
+                                    :github/publish)]
+    (testing "a required lane must have an actual profile"
+      (is (= [:unknown-required-lane]
+             (catalog/catalog-admissibility-errors unknown-required))))
+    (testing "expert lanes cannot publish, read secrets, or run ambient effects"
+      (is (= [:forbidden-lane-tool]
+             (catalog/catalog-admissibility-errors direct-publisher))))))

--- a/packages/eta-mu/test/cljs/eta_mu/domain/evidence_review_test.cljs
+++ b/packages/eta-mu/test/cljs/eta_mu/domain/evidence_review_test.cljs
@@ -1,0 +1,190 @@
+(ns eta-mu.domain.evidence-review-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.domain.evidence-review :as review]
+            [eta-mu.law.evidence-review :as law]))
+
+(defn- digest
+  [character]
+  (str "sha256:" (apply str (repeat 64 character))))
+
+(def snapshot
+  {:schema/version 1
+   :review/repository-id 123456
+   :review/pull-request 42
+   :review/head (apply str (repeat 40 "a"))
+   :review/snapshot-hash (digest "b")
+   :review/dependency-closure-hash (digest "c")
+   :review/episode "axxium:episode:review-42"})
+
+(def required-lanes
+  #{:contracts-schema :tests-failures :ci-provenance})
+
+(def lane-revisions
+  {:contracts-schema (digest "1")
+   :tests-failures (digest "2")
+   :ci-provenance (digest "3")})
+
+(def artifact-digests
+  {:contracts-schema (digest "4")
+   :tests-failures (digest "5")
+   :ci-provenance (digest "6")})
+
+(defn- artifact
+  [lane]
+  {:artifact/kind :lane-manifest
+   :artifact/hash (get artifact-digests lane)
+   :artifact/location {:path (str "evidence/" (name lane) ".edn")
+                       :line-start 1
+                       :line-end 1}})
+
+(defn- lane-result
+  ([lane]
+   (lane-result lane {}))
+  ([lane overrides]
+   (merge snapshot
+          {:evidence/lane lane
+           :evidence/lane-revision (get lane-revisions lane)
+           :evidence/producer
+           {:producer/actor-binding (str "axxium:binding:" (name lane))
+            :producer/profile-revision (digest "7")
+            :producer/workflow-revision (apply str (repeat 40 "8"))
+            :producer/attestation-hash (digest "9")}
+           :coverage/status :complete
+           :coverage/inspected [(artifact lane)]
+           :findings []}
+          overrides)))
+
+(defn- finding
+  ([lane]
+   (finding lane {}))
+  ([lane overrides]
+   (merge {:finding/id (digest "d")
+           :finding/status :confirmed
+           :finding/disposition :blocking
+           :finding/severity :high
+           :finding/scope :changed-line
+           :finding/path "src/example.cljs"
+           :finding/line 73
+           :finding/claim "The declared contract cannot be resolved."
+           :finding/failure-trace "Validator exited 1 at src/example.cljs:73."
+           :finding/evidence [(artifact lane)]
+           :finding/confidence 0.98}
+          overrides)))
+
+(deftest complete-required-lanes-succeed
+  (let [results (mapv lane-result required-lanes)
+        verdict (review/aggregate-verdict snapshot required-lanes results)]
+    (testing "success requires every required lane to be complete"
+      (is (= :success (:aggregate/conclusion verdict)))
+      (is (empty? (:aggregate/reasons verdict)))
+      (is (every? #(= :complete (:coverage/status %))
+                  (:aggregate/lane-statuses verdict)))
+      (is (law/valid-aggregate-verdict? verdict)))))
+
+(deftest incomplete-evidence-blocks-without-inventing-a-defect
+  (let [verdict (review/aggregate-verdict
+                 snapshot
+                 required-lanes
+                 [(lane-result :contracts-schema)
+                  (lane-result :tests-failures
+                               {:coverage/status :unavailable
+                                :coverage/inspected []})])]
+    (testing "missing and unavailable lanes remain explicit"
+      (is (= :blocked (:aggregate/conclusion verdict)))
+      (is (contains? (set (:aggregate/reasons verdict))
+                     :missing-required-lane))
+      (is (contains? (set (:aggregate/reasons verdict))
+                     :unavailable-required-lane))
+      (is (empty? (:aggregate/confirmed-blockers verdict))))))
+
+(deftest sound-blocker-outranks-silent-lanes
+  (let [blocker (finding :contracts-schema)
+        verdict (review/aggregate-verdict
+                 snapshot
+                 required-lanes
+                 [(lane-result :contracts-schema {:findings [blocker]})
+                  (lane-result :tests-failures
+                               {:coverage/status :unavailable
+                                :coverage/inspected []})])]
+    (testing "one retained, supported blocker fails even when other lanes are incomplete"
+      (is (= :failure (:aggregate/conclusion verdict)))
+      (is (= [blocker] (:aggregate/confirmed-blockers verdict)))
+      (is (contains? (set (:aggregate/reasons verdict)) :confirmed-blocker)))))
+
+(deftest unsupported-blocker-is-rejected-not-promoted
+  (let [unsupported (-> (finding :contracts-schema)
+                        (dissoc :finding/failure-trace)
+                        (assoc :finding/evidence
+                               [{:artifact/kind :validator-output
+                                 :artifact/hash (digest "e")}]))
+        verdict (review/aggregate-verdict
+                 snapshot
+                 #{:contracts-schema}
+                 [(lane-result :contracts-schema {:findings [unsupported]})])]
+    (testing "a blocker without a trace or retained artifact cannot fail the code"
+      (is (= :blocked (:aggregate/conclusion verdict)))
+      (is (= [{:rejection/reason :unsupported-finding
+               :evidence/lane :contracts-schema}]
+             (:aggregate/rejections verdict)))
+      (is (empty? (:aggregate/confirmed-blockers verdict))))))
+
+(deftest stale-or-foreign-results-are-rejected
+  (let [stale (assoc (lane-result :contracts-schema)
+                     :review/head
+                     (apply str (repeat 40 "f")))
+        verdict (review/aggregate-verdict
+                 snapshot #{:contracts-schema} [stale])]
+    (testing "matching a mutable PR number is not enough; the exact snapshot must match"
+      (is (= :blocked (:aggregate/conclusion verdict)))
+      (is (= :rejected
+             (-> verdict :aggregate/lane-statuses first :coverage/status)))
+      (is (= :review-snapshot-mismatch
+             (-> verdict :aggregate/rejections first :rejection/reason))))))
+
+(deftest duplicates-are-idempotent-but-conflicts-block
+  (let [complete (lane-result :contracts-schema)
+        duplicate-verdict (review/aggregate-verdict
+                           snapshot #{:contracts-schema} [complete complete])
+        conflicting (assoc complete
+                           :coverage/status :partial
+                           :coverage/reason :artifact-budget-exhausted)
+        conflict-verdict (review/aggregate-verdict
+                          snapshot #{:contracts-schema} [complete conflicting])]
+    (testing "byte-equal redelivery is idempotent"
+      (is (= :success (:aggregate/conclusion duplicate-verdict))))
+    (testing "two distinct results for one lane are preserved as a conflict"
+      (is (= :blocked (:aggregate/conclusion conflict-verdict)))
+      (is (= :conflicted
+             (-> conflict-verdict
+                 :aggregate/lane-statuses
+                 first
+                 :coverage/status)))
+      (is (= :conflicting-lane-results
+             (-> conflict-verdict
+                 :aggregate/rejections
+                 first
+                 :rejection/reason))))))
+
+(deftest contradictions-survive-aggregation
+  (let [blocker (finding :contracts-schema)
+        contradiction (assoc blocker
+                             :finding/id (digest "e")
+                             :finding/status :contradicted
+                             :finding/failure-trace
+                             "Replay fixture disproved the proposed failure trace.")
+        verdict (review/aggregate-verdict
+                 snapshot
+                 #{:contracts-schema}
+                 [(lane-result :contracts-schema
+                               {:findings [contradiction blocker]})])]
+    (testing "contradictory evidence is retained rather than counted as a vote"
+      (is (= :failure (:aggregate/conclusion verdict)))
+      (is (= [contradiction] (:aggregate/contradictions verdict)))
+      (is (= [blocker] (:aggregate/confirmed-blockers verdict))))))
+
+(deftest aggregation-is-order-independent
+  (let [results (mapv lane-result required-lanes)
+        forward (review/aggregate-verdict snapshot required-lanes results)
+        reverse-order (review/aggregate-verdict snapshot required-lanes (vec (reverse results)))]
+    (testing "parallel completion order cannot change the verdict"
+      (is (= forward reverse-order)))))

--- a/packages/eta-mu/test/cljs/eta_mu/law/evidence_review_test.cljs
+++ b/packages/eta-mu/test/cljs/eta_mu/law/evidence_review_test.cljs
@@ -38,11 +38,12 @@
 (def lane-result
   (merge valid-snapshot
          {:evidence/lane :contracts-schema
-          :evidence/lane-revision (digest "f")
+          :evidence/lane-revision :eta-mu.lane/contracts-schema-v1
           :evidence/producer
-          {:producer/actor-binding "axxium:binding:contracts-reviewer"
-           :producer/profile-revision (digest "1")
-           :producer/workflow-revision (apply str (repeat 40 "2"))
+          {:producer/actor :eta-mu.agent/contracts-schema-reviewer
+           :producer/actor-binding "axxium:binding:contracts-schema-reviewer-v1"
+           :producer/profile-revision :eta-mu.profile/contracts-schema-reviewer-v1
+           :producer/workflow-revision :eta-mu.workflow/github-evidence-lanes-v1
            :producer/attestation-hash (digest "3")}
           :coverage/status :complete
           :coverage/inspected [artifact]
@@ -50,7 +51,9 @@
 
 (def aggregate-verdict
   (merge valid-snapshot
-         {:aggregate/conclusion :failure
+         {:aggregate/catalog-id :eta-mu/github-evidence-lanes-v1
+          :aggregate/catalog-version 1
+          :aggregate/conclusion :failure
           :aggregate/reasons [:confirmed-blocker]
           :aggregate/required-lanes #{:contracts-schema}
           :aggregate/lane-statuses
@@ -87,17 +90,21 @@
                         [:evidence/producer :producer/workflow-revision]
                         "latest"))))
     (is (not (law/valid-lane-result-shape?
+              (dissoc-in lane-result [:evidence/producer :producer/actor]))))
+    (is (not (law/valid-lane-result-shape?
               (assoc lane-result :coverage/status :passed)))))
   (testing "invalid lane results return diagnostics"
     (is (some? (law/explain-lane-result
                 (dissoc lane-result :review/episode))))))
 
 (deftest aggregate-verdict-schema-test
-  (testing "a deterministic aggregate verdict validates"
+  (testing "a deterministic, catalog-bound aggregate verdict validates"
     (is (law/valid-aggregate-verdict? aggregate-verdict)))
   (testing "models cannot smuggle publication authority into the verdict"
     (is (not (law/valid-aggregate-verdict?
               (assoc aggregate-verdict :github/publish? true)))))
-  (testing "invalid conclusions return diagnostics"
+  (testing "invalid conclusions or missing catalog identity return diagnostics"
     (is (some? (law/explain-aggregate-verdict
-                (assoc aggregate-verdict :aggregate/conclusion :approve))))))
+                (assoc aggregate-verdict :aggregate/conclusion :approve))))
+    (is (some? (law/explain-aggregate-verdict
+                (dissoc aggregate-verdict :aggregate/catalog-id))))))

--- a/packages/eta-mu/test/cljs/eta_mu/law/evidence_review_test.cljs
+++ b/packages/eta-mu/test/cljs/eta_mu/law/evidence_review_test.cljs
@@ -1,0 +1,103 @@
+(ns eta-mu.law.evidence-review-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.law.evidence-review :as law]))
+
+(defn- digest
+  [character]
+  (str "sha256:" (apply str (repeat 64 character))))
+
+(def valid-snapshot
+  {:schema/version 1
+   :review/repository-id 123456
+   :review/pull-request 42
+   :review/head (apply str (repeat 40 "a"))
+   :review/snapshot-hash (digest "b")
+   :review/dependency-closure-hash (digest "c")
+   :review/episode "axxium:episode:review-42"})
+
+(def artifact
+  {:artifact/kind :validator-output
+   :artifact/hash (digest "d")
+   :artifact/location {:path "src/example.cljs"
+                       :line-start 73
+                       :line-end 73}})
+
+(def finding
+  {:finding/id (digest "e")
+   :finding/status :confirmed
+   :finding/disposition :blocking
+   :finding/severity :high
+   :finding/scope :changed-line
+   :finding/path "src/example.cljs"
+   :finding/line 73
+   :finding/claim "The declared contract cannot be resolved."
+   :finding/failure-trace "Validator exited 1 at src/example.cljs:73."
+   :finding/evidence [artifact]
+   :finding/confidence 0.97})
+
+(def lane-result
+  (merge valid-snapshot
+         {:evidence/lane :contracts-schema
+          :evidence/lane-revision (digest "f")
+          :evidence/producer
+          {:producer/actor-binding "axxium:binding:contracts-reviewer"
+           :producer/profile-revision (digest "1")
+           :producer/workflow-revision (apply str (repeat 40 "2"))
+           :producer/attestation-hash (digest "3")}
+          :coverage/status :complete
+          :coverage/inspected [artifact]
+          :findings [finding]}))
+
+(def aggregate-verdict
+  (merge valid-snapshot
+         {:aggregate/conclusion :failure
+          :aggregate/reasons [:confirmed-blocker]
+          :aggregate/required-lanes #{:contracts-schema}
+          :aggregate/lane-statuses
+          [{:evidence/lane :contracts-schema
+            :coverage/status :complete}]
+          :aggregate/rejections []
+          :aggregate/findings [finding]
+          :aggregate/confirmed-blockers [finding]
+          :aggregate/advisories []
+          :aggregate/contradictions []}))
+
+(deftest review-snapshot-schema-test
+  (testing "an exact-head snapshot with executable closure identity validates"
+    (is (law/valid-review-snapshot? valid-snapshot)))
+  (testing "mutable or malformed snapshot fields fail closed"
+    (is (not (law/valid-review-snapshot?
+              (assoc valid-snapshot :review/head "main"))))
+    (is (not (law/valid-review-snapshot?
+              (assoc valid-snapshot :review/dependency-closure-hash "missing"))))
+    (is (not (law/valid-review-snapshot?
+              (assoc valid-snapshot :review/repository-name "open-hax/eta-mu")))))
+  (testing "invalid snapshots return diagnostics"
+    (is (some? (law/explain-review-snapshot
+                (dissoc valid-snapshot :review/snapshot-hash))))))
+
+(deftest lane-result-schema-test
+  (testing "a closed, producer-bound lane result validates"
+    (is (law/valid-lane-result-shape? lane-result)))
+  (testing "unknown fields and malformed identities are rejected"
+    (is (not (law/valid-lane-result-shape?
+              (assoc lane-result :model/said-pass true))))
+    (is (not (law/valid-lane-result-shape?
+              (assoc-in lane-result
+                        [:evidence/producer :producer/workflow-revision]
+                        "latest"))))
+    (is (not (law/valid-lane-result-shape?
+              (assoc lane-result :coverage/status :passed)))))
+  (testing "invalid lane results return diagnostics"
+    (is (some? (law/explain-lane-result
+                (dissoc lane-result :review/episode))))))
+
+(deftest aggregate-verdict-schema-test
+  (testing "a deterministic aggregate verdict validates"
+    (is (law/valid-aggregate-verdict? aggregate-verdict)))
+  (testing "models cannot smuggle publication authority into the verdict"
+    (is (not (law/valid-aggregate-verdict?
+              (assoc aggregate-verdict :github/publish? true)))))
+  (testing "invalid conclusions return diagnostics"
+    (is (some? (law/explain-aggregate-verdict
+                (assoc aggregate-verdict :aggregate/conclusion :approve))))))


### PR DESCRIPTION
## Signal

Implements delivery slice 1 of #324 under the existing in-progress board card `kanban/tasks/opencode-mimo-evidence-review-agent.md`.

This does not fan out live model processes yet. It first creates the authority boundary the fan-out must obey:

- closed Malli schemas for immutable review snapshots, producer-bound lane results, retained artifact references, typed findings, and aggregate verdicts;
- a pure, order-independent verdict fold outside model authority;
- a versioned first catalog containing three dedicated lanes: contracts/schema, tests/failures, and CI provenance;
- independent actor identities, artifact classes, tools, wall/input/output/finding budgets;
- explicit rejection of direct GitHub publication, secret access, ambient process execution, network requests, and filesystem writes from expert lanes.

## Verdict law

- `success` requires every required lane to be `complete`.
- A sound confirmed blocker with a concrete failure trace and retained cited artifact yields `failure`, even when another lane is unavailable.
- Missing, stale, partial, failed, timed-out, unavailable, rejected, or conflicting required evidence yields `blocked`, not a false pass or invented code failure.
- Exact duplicate delivery is idempotent; distinct results for one lane conflict.
- Results must match immutable repository ID, pull request, exact head, snapshot hash, dependency-closure hash, and Axxium episode.
- Findings must cite artifacts already present in the lane's inspected manifest.
- Contradictions survive aggregation; they are not converted into votes.
- The output contains no GitHub publication command or authority.

## Changed boundaries

### `law.*`

- evidence review snapshot/result/finding/verdict schemas;
- expert lane catalog/profile/budget schemas.

### `domain.*`

- result admission, evidence checks, duplicate/conflict handling, deterministic verdict fold;
- first bounded three-lane catalog and catalog-admissibility law.

### Regression evidence

Tests cover:

- closed schemas and malformed exact-head/closure identities;
- successful complete aggregation;
- missing and unavailable evidence;
- supported blockers versus unsupported blocker claims;
- stale snapshot rejection;
- idempotent duplicate delivery versus conflicting lane results;
- contradiction preservation;
- order-independent parallel completion;
- unique dedicated actors, required-lane resolution, hard budgets, and forbidden tools.

## Board and provenance

This implementation is anchored to the existing `opencode-mimo-evidence-review-agent` card, whose remaining canary work exposed the weakness being repaired. Issue #324 is the issue-backed child specification. No Kanban frontmatter or Rheos ledger history was synthesized through the connector.

## Verification status

No local pass is claimed: the connector environment cannot materialize the repository or run its pnpm/ClojureScript toolchain. Exact-head hosted CI on this PR must run `pnpm -C packages/eta-mu test` and `pnpm -C packages/eta-mu lint:kondo`; failures remain blockers.

Related: #270, #297, #323, #324, open-hax/knoxx#295, open-hax/foresight#69.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured evidence-lane catalogs with versioning, lane profiles, budgets, and admissibility checks.
  * Added evidence review aggregation that validates lane results, rejects stale or unsupported findings, deduplicates evidence, and produces deterministic verdicts.
  * Added validation and diagnostic reporting for review snapshots, lane results, findings, and aggregate verdicts.

* **Tests**
  * Added comprehensive coverage for catalog rules, evidence aggregation, malformed inputs, contradictions, duplicates, and incomplete reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->