### PR TITLE
Add typed evidence lanes and fail-closed aggregation

### DIFF
--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence.cljs
@@ -2,7 +2,7 @@
   "Pure deterministic aggregation for typed evidence-lane results.
 
    The fold never executes a reviewer and never publishes to GitHub. It accepts
-   only exact-head data described by `eta-mu.law.evidence` and returns a
+   only exact-snapshot data described by `eta-mu.law.evidence` and returns a
    fail-closed decision that an infra publisher may later validate and render."
   (:require [clojure.string :as str]
             [eta-mu.law.evidence :as law]))
@@ -12,9 +12,19 @@
    :advisory 0
    :contradicted 0})
 
+(defn- collection-values
+  "Return only sequence-shaped values used by the public aggregate contracts.
+   Malformed scalar or map inputs become an empty sequence here so the fold can
+   return a schema failure instead of throwing before validation."
+  [values]
+  (cond
+    (nil? values) []
+    (or (sequential? values) (set? values)) values
+    :else []))
+
 (defn- stable-keywords
   [values]
-  (->> values
+  (->> (collection-values values)
        (filter keyword?)
        distinct
        (sort-by str)
@@ -22,7 +32,7 @@
 
 (defn- stable-strings
   [values]
-  (->> values
+  (->> (collection-values values)
        (filter string?)
        distinct
        sort
@@ -30,7 +40,7 @@
 
 (defn- stable-findings
   [findings]
-  (->> findings
+  (->> (collection-values findings)
        distinct
        (sort-by (fn [finding]
                   (str (:finding/id finding) "\u0000" (pr-str finding))))
@@ -97,7 +107,7 @@
 
 (defn- duplicate-values
   [values]
-  (->> values
+  (->> (collection-values values)
        frequencies
        (keep (fn [[value count]]
                (when (> count 1) value)))
@@ -121,25 +131,33 @@
                       (:evidence/lane result)))))
        stable-strings))
 
+(defn- status-label
+  [statuses]
+  (->> statuses
+       stable-keywords
+       (map name)
+       (str/join ",")))
+
 (defn- required-coverage-problems
   [required-lanes results-by-lane]
   (->> required-lanes
        (keep (fn [lane]
-               (when-let [result (first (get results-by-lane lane))]
-                 (when-not (= :complete (:coverage/status result))
-                   (str "required lane is not complete: " lane
-                        " (" (:coverage/status result) ")")))))
+               (when-let [lane-results (seq (get results-by-lane lane))]
+                 (let [statuses (set (map :coverage/status lane-results))]
+                   (when (not= #{:complete} statuses)
+                     (str "required lane is not complete: " lane
+                          " (" (status-label statuses) ")"))))))
        stable-strings))
 
 (defn- empty-inspection-problems
   [required-lanes results-by-lane]
   (->> required-lanes
        (keep (fn [lane]
-               (when-let [result (first (get results-by-lane lane))]
-                 (when (and (= :complete (:coverage/status result))
-                            (empty? (:coverage/inspected result)))
-                   (str "complete required lane inspected no retained artifacts: "
-                        lane)))))
+               (when (some #(and (= :complete (:coverage/status %))
+                                 (empty? (:coverage/inspected %)))
+                           (get results-by-lane lane))
+                 (str "complete required lane inspected no retained artifacts: "
+                      lane))))
        stable-strings))
 
 (defn- unsupported-finding-problems
@@ -192,8 +210,8 @@
    4. supported confirmed advisories => `:advisory`;
    5. complete clean required lanes => `:approved`.
 
-   Input ordering cannot change the returned lane, problem, finding, or verdict
-   ordering."
+   Malformed collection fields never escape as exceptions. Input ordering cannot
+   change the returned lane, problem, finding, or verdict ordering."
   [request]
   (if-not (law/valid-aggregate-request? request)
     (malformed-request-decision request)

--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence.cljs
@@ -1,0 +1,274 @@
+(ns eta-mu.domain.evidence
+  "Pure deterministic aggregation for typed evidence-lane results.
+
+   The fold never executes a reviewer and never publishes to GitHub. It accepts
+   only exact-head data described by `eta-mu.law.evidence` and returns a
+   fail-closed decision that an infra publisher may later validate and render."
+  (:require [clojure.string :as str]
+            [eta-mu.law.evidence :as law]))
+
+(def ^:private empty-finding-counts
+  {:blocking 0
+   :advisory 0
+   :contradicted 0})
+
+(defn- stable-keywords
+  [values]
+  (->> values
+       (filter keyword?)
+       distinct
+       (sort-by str)
+       vec))
+
+(defn- stable-strings
+  [values]
+  (->> values
+       (filter string?)
+       distinct
+       sort
+       vec))
+
+(defn- stable-findings
+  [findings]
+  (->> findings
+       distinct
+       (sort-by (fn [finding]
+                  (str (:finding/id finding) "\u0000" (pr-str finding))))
+       vec))
+
+(defn- non-blank-string?
+  [value]
+  (and (string? value) (not (str/blank? value))))
+
+(defn- confirmed?
+  [finding]
+  (= :confirmed (:finding/status finding)))
+
+(defn- blocking?
+  [finding]
+  (= :blocking (:finding/disposition finding)))
+
+(defn- advisory?
+  [finding]
+  (= :advisory (:finding/disposition finding)))
+
+(defn- supported-confirmed-finding?
+  [finding]
+  (and (confirmed? finding)
+       (seq (:finding/evidence finding))
+       (or (advisory? finding)
+           (and (blocking? finding)
+                (non-blank-string? (:finding/failure-trace finding))))))
+
+(defn- request-required-lanes
+  [request]
+  (stable-keywords (:required/lanes request)))
+
+(defn- base-decision
+  [request]
+  (let [required-lanes (request-required-lanes request)]
+    (cond-> {:schema/version 1
+             :aggregate/status :evidence-unavailable
+             :required/lanes required-lanes
+             :complete/lanes []
+             :missing/lanes required-lanes
+             :finding/counts empty-finding-counts
+             :findings []
+             :problems []}
+      (law/valid-aggregate-request? request)
+      (assoc :review/target (:review/target request)
+             :review/episode (:review/episode request)))))
+
+(defn- malformed-request-decision
+  [request]
+  (assoc (base-decision request)
+         :problems ["aggregate request failed its closed schema"]))
+
+(defn- invalid-result-problems
+  [results]
+  (->> results
+       (keep-indexed
+        (fn [index result]
+          (when-not (law/valid-lane-result? result)
+            (str "lane result failed its closed schema: "
+                 (or (some-> (:evidence/lane result) str)
+                     (str "input-" index))))))
+       stable-strings))
+
+(defn- duplicate-values
+  [values]
+  (->> values
+       frequencies
+       (keep (fn [[value count]]
+               (when (> count 1) value)))
+       stable-keywords))
+
+(defn- lane-result-groups
+  [results]
+  (group-by :evidence/lane results))
+
+(defn- exact-target?
+  [request result]
+  (and (= (:review/target request) (:review/target result))
+       (= (:review/episode request) (:review/episode result))))
+
+(defn- target-problems
+  [request valid-results]
+  (->> valid-results
+       (keep (fn [result]
+               (when-not (exact-target? request result)
+                 (str "lane target or episode does not match aggregate request: "
+                      (:evidence/lane result)))))
+       stable-strings))
+
+(defn- required-coverage-problems
+  [required-lanes results-by-lane]
+  (->> required-lanes
+       (keep (fn [lane]
+               (when-let [result (first (get results-by-lane lane))]
+                 (when-not (= :complete (:coverage/status result))
+                   (str "required lane is not complete: " lane
+                        " (" (:coverage/status result) ")")))))
+       stable-strings))
+
+(defn- empty-inspection-problems
+  [required-lanes results-by-lane]
+  (->> required-lanes
+       (keep (fn [lane]
+               (when-let [result (first (get results-by-lane lane))]
+                 (when (and (= :complete (:coverage/status result))
+                            (empty? (:coverage/inspected result)))
+                   (str "complete required lane inspected no retained artifacts: "
+                        lane)))))
+       stable-strings))
+
+(defn- unsupported-finding-problems
+  [findings]
+  (->> findings
+       (keep (fn [finding]
+               (when (and (confirmed? finding)
+                          (not (supported-confirmed-finding? finding)))
+                 (str "confirmed finding lacks retained evidence or a blocking failure trace: "
+                      (:finding/id finding)))))
+       stable-strings))
+
+(defn- finding-id-conflicts
+  [findings]
+  (->> findings
+       (group-by :finding/id)
+       (keep (fn [[finding-id same-id-findings]]
+               (when (> (count (distinct same-id-findings)) 1)
+                 finding-id)))
+       stable-strings))
+
+(defn- contradiction-ids
+  [findings]
+  (->> findings
+       (keepcat (fn [finding]
+                  (cond-> []
+                    (= :contradicted (:finding/status finding))
+                    (conj (:finding/id finding))
+
+                    (seq (:finding/contradicts finding))
+                    (into (:finding/contradicts finding)))))
+       stable-strings))
+
+(defn- finding-counts
+  [findings]
+  {:blocking (count (filter #(and (confirmed? %) (blocking? %)) findings))
+   :advisory (count (filter #(and (confirmed? %) (advisory? %)) findings))
+   :contradicted (count (filter #(= :contradicted (:finding/status %)) findings))})
+
+(defn aggregate-verdict
+  "Fold independent evidence-lane records into one deterministic decision.
+
+   Precedence is deliberately fail closed:
+
+   1. malformed, missing, duplicate, stale, mismatched, incomplete, or
+      unsupported evidence => `:evidence-unavailable`;
+   2. trusted contradictions or colliding finding identities =>
+      `:evidence-conflicted`;
+   3. supported confirmed blockers => `:evidence-blocked`;
+   4. supported confirmed advisories => `:advisory`;
+   5. complete clean required lanes => `:approved`.
+
+   Input ordering cannot change the returned lane, problem, finding, or verdict
+   ordering."
+  [request]
+  (if-not (law/valid-aggregate-request? request)
+    (malformed-request-decision request)
+    (let [required-lanes (request-required-lanes request)
+          duplicate-required (duplicate-values (:required/lanes request))
+          results (:lane/results request)
+          invalid-problems (invalid-result-problems results)
+          valid-results (filterv law/valid-lane-result? results)
+          results-by-lane (lane-result-groups valid-results)
+          duplicate-result-lanes
+          (->> results-by-lane
+               (keep (fn [[lane lane-results]]
+                       (when (> (count lane-results) 1) lane)))
+               stable-keywords)
+          result-lanes (set (keys results-by-lane))
+          missing-lanes (->> required-lanes
+                             (remove result-lanes)
+                             stable-keywords)
+          target-problems* (target-problems request valid-results)
+          coverage-problems
+          (required-coverage-problems required-lanes results-by-lane)
+          inspection-problems
+          (empty-inspection-problems required-lanes results-by-lane)
+          trusted-results
+          (filterv #(and (exact-target? request %)
+                         (= :complete (:coverage/status %)))
+                   valid-results)
+          findings (->> trusted-results
+                        (mapcat :findings)
+                        stable-findings)
+          unsupported-problems (unsupported-finding-problems findings)
+          finding-conflicts (finding-id-conflicts findings)
+          contradictions (contradiction-ids findings)
+          problems
+          (stable-strings
+           (concat invalid-problems
+                   target-problems*
+                   coverage-problems
+                   inspection-problems
+                   unsupported-problems
+                   (map #(str "required lane is duplicated: " %)
+                        duplicate-required)
+                   (map #(str "lane result is duplicated: " %)
+                        duplicate-result-lanes)
+                   (map #(str "required lane is missing: " %)
+                        missing-lanes)))
+          blockers (filterv #(and (supported-confirmed-finding? %)
+                                  (blocking? %))
+                            findings)
+          advisories (filterv #(and (supported-confirmed-finding? %)
+                                    (advisory? %))
+                              findings)
+          conflict? (or (seq finding-conflicts) (seq contradictions))
+          status (cond
+                   (seq problems) :evidence-unavailable
+                   conflict? :evidence-conflicted
+                   (seq blockers) :evidence-blocked
+                   (seq advisories) :advisory
+                   :else :approved)
+          conflict-problems
+          (stable-strings
+           (concat (map #(str "finding identity has conflicting bodies: " %)
+                        finding-conflicts)
+                   (map #(str "trusted evidence contains a contradiction: " %)
+                        contradictions)))
+          complete-lanes (->> trusted-results
+                              (map :evidence/lane)
+                              stable-keywords)]
+      {:schema/version 1
+       :aggregate/status status
+       :review/target (:review/target request)
+       :review/episode (:review/episode request)
+       :required/lanes required-lanes
+       :complete/lanes complete-lanes
+       :missing/lanes missing-lanes
+       :finding/counts (finding-counts findings)
+       :findings findings
+       :problems (if conflict? conflict-problems problems)})))

--- a/packages/eta-mu/src/cljs/eta_mu/domain/evidence.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/domain/evidence.cljs
@@ -164,13 +164,13 @@
 (defn- contradiction-ids
   [findings]
   (->> findings
-       (keepcat (fn [finding]
-                  (cond-> []
-                    (= :contradicted (:finding/status finding))
-                    (conj (:finding/id finding))
+       (mapcat (fn [finding]
+                 (cond-> []
+                   (= :contradicted (:finding/status finding))
+                   (conj (:finding/id finding))
 
-                    (seq (:finding/contradicts finding))
-                    (into (:finding/contradicts finding)))))
+                   (seq (:finding/contradicts finding))
+                   (into (:finding/contradicts finding)))))
        stable-strings))
 
 (defn- finding-counts
@@ -227,7 +227,7 @@
           unsupported-problems (unsupported-finding-problems findings)
           finding-conflicts (finding-id-conflicts findings)
           contradictions (contradiction-ids findings)
-          problems
+          availability-problems
           (stable-strings
            (concat invalid-problems
                    target-problems*
@@ -240,25 +240,27 @@
                         duplicate-result-lanes)
                    (map #(str "required lane is missing: " %)
                         missing-lanes)))
-          blockers (filterv #(and (supported-confirmed-finding? %)
-                                  (blocking? %))
-                            findings)
-          advisories (filterv #(and (supported-confirmed-finding? %)
-                                    (advisory? %))
-                              findings)
-          conflict? (or (seq finding-conflicts) (seq contradictions))
-          status (cond
-                   (seq problems) :evidence-unavailable
-                   conflict? :evidence-conflicted
-                   (seq blockers) :evidence-blocked
-                   (seq advisories) :advisory
-                   :else :approved)
           conflict-problems
           (stable-strings
            (concat (map #(str "finding identity has conflicting bodies: " %)
                         finding-conflicts)
                    (map #(str "trusted evidence contains a contradiction: " %)
                         contradictions)))
+          problems (stable-strings
+                    (concat availability-problems conflict-problems))
+          blockers (filterv #(and (supported-confirmed-finding? %)
+                                  (blocking? %))
+                            findings)
+          advisories (filterv #(and (supported-confirmed-finding? %)
+                                    (advisory? %))
+                              findings)
+          conflict? (seq conflict-problems)
+          status (cond
+                   (seq availability-problems) :evidence-unavailable
+                   conflict? :evidence-conflicted
+                   (seq blockers) :evidence-blocked
+                   (seq advisories) :advisory
+                   :else :approved)
           complete-lanes (->> trusted-results
                               (map :evidence/lane)
                               stable-keywords)]
@@ -271,4 +273,4 @@
        :missing/lanes missing-lanes
        :finding/counts (finding-counts findings)
        :findings findings
-       :problems (if conflict? conflict-problems problems)})))
+       :problems problems})))

--- a/packages/eta-mu/src/cljs/eta_mu/law/evidence.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/law/evidence.cljs
@@ -1,6 +1,6 @@
 (ns eta-mu.law.evidence
-  "Closed Malli contracts for exact-head evidence lanes and their deterministic
-   aggregate decision.
+  "Closed Malli contracts for exact-snapshot evidence lanes and their
+   deterministic aggregate decision.
 
    These schemas describe admissible data only. They do not execute reviewers,
    read artifacts, or publish provider outcomes."
@@ -9,17 +9,27 @@
 (def non-empty-string
   [:string {:min 1}])
 
+(def artifact-location-schema
+  [:map {:closed true}
+   [:artifact/id {:optional true} non-empty-string]
+   [:path {:optional true} non-empty-string]
+   [:line-start {:optional true} :int]
+   [:line-end {:optional true} :int]
+   [:lane {:optional true} :keyword]])
+
 (def artifact-ref-schema
   [:map {:closed true}
    [:artifact/kind :keyword]
    [:artifact/hash non-empty-string]
-   [:artifact/location {:optional true} [:map-of :keyword :any]]])
+   [:artifact/location {:optional true} artifact-location-schema]])
 
 (def review-target-schema
   [:map {:closed true}
    [:repository/id [:or :int non-empty-string]]
    [:pull-request/object-id non-empty-string]
+   [:base non-empty-string]
    [:head non-empty-string]
+   [:review-input/hash non-empty-string]
    [:snapshot/hash non-empty-string]
    [:dependency-closure/hash non-empty-string]])
 
@@ -57,7 +67,7 @@
 (def aggregate-request-schema
   "The outer request is closed, while lane values are validated independently.
    This lets the fold report one malformed lane as unavailable evidence without
-   losing the otherwise valid exact-head target."
+   losing the otherwise valid exact-snapshot target."
   [:map {:closed true}
    [:schema/version [:= 1]]
    [:required/lanes [:vector {:min 1} :keyword]]

--- a/packages/eta-mu/src/cljs/eta_mu/law/evidence.cljs
+++ b/packages/eta-mu/src/cljs/eta_mu/law/evidence.cljs
@@ -1,0 +1,111 @@
+(ns eta-mu.law.evidence
+  "Closed Malli contracts for exact-head evidence lanes and their deterministic
+   aggregate decision.
+
+   These schemas describe admissible data only. They do not execute reviewers,
+   read artifacts, or publish provider outcomes."
+  (:require [malli.core :as m]))
+
+(def non-empty-string
+  [:string {:min 1}])
+
+(def artifact-ref-schema
+  [:map {:closed true}
+   [:artifact/kind :keyword]
+   [:artifact/hash non-empty-string]
+   [:artifact/location {:optional true} [:map-of :keyword :any]]])
+
+(def review-target-schema
+  [:map {:closed true}
+   [:repository/id [:or :int non-empty-string]]
+   [:pull-request/object-id non-empty-string]
+   [:head non-empty-string]
+   [:snapshot/hash non-empty-string]
+   [:dependency-closure/hash non-empty-string]])
+
+(def producer-schema
+  [:map {:closed true}
+   [:actor/binding non-empty-string]
+   [:attestation/hash non-empty-string]])
+
+(def finding-schema
+  [:map {:closed true}
+   [:finding/id non-empty-string]
+   [:finding/status [:enum :confirmed :contradicted :retracted]]
+   [:finding/disposition [:enum :blocking :advisory]]
+   [:finding/severity [:enum :critical :high :medium :low :info]]
+   [:finding/claim non-empty-string]
+   [:finding/path {:optional true} non-empty-string]
+   [:finding/line {:optional true} :int]
+   [:finding/failure-trace {:optional true} non-empty-string]
+   [:finding/evidence [:vector artifact-ref-schema]]
+   [:finding/contradicts {:optional true} [:vector non-empty-string]]])
+
+(def lane-result-schema
+  [:map {:closed true}
+   [:schema/version [:= 1]]
+   [:evidence/lane :keyword]
+   [:evidence/lane-revision non-empty-string]
+   [:evidence/producer producer-schema]
+   [:review/target review-target-schema]
+   [:review/episode non-empty-string]
+   [:coverage/status
+    [:enum :complete :partial :blocked :unavailable :timed-out :stale]]
+   [:coverage/inspected [:vector artifact-ref-schema]]
+   [:findings [:vector finding-schema]]])
+
+(def aggregate-request-schema
+  "The outer request is closed, while lane values are validated independently.
+   This lets the fold report one malformed lane as unavailable evidence without
+   losing the otherwise valid exact-head target."
+  [:map {:closed true}
+   [:schema/version [:= 1]]
+   [:required/lanes [:vector {:min 1} :keyword]]
+   [:review/target review-target-schema]
+   [:review/episode non-empty-string]
+   [:lane/results [:vector :any]]])
+
+(def finding-counts-schema
+  [:map {:closed true}
+   [:blocking :int]
+   [:advisory :int]
+   [:contradicted :int]])
+
+(def aggregate-decision-schema
+  [:map {:closed true}
+   [:schema/version [:= 1]]
+   [:aggregate/status
+    [:enum :approved
+     :advisory
+     :evidence-blocked
+     :evidence-conflicted
+     :evidence-unavailable]]
+   [:review/target {:optional true} review-target-schema]
+   [:review/episode {:optional true} non-empty-string]
+   [:required/lanes [:vector :keyword]]
+   [:complete/lanes [:vector :keyword]]
+   [:missing/lanes [:vector :keyword]]
+   [:finding/counts finding-counts-schema]
+   [:findings [:vector finding-schema]]
+   [:problems [:vector :string]]])
+
+(defn valid-artifact-ref? [x]
+  (m/validate artifact-ref-schema x))
+
+(defn valid-finding? [x]
+  (m/validate finding-schema x))
+
+(defn valid-lane-result? [x]
+  (m/validate lane-result-schema x))
+
+(defn explain-lane-result [x]
+  (m/explain lane-result-schema x))
+
+(defn valid-aggregate-request? [x]
+  (m/validate aggregate-request-schema x))
+
+(defn explain-aggregate-request [x]
+  (m/explain aggregate-request-schema x))
+
+(defn valid-aggregate-decision? [x]
+  (m/validate aggregate-decision-schema x))

--- a/packages/eta-mu/test/cljs/eta_mu/domain/evidence_test.cljs
+++ b/packages/eta-mu/test/cljs/eta_mu/domain/evidence_test.cljs
@@ -1,0 +1,186 @@
+(ns eta-mu.domain.evidence-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.domain.evidence :as evidence]
+            [eta-mu.law.evidence :as law]))
+
+(def ^:private target
+  {:repository/id 654321
+   :pull-request/object-id "PR_kwDOexample"
+   :head "0123456789abcdef"
+   :snapshot/hash "sha256:snapshot"
+   :dependency-closure/hash "sha256:closure"})
+
+(def ^:private episode
+  "axxium:episode:review-1")
+
+(def ^:private required-lanes
+  [:contracts :tests :ci-provenance])
+
+(defn- artifact
+  [lane]
+  {:artifact/kind lane
+   :artifact/hash (str "sha256:" (name lane))
+   :artifact/location {:lane lane}})
+
+(defn- lane-result
+  ([lane]
+   (lane-result lane []))
+  ([lane findings]
+   {:schema/version 1
+    :evidence/lane lane
+    :evidence/lane-revision (str "sha256:" (name lane) "-v1")
+    :evidence/producer
+    {:actor/binding (str "axxium:binding:" (name lane) "-reviewer")
+     :attestation/hash (str "sha256:" (name lane) "-attestation")}
+    :review/target target
+    :review/episode episode
+    :coverage/status :complete
+    :coverage/inspected [(artifact lane)]
+    :findings findings}))
+
+(defn- request
+  [results]
+  {:schema/version 1
+   :required/lanes required-lanes
+   :review/target target
+   :review/episode episode
+   :lane/results results})
+
+(defn- clean-results
+  []
+  (mapv lane-result required-lanes))
+
+(def ^:private advisory-finding
+  {:finding/id "finding:docs:1"
+   :finding/status :confirmed
+   :finding/disposition :advisory
+   :finding/severity :low
+   :finding/claim "The operator diagram omits the retry state."
+   :finding/path "docs/workflow.md"
+   :finding/line 18
+   :finding/evidence [(artifact :docs)]})
+
+(def ^:private blocking-finding
+  {:finding/id "finding:contracts:1"
+   :finding/status :confirmed
+   :finding/disposition :blocking
+   :finding/severity :high
+   :finding/claim "The resource cannot be instantiated."
+   :finding/path "contracts/github.edn"
+   :finding/line 12
+   :finding/failure-trace "Malli rejected the unresolved schema."
+   :finding/evidence [(artifact :contracts)]})
+
+(deftest clean-complete-evidence-is-approved
+  (let [decision (evidence/aggregate-verdict (request (clean-results)))]
+    (is (= :approved (:aggregate/status decision)))
+    (is (= [:ci-provenance :contracts :tests]
+           (:complete/lanes decision)))
+    (is (empty? (:missing/lanes decision)))
+    (is (empty? (:findings decision)))
+    (is (empty? (:problems decision)))
+    (is (law/valid-aggregate-decision? decision))))
+
+(deftest supported-findings-determine-advisory-or-blocked
+  (testing "a retained advisory does not become an approval"
+    (let [results (assoc (clean-results)
+                         0 (lane-result :contracts [advisory-finding]))
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :advisory (:aggregate/status decision)))
+      (is (= {:blocking 0 :advisory 1 :contradicted 0}
+             (:finding/counts decision)))))
+  (testing "one supported blocker blocks despite other clean lanes"
+    (let [results (assoc (clean-results)
+                         0 (lane-result :contracts [blocking-finding]))
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :evidence-blocked (:aggregate/status decision)))
+      (is (= {:blocking 1 :advisory 0 :contradicted 0}
+             (:finding/counts decision))))))
+
+(deftest unsupported-or-incomplete-evidence-fails-closed
+  (testing "a blocking claim without a concrete failure trace is unavailable"
+    (let [unsupported (dissoc blocking-finding :finding/failure-trace)
+          results (assoc (clean-results)
+                         0 (lane-result :contracts [unsupported]))
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (some #(re-find #"failure trace" %) (:problems decision)))))
+  (testing "a required partial lane is not silence-as-success"
+    (let [results (assoc (clean-results)
+                         1 (assoc (lane-result :tests)
+                                  :coverage/status :partial))
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (some #(re-find #"not complete" %) (:problems decision)))))
+  (testing "a complete lane cannot claim it inspected nothing"
+    (let [results (assoc (clean-results)
+                         2 (assoc (lane-result :ci-provenance)
+                                  :coverage/inspected []))
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (some #(re-find #"inspected no retained artifacts" %)
+                (:problems decision)))))
+  (testing "a malformed lane result is retained as unavailable evidence"
+    (let [results (assoc (clean-results)
+                         1 (assoc (lane-result :tests)
+                                  :coverage/status :probably-complete))
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (some #(re-find #"closed schema" %) (:problems decision)))
+      (is (law/valid-aggregate-decision? decision)))))
+
+(deftest missing-duplicate-and-stale-lanes-fail-closed
+  (testing "a required lane must be present"
+    (let [decision (evidence/aggregate-verdict
+                    (request (mapv lane-result [:contracts :tests])))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (= [:ci-provenance] (:missing/lanes decision)))))
+  (testing "duplicate lane results are ambiguous rather than votes"
+    (let [decision (evidence/aggregate-verdict
+                    (request (conj (clean-results)
+                                   (lane-result :contracts))))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (some #(re-find #"duplicated" %) (:problems decision)))))
+  (testing "a result for another exact head is stale input"
+    (let [stale-result (assoc-in (lane-result :tests)
+                                 [:review/target :head]
+                                 "different-head")
+          results (assoc (clean-results) 1 stale-result)
+          decision (evidence/aggregate-verdict (request results))]
+      (is (= :evidence-unavailable (:aggregate/status decision)))
+      (is (some #(re-find #"does not match" %) (:problems decision))))))
+
+(deftest contradictions-remain-visible
+  (let [contradicted
+        {:finding/id "finding:tests:contradiction"
+         :finding/status :contradicted
+         :finding/disposition :blocking
+         :finding/severity :high
+         :finding/claim "Two trusted artifacts disagree about the executed tree."
+         :finding/evidence [(artifact :tests)]
+         :finding/contradicts ["finding:tests:pass"]}
+        results (assoc (clean-results)
+                       1 (lane-result :tests [contradicted]))
+        decision (evidence/aggregate-verdict (request results))]
+    (is (= :evidence-conflicted (:aggregate/status decision)))
+    (is (= 1 (get-in decision [:finding/counts :contradicted])))
+    (is (some #(re-find #"contradiction" %) (:problems decision)))))
+
+(deftest aggregation-is-order-invariant-and-deduplicates-identical-findings
+  (let [results [(lane-result :tests [advisory-finding])
+                 (lane-result :ci-provenance)
+                 (lane-result :contracts [advisory-finding])]
+        forward (evidence/aggregate-verdict (request results))
+        reversed (evidence/aggregate-verdict (request (vec (reverse results))))]
+    (is (= forward reversed))
+    (is (= :advisory (:aggregate/status forward)))
+    (is (= 1 (count (:findings forward))))
+    (is (= 1 (get-in forward [:finding/counts :advisory])))))
+
+(deftest malformed-outer-request-is-unavailable-not-an-exception
+  (let [decision (evidence/aggregate-verdict
+                  (dissoc (request (clean-results)) :review/target))]
+    (is (= :evidence-unavailable (:aggregate/status decision)))
+    (is (= ["aggregate request failed its closed schema"]
+           (:problems decision)))
+    (is (law/valid-aggregate-decision? decision))))

--- a/packages/eta-mu/test/cljs/eta_mu/law/evidence_test.cljs
+++ b/packages/eta-mu/test/cljs/eta_mu/law/evidence_test.cljs
@@ -1,0 +1,75 @@
+(ns eta-mu.law.evidence-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [eta-mu.law.evidence :as law]))
+
+(def ^:private target
+  {:repository/id 654321
+   :pull-request/object-id "PR_kwDOexample"
+   :head "0123456789abcdef"
+   :snapshot/hash "sha256:snapshot"
+   :dependency-closure/hash "sha256:closure"})
+
+(def ^:private artifact
+  {:artifact/kind :diff
+   :artifact/hash "sha256:diff"
+   :artifact/location {:path "src/example.cljs"}})
+
+(def ^:private finding
+  {:finding/id "finding:contract:1"
+   :finding/status :confirmed
+   :finding/disposition :blocking
+   :finding/severity :high
+   :finding/claim "The resource cannot be instantiated."
+   :finding/path "src/example.cljs"
+   :finding/line 42
+   :finding/failure-trace "Malli rejected the unresolved schema."
+   :finding/evidence [artifact]})
+
+(def ^:private lane-result
+  {:schema/version 1
+   :evidence/lane :contracts
+   :evidence/lane-revision "sha256:contracts-v1"
+   :evidence/producer
+   {:actor/binding "axxium:binding:contracts-reviewer"
+    :attestation/hash "sha256:attestation"}
+   :review/target target
+   :review/episode "axxium:episode:review-1"
+   :coverage/status :complete
+   :coverage/inspected [artifact]
+   :findings [finding]})
+
+(deftest lane-result-contract-test
+  (testing "one exact-head result with retained finding evidence validates"
+    (is (law/valid-lane-result? lane-result)))
+  (testing "the closed contract rejects unknown fields"
+    (is (not (law/valid-lane-result?
+              (assoc lane-result :ambient/github-token "secret")))))
+  (testing "identity, revision, coverage, and evidence are required"
+    (is (not (law/valid-lane-result?
+              (dissoc lane-result :review/episode))))
+    (is (not (law/valid-lane-result?
+              (dissoc lane-result :evidence/lane-revision))))
+    (is (not (law/valid-lane-result?
+              (dissoc lane-result :coverage/status))))
+    (is (not (law/valid-lane-result?
+              (update lane-result :findings
+                      #(mapv (fn [item]
+                               (dissoc item :finding/evidence))
+                             %))))))
+  (testing "diagnostics survive a malformed lane"
+    (is (some? (law/explain-lane-result
+                (assoc lane-result :coverage/status :probably-complete))))))
+
+(deftest aggregate-contract-test
+  (let [request {:schema/version 1
+                 :required/lanes [:contracts :tests :ci-provenance]
+                 :review/target target
+                 :review/episode "axxium:episode:review-1"
+                 :lane/results [lane-result]}]
+    (testing "the outer request accepts independently validated lane values"
+      (is (law/valid-aggregate-request? request)))
+    (testing "the request itself remains closed and exact-head bound"
+      (is (not (law/valid-aggregate-request?
+                (assoc request :publication/token "secret"))))
+      (is (not (law/valid-aggregate-request?
+                (update request :review/target dissoc :head)))))))


### PR DESCRIPTION
## Outcome

Delivers the first bounded implementation slice of #324 and the existing `opencode-mimo-evidence-review-agent` board lane.

This PR does **not** build the entire reviewer swarm. It establishes the deterministic authority boundary that every expert lane must cross:

- closed Malli contracts for exact-head targets, producer attestations, artifacts, findings, lane results, aggregate requests, and aggregate decisions;
- one pure order-invariant verdict fold;
- explicit `approved`, `advisory`, `evidence-blocked`, `evidence-conflicted`, and `evidence-unavailable` outcomes;
- negative tests for malformed results, missing and duplicate lanes, partial coverage, empty inspection manifests, stale heads, unsupported blockers, contradictions, and malformed outer requests;
- red/green tests proving identical findings are deduplicated rather than counted as votes.

## First required lanes

The fixtures establish the first three required evidence classes:

1. `:contracts`
2. `:tests`
3. `:ci-provenance`

Additional lanes remain data/configuration work after their artifact contracts and seeded canaries exist.

## Fail-closed law

Verdict precedence is:

1. malformed, missing, duplicate, stale, mismatched, incomplete, or unsupported evidence → `:evidence-unavailable`;
2. trusted contradictions or colliding finding identities → `:evidence-conflicted`;
3. supported confirmed blocker → `:evidence-blocked`;
4. supported confirmed advisory → `:advisory`;
5. complete clean required lanes → `:approved`.

A confirmed blocker requires retained evidence plus a concrete failure trace. Same-model agreement is never counted as confidence. Input order cannot change the decision.

## Authority boundary

This code is pure. It does not run models, read GitHub, hold credentials, write ledgers, or publish checks. Later runtime slices must:

- bind producer and episode identities through Axxium;
- retain cited artifacts by digest;
- admit lane results through event-ledger;
- use this fold before the deterministic GitHub publisher;
- keep lane agents unable to publish or adjudicate their own sufficiency.

## Verification

The branch adds schema and domain tests under the existing `packages/eta-mu` Shadow-CLJS test build. Connector-authored work does not claim a local run; GitHub CI and the repository's evidence-review workflows are the execution evidence for the exact PR head.

Closes no issue: #324 remains open for manifests, concurrent execution, publication, ledger integration, canaries, and Knoxx evidence projection.